### PR TITLE
TFT big power display during charging

### DIFF
--- a/src/lcd_tft.cpp
+++ b/src/lcd_tft.cpp
@@ -173,11 +173,12 @@ void LcdTask::setWifiMode(bool client, bool connected)
   wifi_connected = connected;
 }
 
-void LcdTask::begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual)
+void LcdTask::begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual, unsigned long &last_knock)
 {
   _evse = &evse;
   _scheduler = &scheduler;
   _manual = &manual;
+  _last_knock = &last_knock;
   MicroTask.startTask(this);
 }
 
@@ -237,6 +238,8 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
   _tft.startWrite();
 #endif
 
+  uint8_t evse_state = _evse->getEvseState();
+
   switch(_state)
   {
     case State::Boot:
@@ -286,7 +289,12 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
     } break;
 
     case State::Charge:
-    {
+    { 
+      //redraw when going in or out of charging state to switch between pilot and power display
+      if ((evse_state == OPENEVSE_STATE_CHARGING || _previous_evse_state == OPENEVSE_STATE_CHARGING) && evse_state != _previous_evse_state) {  
+        _full_update = true;
+      }
+
       if(_full_update)
       {
         _screen.fillRect(DISPLAY_AREA_X, DISPLAY_AREA_Y, DISPLAY_AREA_WIDTH, DISPLAY_AREA_HEIGHT, TFT_OPENEVSE_BACK);
@@ -301,8 +309,8 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
       if(_evse->isVehicleConnected()) {
         car_icon = "/car_connected.png";
       }
-      
-      switch (_evse->getEvseState())
+
+      switch (evse_state)
       {
         case OPENEVSE_STATE_STARTING:
           status_icon = "/start.png";
@@ -337,7 +345,7 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
       }
 
       char buffer[32] = "";
-      char buffer2[10];
+      char buffer2[12];
 
       if (wifi_client) {
         if (wifi_connected) {
@@ -358,17 +366,36 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
       render_image(car_icon.c_str(), 16, 92);
       render_image(wifi_icon.c_str(), 16, 132);
 
-      snprintf(buffer, sizeof(buffer), "%d", _evse->getChargeCurrent());
-      render_right_text_box(buffer, 66, 175, 154, &FreeSans24pt7b, TFT_BLACK, TFT_WHITE, !_full_update, 2);
-      if(_full_update) {
-        render_left_text_box("A", 224, 165, 34, &FreeSans24pt7b, TFT_BLACK, TFT_WHITE, false, 1);
+
+      if (evse_state == OPENEVSE_STATE_CHARGING) {
+        float power = _evse->getPower() / 1000.0;  //kW
+        if (power < 10) { 
+          snprintf(buffer, sizeof(buffer), "%.2f", power);
+        } else if (power < 100) {
+          snprintf(buffer, sizeof(buffer), "%.1f", power);
+        } else {
+          snprintf(buffer, sizeof(buffer), "%.0f", power);
+        }
+        render_left_text_box(buffer, 66, 157, 188, &FreeSans24pt7b, TFT_BLACK, TFT_WHITE, !_full_update, 2);
+        render_left_text_box("kW", 224, 165, 34, &FreeSans9pt7b, TFT_BLACK, TFT_WHITE, false, 1);
+      } else {
+        snprintf(buffer, sizeof(buffer), "%d", _evse->getChargeCurrent());
+        render_right_text_box(buffer, 66, 175, 154, &FreeSans24pt7b, TFT_BLACK, TFT_WHITE, !_full_update, 2);
+        if (_full_update) {
+          render_left_text_box("A", 224, 165, 34, &FreeSans24pt7b, TFT_BLACK, TFT_WHITE, false, 1);
+        }
       }
       if (_evse->isTemperatureValid(EVSE_MONITOR_TEMP_MONITOR)) {
         snprintf(buffer, sizeof(buffer), "%.1fC", _evse->getTemperature(EVSE_MONITOR_TEMP_MONITOR));
         render_right_text_box(buffer, 415, 30, 50, &FreeSans9pt7b, TFT_WHITE, TFT_OPENEVSE_BACK, false, 1);
       }
+
       snprintf(buffer, sizeof(buffer), "%.1f V  %.2f A", _evse->getVoltage(), _evse->getAmps());
-      get_scaled_number_value(_evse->getPower(), 2, "W", buffer2, sizeof(buffer2));
+      if (evse_state == OPENEVSE_STATE_CHARGING) {
+        snprintf(buffer2, sizeof(buffer2), "Pilot: %dA", _evse->getChargeCurrent());
+      } else {
+        get_scaled_number_value(_evse->getPower(), 2, "W", buffer2, sizeof(buffer2));
+      }
       render_data_box(buffer2, buffer, 66, 175, INFO_BOX_WIDTH, INFO_BOX_HEIGHT, _full_update);
 
       String line = getLine(0);
@@ -397,6 +424,8 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
       strftime(buffer, sizeof(buffer), "%Y-%m-%d  %H:%M:%S", &timeinfo);
       render_left_text_box(buffer, 12, 30, 175, &FreeSans9pt7b, TFT_WHITE, TFT_OPENEVSE_BACK, false, 1);
 
+      _previous_evse_state = evse_state;
+
       //sleep until next whole second so clock doesn't skip
       gettimeofday(&local_time, NULL);
       nextUpdate = 1000 - local_time.tv_usec/1000;
@@ -413,12 +442,12 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
 #endif
 
 #ifdef TFT_BACKLIGHT_TIMEOUT_MS
-  uint8_t evse_state = _evse->getEvseState();
   bool vehicle_state = _evse->isVehicleConnected();
   if (evse_state != _previous_evse_state || vehicle_state != _previous_vehicle_state) {  //wake backlight on state change
     wakeBacklight();
-    _previous_evse_state = evse_state;
     _previous_vehicle_state = vehicle_state;
+  } else if (millis() - *_last_knock <= 1000) {  //knock interrupt in last second
+    wakeBacklight();
   } else {  //otherwise timeout backlight in appropriate states
     bool timeout = true;
     if (_evse->isVehicleConnected()) {
@@ -462,7 +491,7 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
     }
   }
 #endif //TFT_BACKLIGHT_TIMEOUT_MS
-
+  _previous_evse_state = evse_state;
   DBUGVAR(nextUpdate);
   return nextUpdate;
 }

--- a/src/lcd_tft.cpp
+++ b/src/lcd_tft.cpp
@@ -173,12 +173,11 @@ void LcdTask::setWifiMode(bool client, bool connected)
   wifi_connected = connected;
 }
 
-void LcdTask::begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual, unsigned long &last_knock)
+void LcdTask::begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual)
 {
   _evse = &evse;
   _scheduler = &scheduler;
   _manual = &manual;
-  _last_knock = &last_knock;
   MicroTask.startTask(this);
 }
 
@@ -446,8 +445,6 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
   if (evse_state != _previous_evse_state || vehicle_state != _previous_vehicle_state) {  //wake backlight on state change
     wakeBacklight();
     _previous_vehicle_state = vehicle_state;
-  } else if (millis() - *_last_knock <= 1000) {  //knock interrupt in last second
-    wakeBacklight();
   } else {  //otherwise timeout backlight in appropriate states
     bool timeout = true;
     if (_evse->isVehicleConnected()) {

--- a/src/lcd_tft.h
+++ b/src/lcd_tft.h
@@ -95,13 +95,15 @@ class LcdTask : public MicroTasks::Task
     EvseManager *_evse;
     Scheduler *_scheduler;
     ManualOverride *_manual;
+    uint8_t _previous_evse_state;
 #ifdef TFT_BACKLIGHT_TIMEOUT_MS
     long _last_backlight_wakeup = 0;
-    uint8_t _previous_evse_state;
     bool _previous_vehicle_state;
 #endif //TFT_BACKLIGHT_TIMEOUT_MS
     bool wifi_client;
     bool wifi_connected;
+
+    unsigned long *_last_knock;
 
     char _msg[LCD_MAX_LINES][LCD_MAX_LEN + 1];
     bool _msg_cleared;
@@ -116,7 +118,6 @@ class LcdTask : public MicroTasks::Task
     String getLine(int line);
 
 #ifdef TFT_BACKLIGHT_TIMEOUT_MS
-    void wakeBacklight();
     void timeoutBacklight();
 #endif //TFT_BACKLIGHT_TIMEOUT_MS
 
@@ -138,13 +139,17 @@ class LcdTask : public MicroTasks::Task
   public:
     LcdTask();
 
-    void begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual);
+    void begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual, unsigned long &last_knock);
 
     void display(const __FlashStringHelper *msg, int x, int y, int time, uint32_t flags);
     void display(String &msg, int x, int y, int time, uint32_t flags);
     void display(const char *msg, int x, int y, int time, uint32_t flags);
     void setWifiMode(bool client, bool connected);
 
+#ifdef TFT_BACKLIGHT_TIMEOUT_MS
+    void wakeBacklight();
+#endif //TFT_BACKLIGHT_TIMEOUT_MS
+    
     void fill_screen(uint16_t color) {
       _screen.fillScreen(color);
     }

--- a/src/lcd_tft.h
+++ b/src/lcd_tft.h
@@ -103,8 +103,6 @@ class LcdTask : public MicroTasks::Task
     bool wifi_client;
     bool wifi_connected;
 
-    unsigned long *_last_knock;
-
     char _msg[LCD_MAX_LINES][LCD_MAX_LEN + 1];
     bool _msg_cleared;
 
@@ -139,7 +137,7 @@ class LcdTask : public MicroTasks::Task
   public:
     LcdTask();
 
-    void begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual, unsigned long &last_knock);
+    void begin(EvseManager &evse, Scheduler &scheduler, ManualOverride &manual);
 
     void display(const __FlashStringHelper *msg, int x, int y, int time, uint32_t flags);
     void display(String &msg, int x, int y, int time, uint32_t flags);


### PR DESCRIPTION
By popular demand: Uses the big digits to display the measured power during charging.  When not charging, the pilot current setting is displayed here as before.

As there's only room for 3 digits, the number of decimal places changes to fit the available space.

![IMG_20250102_221901602_HDR](https://github.com/user-attachments/assets/b9bbcbab-9f53-4e51-9b8a-afd030217931)
