### PR TITLE
Support configuration updates through MQTT /config/set

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -195,6 +195,21 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
     }
   }
 
+  else if (topic_string == mqtt_topic + "/config/set") {
+    const size_t capacity = JSON_OBJECT_SIZE(128) + 1024;
+    DynamicJsonDocument doc(capacity);
+    DeserializationError error = deserializeJson(doc, payload_str);
+    if(!error)
+    {
+      bool config_modified = config_deserialize(doc);
+      if(config_modified)
+      {
+        config_commit(false);
+        DBUGLN("Config updated");
+      }
+    }
+  }
+
   // Restart
   else if (topic_string == mqtt_topic + "/restart") {
     mqtt_restart_device(payload_str);
@@ -383,6 +398,10 @@ mqtt_connect()
     yield();
 
     mqtt_sub_topic = mqtt_topic + "/limit/set";
+    mqttclient.subscribe(mqtt_sub_topic);
+    yield();
+
+    mqtt_sub_topic = mqtt_topic + "/config/set";
     mqttclient.subscribe(mqtt_sub_topic);
     yield();
 


### PR DESCRIPTION
I know this PR will bring up some discussions, but I am still opening it.

It's been months that I am using OpenEVSE, always up to date with the latest changes on master and always appending this commit on top (so custom build) because I need this feature and it really frustrates me that it is not included in the default firmware.

HTTP API allows to update the gateway configuration, so this PR aims at bringing also this ability through MQTT. The idea is to allow a better integration with Home Assistant, Jeedom and others.

There are several use cases, and I know at least one person also using my branch with these changes to allow a config change through MQTT.

Some non exhaustive possible usages:

- expose some configuration settings with their corresponding (and ore dynamic) widgets (sliders, etc) and not just labels

- ability to update the divert settings based on Tempo Days through some automation (here in France some electricity providers have plans where some random picked days are so expensive that we want to **switch from a no waste strategy to a no import strategy**). 

- compatibility with solar routers: someone having a solar router might be interested in using a no waste strategy with a high ratio to prioritize the solar router (heating water) with the few solar production of the morning before it reaches an interesting threshold where openevse can be triggered), and then after, move the ratio closer to 0.3 or 0.2 to prioritize EV charging.

![](https://user-images.githubusercontent.com/61346/255147134-5985c93b-d5f0-4060-a7e2-4727a447dae3.png)

Here is my gist with thisHA / MQTT integration: https://gist.github.com/mathieucarbou/92a3d5e0dc38d6b68aa1bdaf153a80c5