### PR TITLE
Fix GUI update rules when BUILDSRC_DIR is not defined

### DIFF
--- a/scripts/extra_script.py
+++ b/scripts/extra_script.py
@@ -158,7 +158,7 @@ def make_static(env, target, source):
 
 def process_html_app(source, dest, env):
     web_server_static_files = join(dest, "web_server_static_files.h")
-    web_server_static = join("$BUILDSRC_DIR", "web_server_static.cpp.o")
+    web_server_static = join(env.subst("$BUILD_DIR"), "src/web_server_static.cpp.o")
 
     files = filtered_listdir(source)
 


### PR DESCRIPTION
platformio doesn't appear to define $BUILDSRC_DIR, which means the
generated dependencies never matched actual files and the GUI would
not be regenerated from modified sources.
