### PR TITLE
Tweaks to the release workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,7 +131,6 @@ jobs:
         tag_name: latest
         name: Development Build
         generate_release_notes: true
-        append_body: true
         files: |
           *.bin
 
@@ -139,8 +138,7 @@ jobs:
       if: startsWith(github.ref_name, 'v')
       uses: "softprops/action-gh-release@v2"
       with:
-        draft: true
+        prerelease: true
         name: "${{ github.ref_name }}"
-        generate_release_notes: true
         files: |
           *.bin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,9 +116,9 @@ jobs:
 
     - name: Get the bootloader and partition files
       run: |
-        for i in openevse_wifi_tft_v1:16mb openevse_wifi_v1:4mb do
-          env=${i%%:*}
-          name=${i#*:}
+        for i in openevse_wifi_tft_v1:16mb openevse_wifi_v1:4mb; do
+          env=$(cut -f1 -d: <<< $i)
+          name=$(cut -f2 -d: <<< $i)
           mv artifacts/$env.bin/bootloader.bin bootloader_$name.bin
           mv artifacts/$env.bin/partitions.bin partitions_$name.bin
         done

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.env }}.bin
-        path: .pio/build/${{ matrix.env }}/firmware.bin
+        path: .pio/build/${{ matrix.env }}/*.bin
 
   release:
     name: Upload release assets
@@ -114,14 +114,24 @@ jobs:
           mv "$image" "$board"
         done
 
+    - name: Get the bootloader and partition files
+      run: |
+        for i in openevse_wifi_tft_v1:16mb openevse_wifi_v1:4mb do
+          env=${i%%:*}
+          name=${i#*:}
+          mv artifacts/$env.bin/bootloader.bin bootloader_$name.bin
+          mv artifacts/$env.bin/partitions.bin partitions_$name.bin
+        done
+
     - name: Upload assets to latest release
       if: github.ref_name == 'master'
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: "softprops/action-gh-release@v2"
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: latest
         prerelease: true
-        title: Development Build
+        tag_name: latest
+        name: Development Build
+        generate_release_notes: true
+        append_body: true
         files: |
           *.bin
 
@@ -129,7 +139,8 @@ jobs:
       if: startsWith(github.ref_name, 'v')
       uses: "softprops/action-gh-release@v2"
       with:
-        prerelease: true
+        draft: true
         name: "${{ github.ref_name }}"
+        generate_release_notes: true
         files: |
           *.bin


### PR DESCRIPTION
Grab the bootloader and partition files for 4MB and 16MB builds

`marvinpinto/action-automatic-releases` no longer looks to be maintained and for some reason we are using a different actions for the latest and proper release, so used `softprops/action-gh-release` for both cases.