### PR TITLE
Adding custom mDNS service

### DIFF
--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -408,8 +408,13 @@ net_setup()
   ETH.begin();
 #endif
 
-  if (MDNS.begin(esp_hostname.c_str())) {
+  if (MDNS.begin(esp_hostname.c_str())) 
+  {
     MDNS.addService("http", "tcp", 80);
+    MDNS.addService("openevse", "tcp", 80);
+    MDNS.addServiceTxt("openevse", "tcp", "type", buildenv.c_str());
+    MDNS.addServiceTxt("openevse", "tcp", "version", currentfirmware.c_str());
+    MDNS.addServiceTxt("openevse", "tcp", "id", ESPAL.getLongId());
   }
 }
 


### PR DESCRIPTION
This allows for easy discovery of OpenEVSE devices on the local network as well as providing a few useful bits of info.

For example on Linux:

```
$ avahi-browse -t -r _openevse._tcp
+ wlx0019867194c3 IPv4 openevse-a7d4                                 _openevse._tcp       local
+ enx3448edabdb81 IPv4 openevse-a7d4                                 _openevse._tcp       local
= enx3448edabdb81 IPv4 openevse-a7d4                                 _openevse._tcp       local
   hostname = [openevse-a7d4.local]
   address = [172.16.2.159]
   port = [80]
   txt = ["type=openevse_esp-wrover-kit" "version=4.1.0.dev" "id=240ac411a7d4"]
= wlx0019867194c3 IPv4 openevse-a7d4                                 _openevse._tcp       local
   hostname = [openevse-a7d4.local]
   address = [172.16.2.159]
   port = [80]
   txt = ["type=openevse_esp-wrover-kit" "version=4.1.0.dev" "id=240ac411a7d4"]
```