### PR TITLE
Fix TFT I2C devices

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -109,6 +109,10 @@ build_flags_openevse_tft =
   -D WIFI_PIXEL_NUMBER=1
   -D WIFI_BUTTON=0
   -D WIFI_BUTTON_PRESSED_STATE=LOW
+  -D I2C_SDA=21
+  -D I2C_SCL=22
+  -D ENABLE_MCP9808
+  -D ENABLE_PN532
 build_partitions = min_spiffs.csv
 build_partitions_debug = min_spiffs_debug.csv
 build_partitions_16mb = openevse_16mb.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -447,6 +447,7 @@ lib_deps =
   ${common.lib_deps}
   ${common.gfx_display_libs}
   ${common.neopixel_lib}
+  adafruit/Adafruit MCP9808 Library @ 1.1.2
 board_build.partitions = ${common.build_partitions_16mb}
 board_upload.flash_size = 16MB
 board_build.flash_mode = qio


### PR DESCRIPTION
Add the missing build flags to enable I2C devices (NFC reader and Temperature sensor).