### PR TITLE
Enable RAPI commands in order to turn off the display

### DIFF
--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -603,12 +603,12 @@ void EvseManager::setMaxConfiguredCurrent(long amps)
 
 bool EvseManager::isRapiCommandBlocked(String rapi)
 {
-  //#ifdef ENABLE_FULL_RAPI
-  //  return false;
-  //#else
-  //  return !rapi.startsWith("$G");
-  //#endif
-  return false;
+  #ifdef ENABLE_FULL_RAPI
+    return false;
+  #else
+    // For commands starting with $G, $F0 o $FB
+    return !(rapi.startsWith("$G") || rapi.startsWith("$F0") || rapi.startsWith("$FB"));
+  #endif
 }
 
 bool EvseManager::serializeClaims(DynamicJsonDocument &doc)

--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -603,11 +603,12 @@ void EvseManager::setMaxConfiguredCurrent(long amps)
 
 bool EvseManager::isRapiCommandBlocked(String rapi)
 {
-#ifdef ENABLE_FULL_RAPI
+  //#ifdef ENABLE_FULL_RAPI
+  //  return false;
+  //#else
+  //  return !rapi.startsWith("$G");
+  //#endif
   return false;
-#else
-  return !rapi.startsWith("$G");
-#endif
 }
 
 bool EvseManager::serializeClaims(DynamicJsonDocument &doc)


### PR DESCRIPTION
In past versions we could use this RAPI commands:

--> $F0 0 and $FB 0 in order to freeze the display a put the background to black (so the leds of the display are turned off)
Also:
--> $F0 1 in order to turn on the display

But sine v5, for security reasons these commands were blocked. This PR is to bring back al least this two commands to recover that feature that is very useful for many users. 

Discussed/asked here: https://github.com/OpenEVSE/openevse_esp32_firmware/issues/725