### PR TITLE
Fix divertmode MQTT docs to match HTTP API

### DIFF
--- a/docs/mqtt.md
+++ b/docs/mqtt.md
@@ -51,7 +51,7 @@ Limit:
 
 Main settings:
 
-`<base-topic>/divertmode/set [1 | 2]`       : enable (1)/ disable (2) divert mode  
+`<base-topic>/divertmode/set [1 | 2]`       : normal (1)/ eco (2) divert mode  
 `<base-topic>/shaper/set [0 | 1]`           : temporary enable (1)/ disable (0) current shaper ( doesn't survive reboot )  
 `<base-topic>/restart {"device": "gateway|evse"}` : restart the gateway or openevse module
 


### PR DESCRIPTION
Copied definitions from https://openevse.stoplight.io/docs/openevse-wifi-v4/dba95e8966593-get-the-evse-status  (verified these values make sense experimentally)