### PR TITLE
Clean up, simplify, and correct some energy meter code

### DIFF
--- a/src/energy_meter.h
+++ b/src/energy_meter.h
@@ -39,7 +39,7 @@ public:
   double weekly;	  // kwh
   double monthly;	  // kwh
   double yearly;	  // kwh
-  uint32_t elapsed; // sec
+  double elapsed; // sec
   uint32_t switches; // homw many switches the relay/contactor got
   bool imported;	  // has imported old counter already
   EnergyMeterDate date;
@@ -57,7 +57,6 @@ private:
   uint32_t _write_upd;
   uint32_t _event_upd;
   uint32_t _rotate_upd;
-  uint32_t _elapsed;
   uint8_t _switch_state; // 0: Undefined, 1: Enabled, 2: Disabled
 
   EvseMonitor *_monitor;

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -348,7 +348,7 @@ class EvseManager : public MicroTasks::Task
     bool publishEnergyMeter() {
       return _monitor.publishEnergyMeter();
     }
-		void createEnergyMeterJsonDoc(JsonDocument &doc) {
+    void createEnergyMeterJsonDoc(JsonDocument &doc) {
       _monitor.createEnergyMeterJsonDoc(doc);
     }
     long getFaultCountGFCI() {


### PR DESCRIPTION
Much of this code was copied from the low-level firmware side, where we don't have floating point available, and had to use some tricks to ensure we didn't lose precision. (I should know- I wrote it!) Since this doesn't apply in our ESP32 code, we can just multiply the three values (volts, amps, milliseconds) together to get milliwatt-seconds.

Additionally, we should store elapsed as a floating point value, not an integer number of seconds. As we're going through the pool loop, which repeats every 1000 ms, we might not hit that value exactly. Imagine we are closer to 1020 ms instead due to the work we need to do each iteration. That would allow our elapsed second counter, which stores a truncated value (1020ms gets rounded to integer 1 second), to drift by 1 second every 50 seconds.