### PR TITLE
LCD Display: Display Energy formatted to significant figures instead of decimal digits.

### DIFF
--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -675,6 +675,20 @@ void LcdTask::displayScaledNumberValue(int line, const char *name, double value,
   displayNumberValue(line, name, value, precision, newUnit);
 }
 
+// Display a scaled number and adjust output such that the user gets some number 
+// of significant figures eg, for 4: 1.00598kWh appears as 1.005 rather than 1.0
+// Overloaded on displayScaledNumberValue
+void LcdTask::displayScaledNumberValue(int line, const char *name, double value, const char *unit)
+{
+  
+  char newUnit[20];
+  sprintf(newUnit, "%s%s", ScaleNumberSI(&value), unit);
+
+  displayNumberValueSigFigures(line, name, value, 4, newUnit);
+}
+
+// Display a numeric value preceded by the quantity name, scaled for SI notation, 
+// and with a specific number of digits after the decimal point.
 void LcdTask::displayNumberValue(int line, const char *name, double value, int precision, const char *unit)
 {
   char number[20];

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -643,6 +643,28 @@ const char *LcdTask::ScaleNumberSI(double *value) {
   }
 }
 
+// Format a number to a specif number of signficant figures. 
+// Requires a a number that that has already been adjusted for SI notation.
+//
+// Arguments: buffer, buffer length, 
+// value in question, number of significant figures.
+// returns a pointer to the formatted buffer.
+char *LcdTask::formatDoubleSigFigures(char *buffer, int buflen, double value, int figures)
+{
+  
+  // There is no way to get less than three.
+  int integer_figures;
+  if      ( value >= 100.0 ) integer_figures = 3; 
+  else if ( value >=  10.0 ) integer_figures = 2;
+  else if ( value >=   1.0 ) integer_figures = 1;
+  else                       integer_figures = 0;
+
+  int precision = figures - integer_figures; 
+
+  snprintf(buffer, buflen, "%.*f", precision, value);
+  return(buffer);
+}
+
 
 void LcdTask::displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit)
 {

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -619,26 +619,36 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
   }
 }
 
+// Adjust the value down until its in the range 0-1000,
+// and return the SI prefix for the scaled number. 
+const char *LcdTask::ScaleNumberSI(double *value) {
+  {
+    static const char *mod[] = {
+      "",
+      "k",
+      "m",
+      "g",
+      "t",
+      "p"
+    };
+
+    int index = 0;
+    while (*value > 1000 && index < ARRAY_ITEMS(mod))
+    {
+      *value /= 1000;
+      index++;
+    }
+
+    return(mod[index]);
+  }
+}
+
+
 void LcdTask::displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit)
 {
-  static const char *mod[] = {
-    "",
-    "k",
-    "m",
-    "g",
-    "t",
-    "p"
-  };
-
-  int index = 0;
-  while (value > 1000 && index < ARRAY_ITEMS(mod))
-  {
-    value /= 1000;
-    index++;
-  }
-
+  
   char newUnit[20];
-  sprintf(newUnit, "%s%s", mod[index], unit);
+  sprintf(newUnit, "%s%s", ScaleNumberSI(&value), unit);
 
   displayNumberValue(line, name, value, precision, newUnit);
 }

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -683,6 +683,22 @@ void LcdTask::displayNumberValue(int line, const char *name, double value, int p
   displayNameValue(line, name, number);
 }
 
+
+// Display a numeric value that has already been SI adjusted,  
+// adjusted to a specifed number of significant figures, and appended with units
+void LcdTask::displayNumberValueSigFigures(int line, const char *name, double value, int figures, const char *unit)
+{
+  
+  char number[20];
+  
+  formatDoubleSigFigures(number, sizeof(number), value, figures);
+  
+  char with_unit[20];
+  sprintf(with_unit,"%s%s",number,unit);
+  
+  displayNameValue(line, name, with_unit);
+}
+
 void LcdTask::displayInfoEventTime(const char *name, Scheduler::EventInstance &event)
 {
   char temp[20];

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -509,7 +509,7 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
   {
     case LcdInfoLine::EnergySession:
       // Energy 1,018Wh
-      displayScaledNumberValue(1, "Energy", _evse->getSessionEnergy(), 1, "Wh");
+      displayScaledNumberValue(1, "Energy", _evse->getSessionEnergy(), "Wh");
       _updateInfoLine = false;
       break;
 
@@ -666,6 +666,7 @@ char *LcdTask::formatDoubleSigFigures(char *buffer, int buflen, double value, in
 }
 
 
+// Display a scaled number with a specific number of digits after the decimal point.
 void LcdTask::displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit)
 {
   

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -133,6 +133,7 @@ class LcdTask : public MicroTasks::Task
     void displayStateLine(uint8_t EvseState, unsigned long &nextUpdate);
     void displayInfoLine(LcdInfoLine info, unsigned long &nextUpdate);
     void displayNumberValue(int line, const char *name, double value, int precision, const char *unit);
+    void displayNumberValueSigFigures(int line, const char *name, double value, int figures, const char *unit);
     const char *ScaleNumberSI(double *value);
     char *formatDoubleSigFigures(char *buffer, int buflen, double value, int figures);
     void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -137,6 +137,7 @@ class LcdTask : public MicroTasks::Task
     const char *ScaleNumberSI(double *value);
     char *formatDoubleSigFigures(char *buffer, int buflen, double value, int figures);
     void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);
+    void displayScaledNumberValue(int line, const char *name, double value, const char *unit);
     void displayInfoEventTime(const char *name, Scheduler::EventInstance &event);
     void displayNameValue(int line, const char *name, const char *value);
     void displayStopWatchTime(const char *name, uint32_t time);

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -134,6 +134,7 @@ class LcdTask : public MicroTasks::Task
     void displayInfoLine(LcdInfoLine info, unsigned long &nextUpdate);
     void displayNumberValue(int line, const char *name, double value, int precision, const char *unit);
     const char *ScaleNumberSI(double *value);
+    char *formatDoubleSigFigures(char *buffer, int buflen, double value, int figures);
     void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);
     void displayInfoEventTime(const char *name, Scheduler::EventInstance &event);
     void displayNameValue(int line, const char *name, const char *value);

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -133,6 +133,7 @@ class LcdTask : public MicroTasks::Task
     void displayStateLine(uint8_t EvseState, unsigned long &nextUpdate);
     void displayInfoLine(LcdInfoLine info, unsigned long &nextUpdate);
     void displayNumberValue(int line, const char *name, double value, int precision, const char *unit);
+    const char *ScaleNumberSI(double *value);
     void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);
     void displayInfoEventTime(const char *name, Scheduler::EventInstance &event);
     void displayNameValue(int line, const char *name, const char *value);


### PR DESCRIPTION
The existing FW scales energy to SI notation and then places one digit after the decimal point.

This doesn't work so well for low values in kWh, ie 1.3kWh.

The ADCs in the system deliver about 3 significant figures, so display this number to a total of four - ie:
```
1.305kWh
13.05kWh
130.5kWh
```