### PR TITLE
fix(security): replace dummy TLS RNG with the hardware RNG

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -83,7 +83,9 @@ build_flags =
   -D MG_ENABLE_SSL=1
   -D MG_ENABLE_HTTP_STREAMING_MULTIPART=1
   -D MG_ENABLE_EXTRA_ERRORS_DESC=1
-  -D MG_SSL_MBED_DUMMY_RANDOM=1
+  ; NO MG_SSL_MBED_DUMMY_RANDOM: that feeds mbedTLS a predictable rand() PRNG
+  ; (recoverable TLS session keys). The real RNG is provided by
+  ; src/mongoose_rng.cpp (mg_ssl_if_mbed_random -> esp_fill_random, ESP32 HW RNG).
   -D MG_SSL_IF=MG_SSL_IF_MBEDTLS
   -D MG_SSL_IF_MBEDTLS_FREE_CERTS=1
   #-D MG_SSL_IF_MBEDTLS_MAX_FRAG_LEN=2048

--- a/src/mongoose_rng.cpp
+++ b/src/mongoose_rng.cpp
@@ -1,0 +1,25 @@
+// Real RNG for Mongoose's mbedTLS TLS layer.
+//
+// Mongoose declares mg_ssl_if_mbed_random() `extern` and uses it for
+// mbedtls_ssl_conf_rng(), but only *defines* a dummy rand()-based version under
+// -D MG_SSL_MBED_DUMMY_RANDOM -- which its own source flags as "a bad idea ... in
+// production" (a predictable PRNG makes TLS session keys recoverable). We drop
+// that build flag and provide the real implementation here, backed by the ESP32
+// hardware RNG via esp_fill_random().
+//
+// Entropy quality of esp_random()/esp_fill_random():
+//  * ESP32 / ESP32-C3: true-random whenever Wi-Fi (or BT) is enabled, which the
+//    gateway always is by the time TLS runs.
+//  * ESP32-P4: no on-die radio (Wi-Fi is on the C6 over ESP-Hosted), so the
+//    Wi-Fi-feeds-the-RNG guarantee does not apply. hardware_setup() enables the
+//    internal SAR-ADC noise entropy source (bootloader_random_enable) at boot so
+//    the HWRNG is seeded from on-chip noise instead.
+#include <stddef.h>
+#include <esp_random.h>
+
+extern "C" int mg_ssl_if_mbed_random(void *ctx, unsigned char *buf, size_t len)
+{
+  (void) ctx;
+  esp_fill_random(buf, len);
+  return 0;
+}


### PR DESCRIPTION
## Summary

**Security fix.** HTTPS/TLS is built with `-D MG_SSL_MBED_DUMMY_RANDOM=1`, which makes Mongoose feed mbedTLS a predictable `rand()`-based PRNG for *all* TLS randomness. Mongoose's own source calls this "a bad idea ... in production" — a predictable PRNG makes TLS session keys recoverable. It's been the case since the flag was introduced (~2021).

## Fix

Mongoose declares `mg_ssl_if_mbed_random()` `extern` and wires it into `mbedtls_ssl_conf_rng()`, but only *defines* a dummy implementation under that build flag. This PR:

- **Drops** `-D MG_SSL_MBED_DUMMY_RANDOM=1`.
- **Adds `src/mongoose_rng.cpp`** — the real `mg_ssl_if_mbed_random()`, backed by the ESP32 hardware RNG (`esp_fill_random()`).

`esp_random()`/`esp_fill_random()` are true-random whenever the radio is enabled, which the gateway always is by the time TLS runs (ESP32 / ESP32-C3).

## Validation

Builds clean on `openevse_wifi_v1` and links against ArduinoMongoose's mbedTLS layer. No new dependencies, no API changes — just real entropy where there was none.

> Note: the radioless ESP32-P4 additionally needs the SAR-ADC entropy source enabled at boot; that seeding is documented in `mongoose_rng.cpp` and lives with the P4 port (not in this PR, since upstream has no P4 target yet).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
