### PR TITLE
Adding LedBar Animation for Visual effects of OpenEVSE activity and status

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -379,7 +379,31 @@ build_flags =
   -D RX1=25
   -D TX1=27
 
+
 [env:wt32-eth01]
+# For Wireless Tag
+board = wt32-eth01
+build_flags =
+  ${common.build_flags}
+  ${common.src_build_flags}
+  -D WIFI_LED=12
+  -D WIFI_LED_ON_STATE=HIGH
+  -D WIFI_BUTTON=4
+  -D WIFI_BUTTON_PRESSED_STATE=LOW
+ # -D DEBUG_PORT=Serial
+  -D RAPI_PORT=Serial2
+  -D ENABLE_WIRED_ETHERNET
+  -D RESET_ETH_PHY_ON_BOOT=1
+  -D RX2=5
+  -D TX2=17
+  -D ETH_PHY_TYPE=ETH_PHY_LAN8720
+  -D ETH_PHY_ADDR=1
+  -D ETH_PHY_MDC=23
+  -D ETH_PHY_MDIO=18
+  -D ETH_CLK_MODE=ETH_CLOCK_GPIO0_IN
+  -D ETH_PHY_POWER=16
+
+[env:wt32-eth01-ws2812]
 # For Wireless Tag
 board = wt32-eth01
 lib_deps =
@@ -400,14 +424,16 @@ build_flags =
   -D WIFI_BUTTON_PRESSED_STATE=LOW
  # -D DEBUG_PORT=Serial
   -D RAPI_PORT=Serial2
+  # If using PN532 RFID reader through I2C
   # Need to comment pin definition for SDA and SCL at .platformio/packages/framework-arduinoespressif32/variants/wt32-eth01/pins_arduino.h
-  -D I2C_SDA=2
-  -D I2C_SCL=4
-  -D SDA=2
-  -D SCL=4
+  #-D I2C_SDA=2
+  #-D I2C_SCL=4
+  #-D ENABLE_PN532
+  # If Using MCP9808
+  #-D SDA=2
+  #-D SCL=4
+  #-D ENABLE_MCP9808
   -D ENABLE_WIRED_ETHERNET
-  -D ENABLE_MCP9808
-  -D ENABLE_PN532
   -D RESET_ETH_PHY_ON_BOOT=1
   -D RX2=5
   -D TX2=17

--- a/platformio.ini
+++ b/platformio.ini
@@ -122,6 +122,7 @@ build_partitions_debug = min_spiffs_debug.csv
 build_partitions_16mb = openevse_16mb.csv
 
 neopixel_lib = adafruit/Adafruit NeoPixel@1.12.3
+ws2812fx_lib = kitesurfer1404/WS2812FX@1.4.4
 
 gfx_display_libs =
 #  lvgl/lvgl@8.3.9
@@ -381,16 +382,32 @@ build_flags =
 [env:wt32-eth01]
 # For Wireless Tag
 board = wt32-eth01
+lib_deps =
+  ${common.lib_deps}
+  ${common.neopixel_lib}
+  ${common.ws2812fx_lib}
+  adafruit/Adafruit MCP9808 Library @ 1.1.2
 build_flags =
   ${common.build_flags}
   ${common.src_build_flags}
-  -D WIFI_LED=12
-  -D WIFI_LED_ON_STATE=HIGH
+  #-D WIFI_LED=12
+  #-D WIFI_LED_ON_STATE=HIGH
+  -D NEO_PIXEL_PIN=12
+  -D NEO_PIXEL_LENGTH=15
+  -D ENABLE_WS2812FX
+  -D WIFI_PIXEL_NUMBER=1
   -D WIFI_BUTTON=4
   -D WIFI_BUTTON_PRESSED_STATE=LOW
  # -D DEBUG_PORT=Serial
   -D RAPI_PORT=Serial2
+  # Need to comment pin definition for SDA and SCL at .platformio/packages/framework-arduinoespressif32/variants/wt32-eth01/pins_arduino.h
+  -D I2C_SDA=2
+  -D I2C_SCL=4
+  -D SDA=2
+  -D SCL=4
   -D ENABLE_WIRED_ETHERNET
+  -D ENABLE_MCP9808
+  -D ENABLE_PN532
   -D RESET_ETH_PHY_ON_BOOT=1
   -D RX2=5
   -D TX2=17

--- a/src/LedManagerTask.cpp
+++ b/src/LedManagerTask.cpp
@@ -745,11 +745,11 @@ void LedManagerTask::setBrightness(uint8_t brightness)
   MicroTask.wakeTask(this);
 }
 
-LedManagerTask ledManager;
-
 #if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
-extern void ledManager_loop()
+void LedManagerTask::service()
 {
   ws2812fx.service();
 }
 #endif
+
+LedManagerTask ledManager;

--- a/src/LedManagerTask.cpp
+++ b/src/LedManagerTask.cpp
@@ -44,7 +44,7 @@ class LedAnimatorTask : public MicroTasks::Task
     }
     unsigned long loop(MicroTasks::WakeReason reason) {
       ws2812fx.service();
-      return 40;
+      return 10;
     }
 } animator;
 #endif

--- a/src/LedManagerTask.cpp
+++ b/src/LedManagerTask.cpp
@@ -30,9 +30,12 @@
 #include "emonesp.h"
 #include "LedManagerTask.h"
 
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH)
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && !defined(ENABLE_WS2812FX)
 #include <Adafruit_NeoPixel.h>
 Adafruit_NeoPixel strip = Adafruit_NeoPixel(NEO_PIXEL_LENGTH, NEO_PIXEL_PIN, NEO_GRB + NEO_KHZ800);
+#elif defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+#include <WS2812FX.h>
+WS2812FX ws2812fx = WS2812FX(NEO_PIXEL_LENGTH, NEO_PIXEL_PIN, NEO_GRB + NEO_KHZ800);
 #endif
 
 #define FADE_STEP         16
@@ -40,6 +43,13 @@ Adafruit_NeoPixel strip = Adafruit_NeoPixel(NEO_PIXEL_LENGTH, NEO_PIXEL_PIN, NEO
 
 #define CONNECTING_FLASH_TIME 450
 #define CONNECTED_FLASH_TIME  250
+
+#if defined(ENABLE_WS2812FX)
+// Speed for FX Bar Effects
+#define DEFAULT_FX_SPEED 1000
+#define CONNECTING_FX_SPEED 2000
+#define CONNECTED_FX_SPEED  1000
+#endif
 
 #define TEST_LED_TIME     500
 
@@ -91,6 +101,41 @@ uint8_t buttonShareState = 0;
 
 #define rgb(r,g,b) (r<<16|g<<8|b)
 
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+
+static uint32_t status_colour_map(u_int8_t lcdcol)
+{
+  u_int32_t color;
+  switch (lcdcol)
+  {
+  case OPENEVSE_LCD_OFF:
+    color = 0x000000; // BLACK
+    break;
+  case OPENEVSE_LCD_RED:
+    color = 0xFF0000;  // RED
+    break;
+  case OPENEVSE_LCD_GREEN: 
+    color = 0x00FF00; // GREEN
+    break;
+  case OPENEVSE_LCD_YELLOW: 
+    color = 0xFFFF00; // YELLOW
+    break;
+  case OPENEVSE_LCD_BLUE: 
+    color = 0x0000FF; // BLUE
+    break;
+  case OPENEVSE_LCD_VIOLET: 
+    color = 0xFF00FF; // VIOLET
+    break;
+  case OPENEVSE_LCD_TEAL: 
+    color = 0x00FFFF; // TEAL
+    break;
+  case OPENEVSE_LCD_WHITE: 
+    color = 0xFFFFFF; // WHITE
+    break;
+  }
+  return color; // WHITE
+}
+#else
 static uint32_t status_colour_map[] =
 {
   rgb(0, 0, 0),       // OPENEVSE_LCD_OFF
@@ -102,6 +147,7 @@ static uint32_t status_colour_map[] =
   rgb(0, 255, 255),   // OPENEVSE_LCD_TEAL
   rgb(255, 255, 255), // OPENEVSE_LCD_WHITE
 };
+#endif
 #endif
 
 LedManagerTask::LedManagerTask() :
@@ -125,11 +171,22 @@ void LedManagerTask::begin(EvseManager &evse)
 
 void LedManagerTask::setup()
 {
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH)
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && !defined(ENABLE_WS2812FX)
   DBUGF("Initialising NeoPixels");
   strip.begin();
   //strip.setBrightness(brightness);
   setAllRGB(0, 0, 0);
+#elif defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+  DEBUG.printf("Initialising NeoPixels WS2812FX MODE...\n");
+  ws2812fx.init();
+  ws2812fx.setBrightness(brightness);
+  ws2812fx.setSpeed(DEFAULT_FX_SPEED);
+  ws2812fx.setColor(BLACK);
+  ws2812fx.setMode(FX_MODE_STATIC);
+  //ws2812fx.setBrightness(this->brightness);
+  DEBUG.printf("Brightness: %d ", this->brightness);
+  DEBUG.printf("Brightness: %d ", brightness);
+  ws2812fx.start();
 #endif
 
 #if defined(RED_LED) && defined(GREEN_LED) && defined(BLUE_LED)
@@ -179,6 +236,100 @@ unsigned long LedManagerTask::loop(MicroTasks::WakeReason reason)
   }
 
 #if RGB_LED
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+  switch(state)
+  {
+    case LedState_Off:
+      //setAllRGB(0, 0, 0);
+      ws2812fx.setColor(BLACK);
+      return MicroTask.Infinate;
+
+    case LedState_Test_Red:
+      //setAllRGB(255, 0, 0);
+      ws2812fx.setColor(RED);
+      state = LedState_Test_Green;
+      return TEST_LED_TIME;
+
+    case LedState_Test_Green:
+      //setAllRGB(0, 255, 0);
+      ws2812fx.setColor(GREEN);
+      state = LedState_Test_Blue;
+      return TEST_LED_TIME;
+
+    case LedState_Test_Blue:
+      //setAllRGB(0, 0, 255);
+      ws2812fx.setColor(BLUE);
+      state = LedState_Off;
+      setNewState(false);
+      return TEST_LED_TIME;
+
+
+    case LedState_Evse_State:
+    case LedState_WiFi_Access_Point_Waiting:
+    case LedState_WiFi_Access_Point_Connected:
+    case LedState_WiFi_Client_Connecting:
+    case LedState_WiFi_Client_Connected:
+    {
+      uint8_t lcdCol = _evse->getStateColour();
+      DBUGVAR(lcdCol);
+      uint32_t col = status_colour_map(lcdCol);
+      DBUGVAR(col, HEX);
+      //DEBUG.printf("Color: %x\n", col);
+      bool isCharging;
+      u_int16_t speed;
+      speed = 2000 - ((_evse->getChargeCurrent()/_evse->getMaxHardwareCurrent())*1000);
+      DEBUG.printf("Speed: %d ",speed);
+      DEBUG.printf("Amps: %d ", _evse->getAmps());
+      DEBUG.printf("ChargeCurrent: %d ", _evse->getChargeCurrent());
+      DEBUG.printf("MaxHWCurrent: %d ", _evse->getMaxHardwareCurrent());
+      if (this->brightness == 0){
+        ws2812fx.setBrightness(255);
+      }
+      else {
+        ws2812fx.setBrightness(this->brightness-1);
+      }
+      switch(state)
+      {
+        case LedState_Evse_State:
+          isCharging = _evse->isCharging();
+          if(isCharging){
+            setAllRGB(col, FX_MODE_COLOR_WIPE, speed);
+          }
+          else {
+            setAllRGB(col, FX_MODE_STATIC, DEFAULT_FX_SPEED);
+          }    
+          //DEBUG.printf("MODO:  LedState_Evse_State\n");
+          return MicroTask.Infinate;
+
+        case LedState_WiFi_Access_Point_Waiting:
+          setEvseAndWifiRGB(col, FX_MODE_BLINK, CONNECTING_FX_SPEED);
+          //DEBUG.printf("MODO: LedState_WiFi_Access_Point_Waiting\n");
+          return CONNECTING_FLASH_TIME;
+
+        case LedState_WiFi_Access_Point_Connected:
+          setEvseAndWifiRGB(col, FX_MODE_FADE, CONNECTED_FX_SPEED);
+          flashState = !flashState;
+          //DEBUG.printf("MODO: LedState_WiFi_Access_Point_Connected\n");
+          return CONNECTED_FLASH_TIME;
+
+        case LedState_WiFi_Client_Connecting:
+          setEvseAndWifiRGB(col, FX_MODE_FADE, CONNECTING_FX_SPEED);
+          flashState = !flashState;
+          //DEBUG.printf("MODO: LedState_WiFi_Client_Connecting\n");
+          return CONNECTING_FLASH_TIME;
+
+        case LedState_WiFi_Client_Connected:
+          setEvseAndWifiRGB(col, FX_MODE_FADE, CONNECTED_FX_SPEED);
+          //DEBUG.printf("MODO: LedState_WiFi_Client_Connected\n");
+          return MicroTask.Infinate;
+
+        default:
+          break;
+      }
+    }
+
+  }
+#else
   switch(state)
   {
     case LedState_Off:
@@ -279,6 +430,7 @@ unsigned long LedManagerTask::loop(MicroTasks::WakeReason reason)
 #endif
   }
 #endif
+#endif
 
 #ifdef WIFI_LED
   switch(state)
@@ -339,13 +491,39 @@ int LedManagerTask::fadeLed(int fadeValue, int FadeDir)
 */
 
 #if RGB_LED
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+void LedManagerTask::setAllRGB(uint32_t color, u_int8_t mode, uint16_t speed)
+{
+  setEvseAndWifiRGB(color, mode, speed);
+}
+
+
+void LedManagerTask::setEvseAndWifiRGB(uint32_t evseColor, u_int8_t mode, u_int16_t speed)
+{
+  DBUG("EVSE LED COLOR:");
+  DBUG(evseColor);
+  if(evseColor != ws2812fx.getColor()){
+    ws2812fx.setColor(evseColor);
+  }
+
+  if(speed != ws2812fx.getSpeed()){
+    ws2812fx.setSpeed(speed);
+  }
+  
+  if (ws2812fx.getMode() != mode){
+    ws2812fx.setMode(mode);
+  }
+  
+}
+#else
 void LedManagerTask::setAllRGB(uint8_t red, uint8_t green, uint8_t blue)
 {
   setEvseAndWifiRGB(red, green, blue, red, green, blue);
 }
 #endif
+#endif
 
-#if WIFI_PIXEL_NUMBER
+#if WIFI_PIXEL_NUMBER && !defined(ENABLE_WS2812FX)
 void LedManagerTask::setEvseAndWifiRGB(uint8_t evseRed, uint8_t evseGreen, uint8_t evseBlue, uint8_t wifiRed, uint8_t wifiGreen, uint8_t wifiBlue)
 {
   DBUG("EVSE LED R:");
@@ -385,7 +563,7 @@ void LedManagerTask::setEvseAndWifiRGB(uint8_t evseRed, uint8_t evseGreen, uint8
   DBUG(" B:");
   DBUGLN(wifiBlue);
 
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH)
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && !defined(ENABLE_WS2812FX)
   uint32_t col = strip.gamma32(strip.Color(evseRed, evseGreen, evseBlue));
   DBUGVAR(col, HEX);
   strip.fill(col);
@@ -549,6 +727,18 @@ void LedManagerTask::setBrightness(uint8_t brightness)
   // brightness (off), 255 = just below max brightness.
   this->brightness = brightness + 1;
 
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+// This controls changes on the limits of the web interface slidebar.
+// Otherwise it gets out of sync
+  if (this->brightness == 0){
+    ws2812fx.setBrightness(255);
+  }
+  else {
+    ws2812fx.setBrightness(this->brightness-1);
+  }
+  
+#endif
+
   DBUGVAR(this->brightness);
 
   // Wake the task to refresh the state
@@ -556,3 +746,10 @@ void LedManagerTask::setBrightness(uint8_t brightness)
 }
 
 LedManagerTask ledManager;
+
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+extern void ledManager_loop()
+{
+  ws2812fx.service();
+}
+#endif

--- a/src/LedManagerTask.h
+++ b/src/LedManagerTask.h
@@ -78,13 +78,6 @@ class LedManagerTask : public MicroTasks::Task
     int getButtonPressed();
 
     void setBrightness(uint8_t brightness);
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
-// -------------------------------------------------------------------
-// Perform the background status bar  operations. Must be called in the main
-// loop function
-// -------------------------------------------------------------------
-    void service();
-#endif
 };
 
 extern LedManagerTask ledManager;

--- a/src/LedManagerTask.h
+++ b/src/LedManagerTask.h
@@ -44,8 +44,13 @@ class LedManagerTask : public MicroTasks::Task
     MicroTasks::EventListener onStateChange;
 
 #if RGB_LED
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+    void setAllRGB(uint32_t color, u_int8_t mode, u_int16_t speed);
+    void setEvseAndWifiRGB(uint32_t evseColor, u_int8_t mode, u_int16_t speed);
+#else
     void setAllRGB(uint8_t red, uint8_t green, uint8_t blue);
     void setEvseAndWifiRGB(uint8_t evseRed, uint8_t evseGreen, uint8_t evseBlue, uint8_t wifiRed, uint8_t wifiGreen, uint8_t wifiBlue);
+#endif
 #endif
 
 #ifdef WIFI_LED
@@ -76,5 +81,13 @@ class LedManagerTask : public MicroTasks::Task
 };
 
 extern LedManagerTask ledManager;
+
+// -------------------------------------------------------------------
+// Perform the background status bar  operations. Must be called in the main
+// loop function
+// -------------------------------------------------------------------
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+extern void ledManager_loop();
+#endif
 
 #endif //  LED_MANAGER_TASK_H

--- a/src/LedManagerTask.h
+++ b/src/LedManagerTask.h
@@ -78,16 +78,15 @@ class LedManagerTask : public MicroTasks::Task
     int getButtonPressed();
 
     void setBrightness(uint8_t brightness);
-};
-
-extern LedManagerTask ledManager;
-
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
 // -------------------------------------------------------------------
 // Perform the background status bar  operations. Must be called in the main
 // loop function
 // -------------------------------------------------------------------
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
-extern void ledManager_loop();
+    void service();
 #endif
+};
+
+extern LedManagerTask ledManager;
 
 #endif //  LED_MANAGER_TASK_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,11 +215,6 @@ loop() {
   MicroTask.update();
   Profile_End(MicroTask, 10);
 
-#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
-  // Call ws2812fx service method to update ledbar effect
-  ledManager.service();
-#endif
-
   if(OpenEVSE.isConnected())
   {
     if(OPENEVSE_STATE_STARTING != evse.getEvseState())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,7 +216,8 @@ loop() {
   Profile_End(MicroTask, 10);
 
 #if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
-  ledManager_loop();
+  // Call ws2812fx service method to update ledbar effect
+  ledManager.service();
 #endif
 
   if(OpenEVSE.isConnected())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -215,6 +215,10 @@ loop() {
   MicroTask.update();
   Profile_End(MicroTask, 10);
 
+#if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
+  ledManager_loop();
+#endif
+
   if(OpenEVSE.isConnected())
   {
     if(OPENEVSE_STATE_STARTING != evse.getEvseState())


### PR DESCRIPTION
Here is my modification to the original OpenEVSE project to introduce a led bar as most commercial EVSEs have as seen in this discussion thread https://github.com/OpenEVSE/openevse_esp32_firmware/discussions/891

I'm based on WS2812FX library to perform animations and visual effects.

My first intention is to show visually the status of the EVSE without using the screen nor the web interface and know quickly what is happening in the EVSE as follows:

If the EVSE is not charging the car, the bar have the same color code as the EVSE led (screen, buttons, etc) based on EVSE status
If the EVSE has any error, the led is blinking with corresponding color code
IF the EVSE is loading the car, the led will perform a "loading bar" animation to show this status. Also the speed of the animation will correspond with the intensity in Amps being provided to the car based on max Amp configured.
Led Bar bright can be configured directly from EVSE web interface Led brightness slider, so it is very intuitive to use and naturally integrated

Source code changed for this mod has been mainly done in LedManagerTask to create the integration

Notes for the implementation:

1. My Led Bar uses 15 pixels (you can configure num of pixels based on your own requirements for your bar) Param: NEO_PIXEL_LENGTH=15
2. I'm using the board WT32-ETH01 for the implementation. Thus I'm using some specific pin to communicate with the LED Bar. Change this configuration based on your own esp32 board. Param: NEO_PIXEL_PIN=12
3. An extra parameter has been created to use this functionality on the EVSE. Param: ENABLE_WS2812FX
4. In my use case, I'm also using a PN532 RFID reader to authorize session. Comment this param if not needed.
5. In the event of using PN532 reader with WT32-ETH01 board through I2C You need to comment pin definition for this board in the Arduino.h. Otherwise it will give you an error due to conflict with pins used for I2C
6. Due to the low power of OpenEVSE AC Transformer I decided to use an external AC/DC power source to not overload OpenEVSE power source when full brightness (in future releases of the HW a more amp capable transformer can be used)

New animations and status can be introduced in the future based on this initial implementation.

Some pictures of the OpenEVSE working with this new functionality:


https://github.com/user-attachments/assets/b81d856e-94d1-477d-9cc0-2cc6516dab63

![358304596-50391d9d-2dcd-44c9-bacd-6c80bb85f7b4](https://github.com/user-attachments/assets/2f97e171-6a7a-4861-8ee9-87970cf9f87a)

![358304602-dcb84136-a5da-4086-a372-7aa2f38df942](https://github.com/user-attachments/assets/e5842e70-afb1-4fb4-aa37-3b8229538658)

