### PR TITLE
Change C to Celsius for OCPP MeterValue

### DIFF
--- a/src/ocpp.cpp
+++ b/src/ocpp.cpp
@@ -207,7 +207,7 @@ void ArduinoOcppTask::loadEvseBehavior() {
             return evse->getTemperature(EVSE_MONITOR_TEMP_MONITOR);
         }, 
         "Temperature",
-        "C");
+        "Celsius");
 
     setSmartChargingOutput([this] (float power, float current, int nphases) {
         if (power >= 0.f && current >= 0.f) {


### PR DESCRIPTION
'C' is not listed as a UnitOfMeasure in OCPP 1.6 Section 7.45. Changing 'C' to 'Celsius' to appease protocol validators.