### PR TITLE
Add esp32-c3-devkitc-02

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
           - olimex_esp32-poe-iso
           - heltec_esp32-wifi-lora-v2
           - wt32-eth01
+          - esp32-c3-devkitc-02
         gui:
           - name: gui-v2
             repo: OpenEVSE/openevse-gui-v2

--- a/platformio.ini
+++ b/platformio.ini
@@ -111,7 +111,7 @@ neopixel_lib = adafruit/Adafruit NeoPixel@1.11.0
 #platform = https://github.com/platformio/platform-espressif32.git#feature/stage
 #platform = https://github.com/platformio/platform-espressif32.git#develop
 #platform = espressif32@1.11.1
-platform = espressif32@6.0.1
+platform = espressif32@6.4.0
 #framework = arduino, espidf
 framework = arduino
 lib_deps = ${common.lib_deps}
@@ -342,3 +342,19 @@ build_flags =
   -D ETH_PHY_MDIO=18
   -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN
   -D ETH_PHY_POWER=16
+
+[env:esp32-c3-devkitc-02]
+board = esp32-c3-devkitc-02
+lib_deps =
+  ${common.lib_deps}
+  ${common.neopixel_lib}
+build_flags =
+  ${common.build_flags}
+  ${common.src_build_flags}
+  ${common.debug_flags}
+  -D RAPI_PORT=Serial1
+  -D TX1=6
+  -D RX1=7
+  -D NEO_PIXEL_PIN=8
+  -D NEO_PIXEL_LENGTH=1
+  -D WIFI_PIXEL_NUMBER=1


### PR DESCRIPTION
As I tried to foist this off in #713, this adds support for the [ESP32-C3 devkit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/hw-reference/esp32c3/user-guide-devkitc-02.html) that seems to be working just fine after a month of use. I am using a more recent espressif32 release (6.4.0)  though, as the C3 isn't supported on 6.0.1.

I chose GPIO6 for RAPI TX and GPIO7 for RAPI RX somewhat arbitrarily, just because they aren't ADC pins or the USB DP/DN pins, JTAG pin, or UART0 TX/RX.

| Pin | Function |
|--|--|
| GPIO0 | WiFi Button / BOOT |
| GPIO6 | RAPI TX |
| GPIO7 | RAPI RX |
| GPIO8 | RGB LED |
| GPIO21 | USB Serial TX (cp2102) |
| GPIO20 | USB Serial RX (cp2102) | 

Log messages come out the USB port, the RGB LED color cycles on boot, and my OpenEVSE works just fine with 8.2.2. I believe my OpenEVSE is a v2.5? (2014 it was listed as "OpenEVSE 50A Deluxe Charge Station Combo - Quick Kit with RGB LCD/RTC / OpenEVSE Artwork")

The ESP Info on the firmware page shows "UNKOWNr3 1 core WiFi BLE" due to ESPAL [not supporting anything except the basic ESP32](https://github.com/jeremypoulter/ESPAL/blob/master/src/espal_esp32.h#L30)