### PR TITLE
Be more agressive about clearing the boot lock

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,7 @@ extra_scripts =
   scripts/extra_script.py
 debug_flags =
   -ggdb
+  -D ENABLE_FULL_RAPI
   -D ENABLE_DEBUG
   #-D ENABLE_DEBUG_WEB
   #-D ENABLE_DEBUG_WEB_REQUEST

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -319,6 +319,12 @@ unsigned long EvseMonitor::loop(MicroTasks::WakeReason reason)
   DBUG(", _count = ");
   DBUGLN(_count);
 
+  // unlock openevse fw compiled with BOOTLOCK
+  if (isBootLocked()) {
+    unlock();
+    DBUGLN("Unlocked BOOTLOCK");
+  }
+
   if(_heartbeat)
   {
     _openevse.heartbeatPulse([] (int ret)
@@ -346,12 +352,6 @@ unsigned long EvseMonitor::loop(MicroTasks::WakeReason reason)
   // Fixed in latest OpenEvse firwmare
   if (isCharging()){
     verifyPilot();
-  }
-
-   // unlock openevse fw compiled with BOOTLOCK
-  if (isBootLocked() && OPENEVSE_STATE_STARTING != getEvseState()) {
-    unlock();
-    DBUGLN("Unlocked BOOTLOCK");
   }
 
   _count ++;
@@ -416,7 +416,8 @@ EvseMonitor::ServiceLevel EvseMonitor::getActualServiceLevel()
     ServiceLevel::L1;
 }
 
-void EvseMonitor::unlock() {
+void EvseMonitor::unlock()
+{
   // Unlock OpenEVSE if compiled with BOOTLOCK
   _openevse.clearBootLock([this](int ret)
   {
@@ -427,9 +428,9 @@ void EvseMonitor::unlock() {
     else {
       DBUGF("Unlock OpenEVSE failed");
     }
-
   });
 }
+
 void EvseMonitor::enable()
 {
   OpenEVSE.enable([this](int ret)
@@ -732,7 +733,7 @@ void EvseMonitor::getChargeCurrentAndVoltageFromEvse()
         if(VOLTAGE_MINIMUM <= volts && volts <= VOLTAGE_MAXIMUM) {
           _voltage = volts;
         }
-        _power = _amp * _voltage; 
+        _power = _amp * _voltage;
         if (config_threephase_enabled()) {
           _power = _power * 3;
         }


### PR DESCRIPTION
There was a check to see if the EVSE was not in the starting state, but it does not exit starting until the boot lock in cleared. Just removed that check as it is not needed as there is a flag to indicate if the boot lock is set.

Fixes #798 “Waiting for initialization” after power loss