### PR TITLE
Fix #434: Implement Uptime

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -773,10 +773,14 @@ paths:
                     x-stoplight:
                       id: 7h1cpgfjj5j9j
                     format: date-time
+                  uptime:
+                    type: integer
+                    description: EVSE gateway uptime, in seconds
                 required:
                   - time
                   - offset
                   - local_time
+                  - uptime
       operationId: get-time
       description: Gets the time set on the OpenEVSE
     post:

--- a/models/Status.yaml
+++ b/models/Status.yaml
@@ -175,3 +175,6 @@ properties:
   limit_version:
     type: integer
     description: /limit endpoint current version
+  uptime:
+    type: integer
+    description: EVSE gateway uptime, in seconds

--- a/src/emonesp.h
+++ b/src/emonesp.h
@@ -173,4 +173,6 @@ extern String serial;
 
 void restart_system();
 
+uint64_t uptimeMillis();
+
 #endif // _EMONESP_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,6 +175,8 @@ void
 loop() {
   Profile_Start(loop);
 
+  uptimeMillis();
+
   Profile_Start(Mongoose);
   Mongoose.poll(0);
   Profile_End(Mongoose, 10);
@@ -339,4 +341,14 @@ void handle_serial()
       DEBUG_PORT.printf("{\"code\":200,\"msg\":\"%s\"}\n", config_modified ? "done" : "no change");
     }
   }
+}
+
+// inspired from https://www.snad.cz/en/2018/12/21/uptime-and-esp8266/
+uint64_t uptimeMillis()
+{
+    static uint32_t low32, high32;
+    uint32_t new_low32 = millis();
+    if (new_low32 < low32) high32++;
+    low32 = new_low32;
+    return (uint64_t) high32 << 32 | low32;
 }

--- a/src/time_man.cpp
+++ b/src/time_man.cpp
@@ -278,4 +278,5 @@ void TimeManager::serialise(JsonDocument &doc)
   doc["time"] = time;
   doc["local_time"] = local_time;
   doc["offset"] = offset;
+  doc["uptime"] = uptimeMillis() / 1000;
 }


### PR DESCRIPTION
Example in HA:

```yaml
mqtt:
  sensor:
    - name: OpenEVSE Uptime
      unique_id: 55806B85-C3B9-4EF7-8DB3-2E6C28D97669
      icon: mdi:clock
      state_topic: "openevse/uptime"
      device_class: duration
      state_class: measurement
      unit_of_measurement: s
      value_template: "{{ value|int }}"
      expire_after: 40
```

In HA:

![image](https://github.com/OpenEVSE/ESP32_WiFi_V4.x/assets/61346/3d94d9b5-9d35-4974-bdc7-7faa73633d98)

MQTT Integration: https://gist.github.com/mathieucarbou/92a3d5e0dc38d6b68aa1bdaf153a80c5

In MQTT:

![image](https://github.com/OpenEVSE/ESP32_WiFi_V4.x/assets/61346/46bdfd5c-2cf9-42d8-a402-248ff0751577)

`/status`:

![image](https://github.com/OpenEVSE/ESP32_WiFi_V4.x/assets/61346/acdf0a03-e78e-4aee-bcfd-acb4a22b1b8a)

`/time`:

![image](https://github.com/OpenEVSE/ESP32_WiFi_V4.x/assets/61346/4939f8ae-a262-466d-b9af-c760d68964f7)
