### PR TITLE
feat: Home Assistant integration (OAuth client + entity polling)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-ha-gating-and-vehicle-charge-limit.md
+++ b/docs/superpowers/plans/2026-06-01-ha-gating-and-vehicle-charge-limit.md
@@ -1,0 +1,478 @@
+# HA Capability Gating + Vehicle Charge-Limit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the HA web UI on firmware capability, and read the vehicle's own charge-limit % from HA → surface it (informational) in `/status` and on the TFT.
+
+**Architecture:** Firmware adds a generic `vehicleChargeLimit` field to the EVSE manager (mirroring SoC), fed by a new `ha_vehicle_charge_limit` HA entity via the existing poll chain, exposed in `/status` and the TFT "Charge limit" info-line. The gui derives `ha_supported` from `/config` (presence of `ha_url`) and hides the HA settings page + Vehicle HA-source option when absent.
+
+**Tech Stack:** C++ (Arduino-ESP32, PlatformIO), ArduinoMongoose, ArduinoJson; Svelte + vitest (gui-nightshift).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-ha-gating-and-vehicle-charge-limit-design.md`
+**Branch:** `feature/home-assistant-oauth` (continues — depends on unmerged HA code).
+
+**Build/test commands:** native `pio test -e native -f test_ha_oauth`; core-2 `pio run -e nodemcu-32s`; P4 `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4`. GUI: in `gui-nightshift/`, `npm test` / `npm run build`. **Publish gui from the canonical clone `/home/rar/openevse-gui-nightshift`** (the in-tree clone bundles into the firmware build; see Task 6).
+
+---
+
+## File Structure
+
+**Firmware:** `src/evse_man.{h,cpp}` (field), `src/app_config.{h,cpp}` (config), `src/home_assistant.cpp` (poll field 3), `src/web_server.cpp` (/status), `src/lcd.cpp` (display + rotation).
+**GUI (`gui-nightshift/`):** `src/lib/stores/config.js` (derived flag), `src/lib/config/pages.js` (filter), `src/routes/Settings.svelte` (pass config), `src/routes/settings/Vehicle.svelte` (gate option) + their tests.
+
+---
+
+## Task 1: EVSE manager — `vehicleChargeLimit` field
+
+**Files:** Modify `src/evse_man.h`, `src/evse_man.cpp`. No unit test (firmware glue; validated by build).
+
+- [ ] **Step 1: Add the validity bit in `src/evse_man.h`**
+
+After `#define EVSE_VEHICLE_ETA    (1 << 2)` add:
+
+```cpp
+#define EVSE_VEHICLE_CHARGE_LIMIT (1 << 3)
+```
+
+- [ ] **Step 2: Add the member in `src/evse_man.h`**
+
+Immediately AFTER the `int _vehicleEta;` member declaration (so it's the last of the
+`_vehicleStateOfCharge` / `_vehicleRange` / `_vehicleEta` group — this ordering must match
+the constructor init-list order in Step 6 to avoid a `-Wreorder` warning), add:
+
+```cpp
+    int _vehicleChargeLimit;
+```
+
+- [ ] **Step 3: Add the getter + valid accessor in `src/evse_man.h`**
+
+Next to the existing `getVehicleStateOfCharge()` / `isVehicleStateOfChargeValid()` (around lines 465–484), add:
+
+```cpp
+    int getVehicleChargeLimit() {
+      return _vehicleChargeLimit;
+    }
+```
+
+and, next to the `isVehicle*Valid()` group:
+
+```cpp
+    int isVehicleChargeLimitValid() {
+      return 0 != (_vehicleValid & EVSE_VEHICLE_CHARGE_LIMIT);
+    }
+```
+
+- [ ] **Step 4: Declare the setter in `src/evse_man.h`**
+
+Next to `void setVehicleStateOfCharge(int vehicleStateOfCharge);` (around line 486), add:
+
+```cpp
+    void setVehicleChargeLimit(int vehicleChargeLimit);
+```
+
+- [ ] **Step 5: Implement the setter in `src/evse_man.cpp`**
+
+After `setVehicleEta(...)` (around line 606), add (mirrors `setVehicleStateOfCharge`):
+
+```cpp
+void EvseManager::setVehicleChargeLimit(int vehicleChargeLimit)
+{
+  _vehicleChargeLimit = vehicleChargeLimit;
+  _vehicleValid |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleUpdated |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleLastUpdated = millis();
+  MicroTask.wakeTask(this);
+}
+```
+
+- [ ] **Step 6: Initialize the member in the constructor**
+
+The `EvseManager::EvseManager(...)` initializer list zero-inits the vehicle members at
+`src/evse_man.cpp:134-136`:
+
+```cpp
+  _vehicleStateOfCharge(0),
+  _vehicleRange(0),
+  _vehicleEta(0)
+```
+
+Add `_vehicleChargeLimit(0)` as the new last vehicle initializer — append a comma to the
+`_vehicleEta(0)` line and add the new line after it:
+
+```cpp
+  _vehicleStateOfCharge(0),
+  _vehicleRange(0),
+  _vehicleEta(0),
+  _vehicleChargeLimit(0)
+```
+
+(This matches the header declaration order from Step 2 — `_vehicleEta` then
+`_vehicleChargeLimit` — so no `-Wreorder`. If `_vehicleEta(0)` is followed by more
+initializers in the list, insert `_vehicleChargeLimit(0)` right after `_vehicleEta(0)` with
+the appropriate commas instead.)
+
+- [ ] **Step 7: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/evse_man.h src/evse_man.cpp
+git commit -m "feat(evse): add vehicleChargeLimit field (mirrors SoC)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Config field + HA poll (field 3)
+
+**Files:** Modify `src/app_config.h`, `src/app_config.cpp`, `src/home_assistant.cpp`.
+
+- [ ] **Step 1: Add the extern in `src/app_config.h`**
+
+Next to `extern String ha_vehicle_eta;`, add:
+
+```cpp
+extern String ha_vehicle_charge_limit;
+```
+
+- [ ] **Step 2: Add the variable in `src/app_config.cpp`**
+
+Next to `String ha_vehicle_eta;`, add:
+
+```cpp
+String ha_vehicle_charge_limit;
+```
+
+- [ ] **Step 3: Register the ConfigOpt in `src/app_config.cpp`**
+
+After `new ConfigOptDefinition<String>(ha_vehicle_eta, "", "ha_vehicle_eta", "hve"),` add:
+
+```cpp
+  new ConfigOptDefinition<String>(ha_vehicle_charge_limit, "", "ha_vehicle_charge_limit", "hvc"),
+```
+
+(The existing `config_changed` `name.startsWith("ha_")` branch already wakes the HA task for this key.)
+
+- [ ] **Step 4: Extend the poll chain in `src/home_assistant.cpp`**
+
+In `pollVehicleField(int field)`, add a `case 3` to the entity switch and change the `default`:
+
+```cpp
+  switch (field) {
+    case 0: entity = ha_vehicle_soc;          break;
+    case 1: entity = ha_vehicle_range;        break;
+    case 2: entity = ha_vehicle_eta;          break;
+    case 3: entity = ha_vehicle_charge_limit; break;
+    default: _vehicleInFlight = false; return; // chain complete (now at field 4)
+  }
+```
+
+And in the `onResponse` numeric-parse switch (the one that calls `evse.setVehicle*`), add the field-3 case:
+
+```cpp
+          switch (field) {
+            case 0: evse.setVehicleStateOfCharge((int)lround(v)); break;
+            case 1: evse.setVehicleRange((int)lround(v));         break;
+            case 2: evse.setVehicleEta((int)lround(v));           break;
+            case 3: evse.setVehicleChargeLimit((int)lround(v));   break;
+          }
+```
+
+(No other changes — the blank-skip, numeric guard, chain-advance `pollVehicleField(next)`, and in-flight/timeout logic all already handle the extra field.)
+
+- [ ] **Step 5: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Native tests still pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app_config.h src/app_config.cpp src/home_assistant.cpp
+git commit -m "feat(ha): poll vehicle charge-limit entity into the EVSE field
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Surface in /status + TFT display
+
+**Files:** Modify `src/web_server.cpp`, `src/lcd.cpp`.
+
+- [ ] **Step 1: Expose in `/status` (`src/web_server.cpp`)**
+
+In the vehicle block (right after the `time_to_full_charge` lines, ~line 288), add:
+
+```cpp
+    if(evse.isVehicleChargeLimitValid()) {
+      doc["vehicle_charge_limit"] = evse.getVehicleChargeLimit();
+    }
+```
+
+- [ ] **Step 2: Fill the TFT "Charge limit" display case (`src/lcd.cpp:565`)**
+
+Replace the stub:
+
+```cpp
+    case LcdInfoLine::ChargeLimit:
+      // Charge limit 85%
+      break;
+```
+
+with:
+
+```cpp
+    case LcdInfoLine::ChargeLimit:
+      displayNumberValue(1, "Charge limit", _evse->getVehicleChargeLimit(), 0, "%");
+      break;
+```
+
+- [ ] **Step 3: Insert ChargeLimit into the info-line rotation (`src/lcd.cpp`, `getNextInfoLine`, CHARGING state)**
+
+In the `OPENEVSE_STATE_CHARGING` switch, the chain currently goes `BatterySOC → Range`. Change the `BatterySOC` case to route through `ChargeLimit` when valid, and add a `ChargeLimit` case. Replace:
+
+```cpp
+        case LcdInfoLine::BatterySOC:
+          if(_evse->isVehicleRangeValid()) {
+            return LcdInfoLine::Range;
+          }
+        case LcdInfoLine::Range:
+```
+
+with:
+
+```cpp
+        case LcdInfoLine::BatterySOC:
+          if(_evse->isVehicleChargeLimitValid()) {
+            return LcdInfoLine::ChargeLimit;
+          }
+          // fall through
+        case LcdInfoLine::ChargeLimit:
+          if(_evse->isVehicleRangeValid()) {
+            return LcdInfoLine::Range;
+          }
+          // fall through
+        case LcdInfoLine::Range:
+```
+
+(These are intentional fall-through cases, matching the existing style in this switch — when a value isn't valid the chain falls to the next case. The result: …BatterySOC → ChargeLimit (if valid) → Range (if valid) → TimeLeft (if valid) → EnergySession.)
+
+- [ ] **Step 4: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web_server.cpp src/lcd.cpp
+git commit -m "feat: surface vehicle charge-limit in /status + TFT info-line
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: gui-nightshift — firmware-capability gating
+
+**Files (in `gui-nightshift/`, in-tree):**
+- Modify: `src/lib/stores/config.js`, `src/lib/config/pages.js`, `src/routes/Settings.svelte`, `src/routes/settings/Vehicle.svelte`
+- Test: `src/lib/config/__tests__/pages.test.js` (exists), `src/routes/settings/__tests__/Vehicle.test.js` (exists)
+
+Work from `/home/rar/oevse/openevse_esp32_firmware/gui-nightshift`. Commit in that repo (branch `main`).
+
+- [ ] **Step 1: Read the current files**
+
+Read `src/lib/stores/config.js` (the `withDerived()` function that adds `firmware_is_eu`), `src/lib/config/pages.js` (`SETTINGS_PAGES` + `pagesBySection()`), `src/routes/Settings.svelte` (calls `pagesBySection()`), `src/routes/settings/Vehicle.svelte` (the `srcOptions` `$derived` with the `'4'` HA entry), and `src/lib/config/__tests__/pages.test.js` (mirror its assertion style).
+
+- [ ] **Step 2: Write failing tests**
+
+In `src/lib/config/__tests__/pages.test.js`, add (adapt import of `pagesBySection` to the file's existing import):
+
+```js
+  it('hides the home-assistant page when ha is unsupported', () => {
+    const groups = pagesBySection({})
+    const keys = groups.flatMap((g) => g.pages.map((p) => p.key))
+    expect(keys).not.toContain('home-assistant')
+  })
+
+  it('shows the home-assistant page when ha_supported', () => {
+    const groups = pagesBySection({ ha_supported: true })
+    const keys = groups.flatMap((g) => g.pages.map((p) => p.key))
+    expect(keys).toContain('home-assistant')
+  })
+
+  it('still shows non-gated pages with no config', () => {
+    const groups = pagesBySection(undefined)
+    const keys = groups.flatMap((g) => g.pages.map((p) => p.key))
+    expect(keys).toContain('network')
+  })
+```
+
+In `src/routes/settings/__tests__/Vehicle.test.js`, add:
+
+```js
+  it('offers the Home Assistant source only when ha is supported', () => {
+    config_store.set({ vehicle_data_src: 0, ha_supported: true })
+    const { getByText } = render(Vehicle)
+    expect(getByText('config.vehicle.src_homeassistant')).toBeInTheDocument()
+  })
+
+  it('hides the Home Assistant source when ha is unsupported', () => {
+    config_store.set({ vehicle_data_src: 0 })
+    const { queryByText } = render(Vehicle)
+    expect(queryByText('config.vehicle.src_homeassistant')).not.toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `npm test -- pages Vehicle`
+Expected: FAIL (home-assistant still present without ha_supported; src_homeassistant always present).
+
+- [ ] **Step 4: Add the `ha_supported` derived flag in `src/lib/stores/config.js`**
+
+In `withDerived(obj)`, where it returns `{ ...obj, firmware_is_eu, max_current_firmware }`, add `ha_supported`:
+
+```js
+    const ha_supported = !!(obj && obj.ha_url !== undefined)
+    return { ...obj, firmware_is_eu, max_current_firmware, ha_supported }
+```
+
+(Place the `const ha_supported = ...` next to the other derived consts inside the `if (obj && typeof obj === 'object')` block.)
+
+- [ ] **Step 5: Gate the page list in `src/lib/config/pages.js`**
+
+Add `requires: 'ha_supported'` to the `home-assistant` entry:
+
+```js
+  { key: 'home-assistant', route: '/settings/home-assistant', icon: 'mdi:home-assistant', labelKey: 'config.pages.home_assistant', section: 'connectivity', requires: 'ha_supported' },
+```
+
+Change `pagesBySection()` to accept config and filter:
+
+```js
+export function pagesBySection(config) {
+  return SECTIONS.map((section) => ({
+    section,
+    pages: SETTINGS_PAGES.filter(
+      (p) => p.section === section && (!p.requires || (config && config[p.requires])),
+    ),
+  }))
+}
+```
+
+- [ ] **Step 6: Pass config in `src/routes/Settings.svelte`**
+
+Find `const groups = pagesBySection()` and change it to read the config store reactively. If the file imports `config_store`, use:
+
+```svelte
+  import { config_store } from '../lib/stores/config.js'  // add if not already imported
+  let groups = $derived(pagesBySection($config_store))
+```
+
+(If `groups` was a `const`, convert to `$derived` so it updates when config loads. Match the file's Svelte 5 rune style — other derived values in the codebase use `$derived`.)
+
+- [ ] **Step 7: Gate the source option in `src/routes/settings/Vehicle.svelte`**
+
+Change the `srcOptions` `$derived` so the HA entry is conditional:
+
+```js
+  let srcOptions = $derived([
+    { value: '0', label: $_('config.vehicle.src_none') },
+    { value: '1', label: $_('config.vehicle.src_tesla') },
+    { value: '2', label: $_('config.vehicle.src_mqtt') },
+    { value: '3', label: $_('config.vehicle.src_http') },
+    ...($config_store?.ha_supported
+      ? [{ value: '4', label: $_('config.vehicle.src_homeassistant') }]
+      : []),
+  ])
+```
+
+(Leave the `{:else if src === 4}` reveal block untouched — it renders by `src` value; the existing VD-Task-4 test that sets `vehicle_data_src: 4` still passes because that block isn't gated.)
+
+- [ ] **Step 8: Run tests**
+
+Run: `npm test -- pages Vehicle`
+Expected: PASS (new cases green; the existing `vehicle_data_src: 4` reveal test still green).
+
+Run: `npm test`
+Expected: PASS (full suite; locale parity unaffected — no new i18n keys).
+
+- [ ] **Step 9: Build the GUI**
+
+Run: `npm run build`
+Expected: SUCCESS.
+
+- [ ] **Step 10: Commit (in gui-nightshift)**
+
+```bash
+cd gui-nightshift
+git add src/lib/stores/config.js src/lib/config/pages.js src/routes/Settings.svelte src/routes/settings/Vehicle.svelte src/lib/config/__tests__/pages.test.js src/routes/settings/__tests__/Vehicle.test.js
+git commit -m "feat(ha): gate HA settings page + vehicle source on firmware capability
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+cd ..
+```
+
+---
+
+## Task 5: Full build + hardware validation
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Native tests** — `pio test -e native -f test_ha_oauth` → PASS.
+- [ ] **Step 2: Core-2 build** — `pio run -e nodemcu-32s` → SUCCESS.
+- [ ] **Step 3: P4 build (gui bundled)** — `( cd gui-nightshift && npm run build )` then `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4` → SUCCESS.
+- [ ] **Step 4: Flash + on-hardware (manual)**
+
+Flash: `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4 -t upload --upload-port /dev/ttyACM5`; wait for HTTP 200. Then:
+- Set `ha_vehicle_charge_limit` to a real HA entity reporting the car's target % (e.g. `number.car_charge_limit`). Confirm `GET /status` shows `vehicle_charge_limit` matching, within ~30 s.
+- On the TFT, during a charging session, confirm the "Charge limit" line appears in the info-line rotation showing the value.
+- Gating check: on this firmware (HA-capable), confirm the Home Assistant settings page and the Vehicle "Home Assistant" source are present (since `/config` has `ha_url`). (Gating-off can only be exercised against older firmware; the unit tests cover the negative path.)
+
+- [ ] **Step 5: Commit any fixes; confirm clean tree.**
+
+---
+
+## Task 6: Publish
+
+- [ ] **Step 1: Publish the GUI from the canonical clone**
+
+```bash
+S=/home/rar/oevse/openevse_esp32_firmware/gui-nightshift
+T=/home/rar/openevse-gui-nightshift
+git -C "$T" fetch origin && git -C "$T" checkout main && git -C "$T" rebase origin/main
+rm -rf /tmp/ha-gate-patch && mkdir -p /tmp/ha-gate-patch
+git -C "$S" format-patch -1 HEAD -o /tmp/ha-gate-patch        # the Task 4 gui commit
+git -C "$T" am /tmp/ha-gate-patch/*.patch
+git -C "$T" push origin main
+```
+
+If `am` conflicts, re-apply the Task 4 edits onto the canonical clone's files and `git -C "$T" am --continue`. Publish ONLY from `$T` (its remote is SSH; the in-tree clone's remote is HTTPS and the classifier blocks changing it).
+
+- [ ] **Step 2: Push the firmware branch**
+
+```bash
+git push origin feature/home-assistant-oauth
+```
+
+---
+
+## Notes for the implementer
+
+- **`vehicleChargeLimit` is source-agnostic** — only HA feeds it this round; Tesla/MQTT could adopt `setVehicleChargeLimit()` later without refactoring.
+- **LCD rotation fall-through** is the established style in `getNextInfoLine` — do not add `break;` to those cases; the fall-through is what skips invalid lines.
+- **No new pure logic** → no new native test; the field is verified by build + on-hardware + the gui gating unit tests.
+- **`vehicle_charge_limit`** `/status` key is deliberately distinct from the EVSE-side `/limit` endpoint and from Tesla's `charge_limit_soc` event field.
+- **Two gui clones:** build/bundle from in-tree `gui-nightshift`; publish from `/home/rar/openevse-gui-nightshift` (Task 6).

--- a/docs/superpowers/plans/2026-06-01-ha-vehicle-data-source.md
+++ b/docs/superpowers/plans/2026-06-01-ha-vehicle-data-source.md
@@ -1,0 +1,506 @@
+# Home Assistant Vehicle-Data Source — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the user pick Home Assistant as the charger's vehicle-data source and configure HA entity IDs for SoC/range/ETA, which the HA client polls (via the existing `homeAssistant.get()` seam) and feeds into the EVSE manager.
+
+**Architecture:** Approach A — the poll lives inside `HomeAssistantClient`, driven by its existing 30 s `loop()`, gated on `isConnected() && vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT`. A pure, natively-tested `ha_parse_entity_state()` extracts `.state` from HA's `/api/states/<entity>` JSON; the poll chains the configured entities sequentially on the shared HTTP client and calls `evse.setVehicleStateOfCharge/Range/Eta`.
+
+**Tech Stack:** C++ (Arduino-ESP32, PlatformIO), ArduinoMongoose (`MongooseHttpClient`), ArduinoJson 6.20.1, doctest (native tests), Svelte + vitest (gui-nightshift).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-ha-vehicle-data-source-design.md`
+**Branch:** `feature/home-assistant-oauth` (this work continues on it — it depends on the HA-connection code that isn't merged to master yet).
+
+**Build/test commands** (plain `pio` for native/core-2; `./scripts/pio` for the P4/core-3 env):
+- Native unit tests: `pio test -e native -f test_ha_oauth`
+- Core-2 compile check: `pio run -e nodemcu-32s`
+- P4 (gui bundled): `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4`
+
+**GUI clone note:** Do the gui work in the **in-tree** clone `gui-nightshift/` (the firmware build bundles its `dist`). Publishing to GitHub happens from the canonical clone `/home/rar/openevse-gui-nightshift` in the final task (the in-tree clone's remote is HTTPS / no push creds; the classifier blocks changing it).
+
+---
+
+## File Structure
+
+**Firmware (this repo):**
+- Modify `src/ha_oauth.h` / `src/ha_oauth.cpp` — add pure `ha_parse_entity_state()`.
+- Modify `test/test_ha_oauth/test_ha_oauth.cpp` — doctest cases for it.
+- Modify `src/app_config.h` — append `VEHICLE_DATA_SRC_HOMEASSISTANT`; extern the 3 config strings.
+- Modify `src/app_config.cpp` — declare + register the 3 config strings.
+- Modify `src/home_assistant.h` / `src/home_assistant.cpp` — vehicle polling (loop gate + `pollVehicle()`/`pollVehicleField()`, `_lastVehiclePoll`, `evse`/`app_config` use).
+
+**GUI (`gui-nightshift/`, in-tree):**
+- Modify `src/routes/settings/Vehicle.svelte` — HA source option + entity fields.
+- Modify `src/routes/settings/__tests__/Vehicle.test.js` — reveal test.
+- Modify the 4 locale files `src/lib/i18n/{en,es,fr,hu}.json` — new vehicle strings.
+
+---
+
+## Task 1: Pure `ha_parse_entity_state()` + native tests
+
+**Files:**
+- Modify: `src/ha_oauth.h`, `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Declare the function in `src/ha_oauth.h`**
+
+Add after the `ha_parse_token_response(...)` declaration:
+
+```cpp
+// Extract the `.state` string from a Home Assistant /api/states/<entity> JSON
+// response. Returns false if the body doesn't parse, `state` is missing/non-string,
+// or it is empty / "unknown" / "unavailable". Uses an ArduinoJson filter so it is
+// memory-safe regardless of how large the entity's `attributes` object is.
+bool ha_parse_entity_state(const std::string &json, std::string &out);
+```
+
+- [ ] **Step 2: Add failing tests** — append to `test/test_ha_oauth/test_ha_oauth.cpp`:
+
+```cpp
+TEST_CASE("ha_parse_entity_state extracts the state, ignoring attributes") {
+  std::string s;
+  CHECK(ha_parse_entity_state(
+      "{\"entity_id\":\"sensor.car\",\"state\":\"73.5\","
+      "\"attributes\":{\"unit_of_measurement\":\"%\",\"friendly_name\":\"Car\"}}", s));
+  CHECK(s == "73.5");
+}
+
+TEST_CASE("ha_parse_entity_state rejects unavailable/unknown/missing/bad") {
+  std::string s;
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"unavailable\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"unknown\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"attributes\":{}}", s)); // no state key
+  CHECK_FALSE(ha_parse_entity_state("not json", s));
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: FAIL — undefined reference to `ha_parse_entity_state`.
+
+- [ ] **Step 4: Implement in `src/ha_oauth.cpp`** (append; `<ArduinoJson.h>` is already included from the token-parser task):
+
+```cpp
+bool ha_parse_entity_state(const std::string &json, std::string &out) {
+  // Filter so only "state" is materialized — entity `attributes` can be large.
+  StaticJsonDocument<32> filter;
+  filter["state"] = true;
+  StaticJsonDocument<128> doc;
+  if (deserializeJson(doc, json, DeserializationOption::Filter(filter))) {
+    return false;
+  }
+  if (!doc["state"].is<const char *>()) {
+    return false;
+  }
+  std::string s = doc["state"].as<const char *>();
+  if (s.empty() || s == "unknown" || s == "unavailable") {
+    return false;
+  }
+  out = s;
+  return true;
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS (all prior cases + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ha_oauth.h src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): parse entity .state from /api/states response
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Config — enum value + entity-ID fields
+
+**Files:**
+- Modify: `src/app_config.h`, `src/app_config.cpp`
+
+No unit test (config glue); verified by the Task 3 build.
+
+- [ ] **Step 1: Append the enum value in `src/app_config.h`**
+
+Change the `vehicle_data_src` enum to append HA last (preserving existing numeric values):
+
+```cpp
+enum vehicle_data_src {
+  VEHICLE_DATA_SRC_NONE,
+  VEHICLE_DATA_SRC_TESLA,
+  VEHICLE_DATA_SRC_MQTT,
+  VEHICLE_DATA_SRC_HTTP,
+  VEHICLE_DATA_SRC_HOMEASSISTANT
+};
+```
+
+- [ ] **Step 2: Add externs in `src/app_config.h`**
+
+Next to the other Home Assistant externs (`extern String ha_url;` … `extern String ha_client_id;`), add:
+
+```cpp
+extern String ha_vehicle_soc;
+extern String ha_vehicle_range;
+extern String ha_vehicle_eta;
+```
+
+- [ ] **Step 3: Declare the variables in `src/app_config.cpp`**
+
+After the existing Home Assistant variable block (`String ha_client_id;`), add:
+
+```cpp
+String ha_vehicle_soc;
+String ha_vehicle_range;
+String ha_vehicle_eta;
+```
+
+- [ ] **Step 4: Register the ConfigOpt entries in `src/app_config.cpp`**
+
+After the `new ConfigOptDefinition<String>(ha_client_id, "", "ha_client_id", "hac"),` line, add:
+
+```cpp
+  new ConfigOptDefinition<String>(ha_vehicle_soc, "", "ha_vehicle_soc", "hvs"),
+  new ConfigOptDefinition<String>(ha_vehicle_range, "", "ha_vehicle_range", "hvr"),
+  new ConfigOptDefinition<String>(ha_vehicle_eta, "", "ha_vehicle_eta", "hve"),
+```
+
+- [ ] **Step 5: Verify it compiles (built with Task 3)**
+
+These vars are consumed in Task 3; do not commit separately. Mark this task's checkboxes done and proceed to Task 3, which builds and commits both together.
+
+---
+
+## Task 3: Vehicle polling in `HomeAssistantClient`
+
+**Files:**
+- Modify: `src/home_assistant.h`, `src/home_assistant.cpp`
+
+- [ ] **Step 1: Add the poll-interval macro in `src/home_assistant.cpp`**
+
+Near the other `HA_*` macros at the top (after `HA_LOOP_INTERVAL_MS`), add:
+
+```cpp
+#define HA_VEHICLE_POLL_MS        (30 * 1000UL)   // poll HA vehicle entities every 30 s
+```
+
+- [ ] **Step 2: Add includes in `src/home_assistant.cpp`**
+
+With the other includes at the top, add:
+
+```cpp
+#include <math.h>      // lround
+#include "input.h"     // global EvseManager `evse`
+```
+
+(`app_config.h` — which declares `vehicle_data_src` and the `ha_vehicle_*` strings — is already included.)
+
+- [ ] **Step 3: Declare members + methods in `src/home_assistant.h`**
+
+In the `private:` section, after `unsigned long _lastRefreshAttempt;` add:
+
+```cpp
+    unsigned long _lastVehiclePoll;
+```
+
+After the `void storeTokens(const HaTokens &t);` line add:
+
+```cpp
+    void pollVehicle();
+    void pollVehicleField(int field); // 0=soc, 1=range, 2=eta; chains to the next
+```
+
+- [ ] **Step 4: Initialize the member in the constructor**
+
+In `src/home_assistant.cpp`, the constructor initializer list currently ends with `_lastRefreshAttempt(0)`. Change it to also init the new member:
+
+```cpp
+HomeAssistantClient::HomeAssistantClient() :
+  MicroTasks::Task(),
+  _pendingStateTime(0),
+  _refreshInFlight(false),
+  _lastRefreshAttempt(0),
+  _lastVehiclePoll(0)
+{
+}
+```
+
+- [ ] **Step 5: Add the poll gate to `loop()`**
+
+In `src/home_assistant.cpp`, in `loop()`, immediately BEFORE the final `return HA_LOOP_INTERVAL_MS;`, add:
+
+```cpp
+  // Poll HA vehicle entities when HA is the selected vehicle-data source.
+  if (isConnected()
+      && vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT
+      && (_lastVehiclePoll == 0 || (millis() - _lastVehiclePoll) >= HA_VEHICLE_POLL_MS)) {
+    _lastVehiclePoll = millis();
+    if (_lastVehiclePoll == 0) _lastVehiclePoll = 1; // 0 means "never polled"
+    pollVehicle();
+  }
+```
+
+- [ ] **Step 6: Implement `pollVehicle()` / `pollVehicleField()`**
+
+Append to `src/home_assistant.cpp`:
+
+```cpp
+void HomeAssistantClient::pollVehicle() {
+  pollVehicleField(0);
+}
+
+// Fetch one configured vehicle entity, set the matching EVSE value, then chain to
+// the next field. Sequential (one in-flight request at a time) to stay safe on the
+// shared MongooseHttpClient. An empty entity, a failed request, or an
+// unknown/unavailable state simply skips that field (keeps the last good value).
+void HomeAssistantClient::pollVehicleField(int field) {
+  String entity;
+  switch (field) {
+    case 0: entity = ha_vehicle_soc;   break;
+    case 1: entity = ha_vehicle_range; break;
+    case 2: entity = ha_vehicle_eta;   break;
+    default: return; // chain complete
+  }
+
+  if (entity.length() == 0) {
+    pollVehicleField(field + 1); // not configured -> skip to next
+    return;
+  }
+
+  String path = "/api/states/" + entity; // entity IDs are URL-safe (sensor.x_y)
+  int next = field + 1;
+  get(path, [this, field, next](MongooseHttpClientResponse *response) {
+    if (response->respCode() == 200) {
+      MongooseString body = response->body();
+      std::string state;
+      if (ha_parse_entity_state(std::string((const char *)body, body.length()), state)) {
+        double v = atof(state.c_str());
+        switch (field) {
+          case 0: evse.setVehicleStateOfCharge((int)lround(v)); break;
+          case 1: evse.setVehicleRange((int)lround(v));         break;
+          case 2: evse.setVehicleEta((int)v);                   break; // seconds
+        }
+      } else {
+        DBUGF("[ha] vehicle field %d: state unavailable/unparseable", field);
+      }
+    } else {
+      DBUGF("[ha] vehicle field %d: HTTP %d", field, response->respCode());
+    }
+    pollVehicleField(next); // advance regardless of this field's outcome
+  });
+}
+```
+
+- [ ] **Step 7: Build (this also validates Task 2)**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 8: Native tests still pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 9: Commit (Tasks 2 + 3 together)**
+
+```bash
+git add src/app_config.h src/app_config.cpp src/home_assistant.h src/home_assistant.cpp
+git commit -m "feat(ha): poll HA entities for vehicle SoC/range/ETA
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: gui-nightshift — Vehicle settings HA source
+
+**Files (in `gui-nightshift/`, in-tree):**
+- Modify: `src/routes/settings/Vehicle.svelte`
+- Test: `src/routes/settings/__tests__/Vehicle.test.js`
+- Modify: `src/lib/i18n/en.json`, `es.json`, `fr.json`, `hu.json`
+
+Work from `/home/rar/oevse/openevse_esp32_firmware/gui-nightshift`. Commit in that repo.
+
+- [ ] **Step 1: Read the current files**
+
+Read `src/routes/settings/Vehicle.svelte` (note the `srcOptions` array and the `{#if src === 2}` MQTT block — the HA block mirrors it for `src === 4`), `src/routes/settings/__tests__/Vehicle.test.js` (mirror its mock/render setup), and the `config.vehicle` block in `src/lib/i18n/en.json` (note the exact existing keys: `src_none/src_tesla/src_mqtt/src_http`, `topic_soc/topic_range/topic_eta`, `range_unit`).
+
+- [ ] **Step 2: Write the failing test** — add this case to the `describe('Vehicle page', ...)` block in `src/routes/settings/__tests__/Vehicle.test.js` (it mirrors the existing MQTT/HTTP cases exactly — `config_store.set(...)` then assert on the i18n key, since `svelte-i18n` is mocked to return keys):
+
+```js
+  it('reveals HA entity fields when the source is Home Assistant', () => {
+    config_store.set({ vehicle_data_src: 4 })
+    const { getByText, queryByText } = render(Vehicle)
+    expect(getByText('config.vehicle.entity_soc')).toBeInTheDocument()
+    expect(queryByText('config.vehicle.topic_soc')).not.toBeInTheDocument() // not the MQTT block
+  })
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run (in `gui-nightshift/`): `npm test -- Vehicle`
+Expected: FAIL — no element with text `config.vehicle.entity_soc`.
+
+- [ ] **Step 4: Add the HA source option in `Vehicle.svelte`**
+
+In the `srcOptions` `$derived` array, add a 5th entry:
+
+```js
+    { value: '4', label: $_('config.vehicle.src_homeassistant') },
+```
+
+- [ ] **Step 5: Add the HA reveal block in `Vehicle.svelte`**
+
+Immediately AFTER the `{:else if src === 3} … {/if}` HTTP block's content and BEFORE the closing `{/if}`, add a new branch (i.e. change the `{:else if src === 3}` block so the HA branch follows it):
+
+```svelte
+  {:else if src === 4}
+    <ConfigSection title={$_('config.vehicle.src_homeassistant')}>
+      <p class="text-sm text-text-dim">{$_('config.vehicle.ha_info')}</p>
+      <FormField label={$_('config.vehicle.range_unit')} status={$ss.mqtt_vehicle_range_miles ?? 'idle'}>
+        <Select
+          options={unitOptions}
+          value={String(!!$config_store?.mqtt_vehicle_range_miles)}
+          onchange={(v) => form.saveField('mqtt_vehicle_range_miles', v === 'true')}
+        />
+      </FormField>
+      <FormField label={$_('config.vehicle.entity_soc')} status={$ss.ha_vehicle_soc ?? 'idle'}>
+        <TextInput
+          value={$config_store?.ha_vehicle_soc ?? ''}
+          placeholder="sensor.car_battery"
+          revert={form.revert}
+          onchange={(v) => form.saveField('ha_vehicle_soc', v)}
+        />
+      </FormField>
+      <FormField label={$_('config.vehicle.entity_range')} status={$ss.ha_vehicle_range ?? 'idle'}>
+        <TextInput
+          value={$config_store?.ha_vehicle_range ?? ''}
+          placeholder="sensor.car_range"
+          revert={form.revert}
+          onchange={(v) => form.saveField('ha_vehicle_range', v)}
+        />
+      </FormField>
+      <FormField label={$_('config.vehicle.entity_eta')} status={$ss.ha_vehicle_eta ?? 'idle'}>
+        <TextInput
+          value={$config_store?.ha_vehicle_eta ?? ''}
+          placeholder="sensor.car_time_to_full"
+          revert={form.revert}
+          onchange={(v) => form.saveField('ha_vehicle_eta', v)}
+        />
+      </FormField>
+    </ConfigSection>
+  {/if}
+```
+
+(The `mqtt_vehicle_range_miles` range-unit field is reused — it's the EVSE's single range-unit setting, per the spec.)
+
+- [ ] **Step 6: Add i18n strings to ALL four locales**
+
+In the `config.vehicle` object of `src/lib/i18n/en.json`, add:
+
+```json
+      "src_homeassistant": "Home Assistant",
+      "ha_info": "Reads vehicle data from Home Assistant entities. Requires Home Assistant to be connected (Settings → Home Assistant).",
+      "entity_soc": "SoC entity",
+      "entity_range": "Range entity",
+      "entity_eta": "Time-to-full entity",
+```
+
+Add the same keys to `es.json`, `fr.json`, `hu.json` (translate the values; keep the key set identical across all four — there is a locale-parity test). Suggested translations:
+- es: `"src_homeassistant": "Home Assistant"`, `"ha_info": "Lee los datos del vehículo desde entidades de Home Assistant. Requiere que Home Assistant esté conectado (Ajustes → Home Assistant)."`, `"entity_soc": "Entidad de SoC"`, `"entity_range": "Entidad de autonomía"`, `"entity_eta": "Entidad de tiempo de carga"`.
+- fr: `"src_homeassistant": "Home Assistant"`, `"ha_info": "Lit les données du véhicule depuis des entités Home Assistant. Nécessite que Home Assistant soit connecté (Réglages → Home Assistant)."`, `"entity_soc": "Entité de SoC"`, `"entity_range": "Entité d'autonomie"`, `"entity_eta": "Entité de temps de charge"`.
+- hu: `"src_homeassistant": "Home Assistant"`, `"ha_info": "A jármű adatait Home Assistant entitásokból olvassa. Csatlakoztatott Home Assistant szükséges (Beállítások → Home Assistant)."`, `"entity_soc": "SoC entitás"`, `"entity_range": "Hatótáv entitás"`, `"entity_eta": "Töltési idő entitás"`.
+
+- [ ] **Step 7: Run the Vehicle test + full suite**
+
+Run: `npm test -- Vehicle`
+Expected: PASS.
+
+Run: `npm test`
+Expected: PASS (no regressions; locale-parity test green).
+
+- [ ] **Step 8: Build the GUI**
+
+Run: `npm run build`
+Expected: SUCCESS.
+
+- [ ] **Step 9: Commit (in gui-nightshift)**
+
+```bash
+cd gui-nightshift
+git add src/routes/settings/Vehicle.svelte src/routes/settings/__tests__/Vehicle.test.js src/lib/i18n/
+git commit -m "feat(ha): Home Assistant vehicle-data source in Vehicle settings
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+cd ..
+```
+
+---
+
+## Task 5: Full build + hardware validation + publish GUI
+
+**Files:** none (verification + publish)
+
+- [ ] **Step 1: Native tests**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 2: Core-2 regression build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 3: P4 build with GUI bundled**
+
+Run: `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Flash + on-hardware validation (manual)**
+
+Flash the P4 (`GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4 -t upload --upload-port /dev/ttyACM5`), wait for HTTP 200 at the board IP, then with HA connected:
+- Settings → Vehicle → set source = **Home Assistant**; set `ha_vehicle_soc` to a real HA `sensor.*` reporting a battery %.
+- Confirm `GET /status` shows `battery_level` matching the entity, and the value appears on the display.
+- Set range/ETA entities; confirm `battery_range` updates.
+- Point an entity at an `unavailable` sensor; confirm the last good value is retained (no clobber, no crash).
+
+- [ ] **Step 5: Commit any validation fixes; verify the firmware branch is clean**
+
+Commit any fixes found, then confirm `git status` shows only the known deliberately-excluded leftovers.
+
+- [ ] **Step 6: Publish the GUI from the canonical clone**
+
+The firmware build bundles the in-tree `gui-nightshift`; publishing happens from `/home/rar/openevse-gui-nightshift` (SSH remote). Transplant the Task 4 commit and push:
+
+```bash
+S=/home/rar/oevse/openevse_esp32_firmware/gui-nightshift
+T=/home/rar/openevse-gui-nightshift
+git -C "$T" fetch origin && git -C "$T" checkout main && git -C "$T" rebase origin/main
+rm -rf /tmp/ha-veh-patch && mkdir -p /tmp/ha-veh-patch
+git -C "$S" format-patch -1 HEAD -o /tmp/ha-veh-patch          # the Task 4 gui commit
+git -C "$T" am /tmp/ha-veh-patch/*.patch
+git -C "$T" push origin main
+```
+
+If `am` conflicts (e.g. the canonical clone's Vehicle.svelte differs), resolve by re-applying the Task 4 edits onto the canonical clone's Vehicle.svelte, then `git -C "$T" am --continue`. NOTE: pushing from `$T` is allowed (its remote is already SSH); changing the in-tree clone's remote is NOT (classifier-blocked) — always publish from `$T`.
+
+- [ ] **Step 7: Push the firmware branch**
+
+```bash
+git push origin feature/home-assistant-oauth
+```
+
+---
+
+## Notes for the implementer
+
+- **Async chaining:** `pollVehicleField()` re-enters itself from the `get()` `onResponse` lambda (or directly when an entity is unconfigured). `homeAssistant` is a program-lifetime global, so the `[this]` capture is safe (same basis as the existing exchange/refresh callbacks). Only one request is ever in flight.
+- **`get()` gating:** `homeAssistant.get()` already returns early unless `isConnected() && ha_url` set, so the poll is inert when HA isn't connected — the `loop()` gate is belt-and-suspenders.
+- **Range units:** reuse the existing `mqtt_vehicle_range_miles` flag (the EVSE's one range-unit setting); do not add a new units config.
+- **No `main.cpp` change:** unlike Tesla (pumped from `main`), the HA client's own `loop()` drives the poll.
+- **Two gui clones:** build/bundle from in-tree `gui-nightshift`; push from `/home/rar/openevse-gui-nightshift` (see Task 5 Step 6).

--- a/docs/superpowers/plans/2026-06-01-home-assistant-oauth.md
+++ b/docs/superpowers/plans/2026-06-01-home-assistant-oauth.md
@@ -1,0 +1,1518 @@
+# Home Assistant OAuth Connection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global Home Assistant connection to the OpenEVSE firmware that authenticates via HA's OAuth2 browser-redirect flow (ESP32 is its own client_id/redirect_uri), maintains tokens, and surfaces a Connect/Disconnect control on the gui-nightshift settings page.
+
+**Architecture:** Pure, dependency-light OAuth logic (`src/ha_oauth.{h,cpp}`, std::string + ArduinoJson) is unit-tested natively with doctest. Arduino/Mongoose glue (`src/home_assistant.{h,cpp}`) owns token lifecycle + refresh as a MicroTask, calls the pure logic, and does HTTP via `MongooseHttpClient`. Web handlers (`src/web_server_home_assistant.cpp`) drive the browser flow. Tokens persist via the existing `ConfigOptSecret` config system. The UI lives in the separate `gui-nightshift` repo (Svelte + vitest).
+
+**Tech Stack:** C++ (Arduino-ESP32, PlatformIO), ArduinoMongoose (`MongooseHttpClient`/`MongooseHttpServer`), ArduinoJson 6.20.1, doctest (native tests), Svelte + Vite + vitest (gui-nightshift).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-home-assistant-oauth-design.md`
+
+**Branch:** `feature/home-assistant-oauth` (already created; spec already committed there).
+
+**Design refinement vs spec:** HA's `/auth/token` endpoint takes `grant_type`, `code`, `client_id` (and `grant_type`, `refresh_token`, `client_id` for refresh) — **not** `redirect_uri`. So the pending-auth stash holds `{state, client_id}`; `redirect_uri` is only used to build the authorize URL. `client_id` must be identical at authorize and token exchange (both derived from the same request Host).
+
+---
+
+## File Structure
+
+**Firmware (this repo):**
+- Create `src/ha_oauth.h` — pure OAuth helper declarations (std::string).
+- Create `src/ha_oauth.cpp` — pure OAuth helper implementations.
+- Create `test/test_ha_oauth/test_ha_oauth.cpp` — doctest unit tests for the pure helpers.
+- Create `src/home_assistant.h` / `src/home_assistant.cpp` — `HomeAssistantClient` MicroTask (glue: config, HTTP, refresh).
+- Create `src/web_server_home_assistant.cpp` — HTTP handlers for the OAuth flow + status/disconnect.
+- Create `test/homeassistant.http` — REST integration script (manual).
+- Modify `platformio.ini` — add `[env:native]`.
+- Modify `src/app_config.h` / `src/app_config.cpp` — config fields, service flag, dispatch.
+- Modify `src/web_server.cpp` — register routes; declare handlers.
+- Modify `src/main.cpp` — construct/begin/pump the task.
+
+**UI (`gui-nightshift` repo):**
+- Create `src/lib/config/homeassistant.js` — connection-state helper + connect/disconnect actions.
+- Create `src/lib/config/__tests__/homeassistant.test.js` — vitest unit tests.
+- Create `src/routes/settings/HomeAssistant.svelte` — settings page.
+- Create `src/routes/settings/__tests__/HomeAssistant.test.js` — vitest component test.
+- Modify `src/lib/config/pages.js` — register the settings page.
+
+---
+
+## Task 1: Native test harness + first pure helper (`ha_derive_base_url`)
+
+**Files:**
+- Modify: `platformio.ini` (add `[env:native]` at end of file)
+- Create: `src/ha_oauth.h`
+- Create: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Add the native test env to `platformio.ini`**
+
+Append this block to the end of `platformio.ini`:
+
+```ini
+[env:native]
+; Host-side unit tests for the pure Home Assistant OAuth logic (src/ha_oauth.cpp).
+; Run with: pio test -e native
+platform = native
+test_framework = doctest
+test_build_src = true
+build_src_filter = -<*> +<ha_oauth.cpp>
+build_flags = -std=gnu++17
+lib_deps = bblanchon/ArduinoJson@6.20.1
+```
+
+- [ ] **Step 2: Create the header `src/ha_oauth.h`**
+
+```cpp
+#ifndef HA_OAUTH_H
+#define HA_OAUTH_H
+
+#include <string>
+#include <cstdint>
+
+// Parsed token response from HA's /auth/token endpoint.
+struct HaTokens {
+  std::string access_token;
+  std::string refresh_token;
+  long expires_in = 0; // seconds
+};
+
+// Percent-encode a string for use in a URL query value.
+std::string ha_url_encode(const std::string &in);
+
+// Build "<scheme>://<host>" with no trailing slash.
+// host is the raw HTTP Host header value (may include :port).
+std::string ha_derive_base_url(const std::string &scheme, const std::string &host);
+
+// base_url + "/ha_callback"
+std::string ha_build_redirect_uri(const std::string &base_url);
+
+// HA authorize URL:
+//   <ha_url>/auth/authorize?response_type=code&client_id=..&redirect_uri=..&state=..
+std::string ha_build_authorize_url(const std::string &ha_url,
+                                   const std::string &client_id,
+                                   const std::string &redirect_uri,
+                                   const std::string &state);
+
+// x-www-form-urlencoded body for grant_type=authorization_code.
+std::string ha_build_token_exchange_body(const std::string &client_id,
+                                         const std::string &code);
+
+// x-www-form-urlencoded body for grant_type=refresh_token.
+std::string ha_build_refresh_body(const std::string &client_id,
+                                  const std::string &refresh_token);
+
+// Parse the /auth/token JSON response. Returns true on success
+// (access_token and expires_in present); refresh_token may be empty on refresh.
+bool ha_parse_token_response(const std::string &json, HaTokens &out);
+
+// Absolute expiry = now_unix + expires_in (0 if expires_in <= 0).
+uint64_t ha_compute_expiry(uint64_t now_unix, long expires_in);
+
+// True if the token should be refreshed: now_unix >= expiry_unix - margin_sec.
+bool ha_refresh_due(uint64_t expiry_unix, uint64_t now_unix, uint64_t margin_sec);
+
+#endif // HA_OAUTH_H
+```
+
+- [ ] **Step 3: Create `src/ha_oauth.cpp` with only `ha_url_encode` + `ha_derive_base_url` implemented**
+
+```cpp
+#include "ha_oauth.h"
+#include <cctype>
+
+std::string ha_url_encode(const std::string &in) {
+  static const char *hex = "0123456789ABCDEF";
+  std::string out;
+  out.reserve(in.size() * 3);
+  for (unsigned char c : in) {
+    if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+      out += (char)c;
+    } else {
+      out += '%';
+      out += hex[(c >> 4) & 0xF];
+      out += hex[c & 0xF];
+    }
+  }
+  return out;
+}
+
+std::string ha_derive_base_url(const std::string &scheme, const std::string &host) {
+  std::string s = scheme.empty() ? "http" : scheme;
+  std::string h = host;
+  // strip any trailing slash on host (defensive)
+  while (!h.empty() && h.back() == '/') h.pop_back();
+  return s + "://" + h;
+}
+```
+
+- [ ] **Step 4: Write the failing test `test/test_ha_oauth/test_ha_oauth.cpp`**
+
+```cpp
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "ha_oauth.h"
+
+TEST_CASE("ha_url_encode percent-encodes reserved characters") {
+  CHECK(ha_url_encode("abc-123_.~") == "abc-123_.~");
+  CHECK(ha_url_encode("http://h:8123/") == "http%3A%2F%2Fh%3A8123%2F");
+  CHECK(ha_url_encode("a b") == "a%20b");
+}
+
+TEST_CASE("ha_derive_base_url joins scheme and host") {
+  CHECK(ha_derive_base_url("http", "openevse.local") == "http://openevse.local");
+  CHECK(ha_derive_base_url("https", "10.0.0.5:443") == "https://10.0.0.5:443");
+  CHECK(ha_derive_base_url("", "h") == "http://h");          // default scheme
+  CHECK(ha_derive_base_url("http", "h/") == "http://h");     // trailing slash stripped
+}
+```
+
+- [ ] **Step 5: Run the test to verify it builds & passes**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS — `test_ha_oauth.cpp` compiles, both `TEST_CASE`s green. (doctest is fetched automatically by PlatformIO's doctest runner.)
+
+If it fails to find `doctest.h`: confirm `test_framework = doctest` is set; PlatformIO injects the doctest include path for the test build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platformio.ini src/ha_oauth.h src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "test(ha): native doctest harness + ha_url_encode/ha_derive_base_url
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Authorize-URL builders (`ha_build_redirect_uri`, `ha_build_authorize_url`)
+
+**Files:**
+- Modify: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `test/test_ha_oauth/test_ha_oauth.cpp`:
+
+```cpp
+TEST_CASE("ha_build_redirect_uri appends the callback path") {
+  CHECK(ha_build_redirect_uri("http://openevse.local") ==
+        "http://openevse.local/ha_callback");
+}
+
+TEST_CASE("ha_build_authorize_url builds an encoded query") {
+  std::string url = ha_build_authorize_url(
+      "http://homeassistant.local:8123",
+      "http://openevse.local/",
+      "http://openevse.local/ha_callback",
+      "abc123");
+  CHECK(url ==
+        "http://homeassistant.local:8123/auth/authorize"
+        "?response_type=code"
+        "&client_id=http%3A%2F%2Fopenevse.local%2F"
+        "&redirect_uri=http%3A%2F%2Fopenevse.local%2Fha_callback"
+        "&state=abc123");
+}
+
+TEST_CASE("ha_build_authorize_url strips a trailing slash from ha_url") {
+  std::string url = ha_build_authorize_url(
+      "http://ha:8123/", "cid", "ruri", "s");
+  CHECK(url.rfind("http://ha:8123/auth/authorize", 0) == 0);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: FAIL — link error / undefined reference to `ha_build_redirect_uri` and `ha_build_authorize_url`.
+
+- [ ] **Step 3: Implement in `src/ha_oauth.cpp`**
+
+Append:
+
+```cpp
+std::string ha_build_redirect_uri(const std::string &base_url) {
+  return base_url + "/ha_callback";
+}
+
+std::string ha_build_authorize_url(const std::string &ha_url,
+                                   const std::string &client_id,
+                                   const std::string &redirect_uri,
+                                   const std::string &state) {
+  std::string base = ha_url;
+  while (!base.empty() && base.back() == '/') base.pop_back();
+  std::string url = base + "/auth/authorize";
+  url += "?response_type=code";
+  url += "&client_id=" + ha_url_encode(client_id);
+  url += "&redirect_uri=" + ha_url_encode(redirect_uri);
+  url += "&state=" + ha_url_encode(state);
+  return url;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS — all cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): authorize-URL + redirect-URI builders
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Token request body builders
+
+**Files:**
+- Modify: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```cpp
+TEST_CASE("ha_build_token_exchange_body encodes the form body") {
+  CHECK(ha_build_token_exchange_body("http://openevse.local/", "the+code") ==
+        "grant_type=authorization_code"
+        "&code=the%2Bcode"
+        "&client_id=http%3A%2F%2Fopenevse.local%2F");
+}
+
+TEST_CASE("ha_build_refresh_body encodes the form body") {
+  CHECK(ha_build_refresh_body("cid", "rtok") ==
+        "grant_type=refresh_token"
+        "&refresh_token=rtok"
+        "&client_id=cid");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: FAIL — undefined references.
+
+- [ ] **Step 3: Implement**
+
+Append to `src/ha_oauth.cpp`:
+
+```cpp
+std::string ha_build_token_exchange_body(const std::string &client_id,
+                                         const std::string &code) {
+  std::string b = "grant_type=authorization_code";
+  b += "&code=" + ha_url_encode(code);
+  b += "&client_id=" + ha_url_encode(client_id);
+  return b;
+}
+
+std::string ha_build_refresh_body(const std::string &client_id,
+                                  const std::string &refresh_token) {
+  std::string b = "grant_type=refresh_token";
+  b += "&refresh_token=" + ha_url_encode(refresh_token);
+  b += "&client_id=" + ha_url_encode(client_id);
+  return b;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): token-exchange + refresh form-body builders
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Token-response parser (ArduinoJson)
+
+**Files:**
+- Modify: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```cpp
+TEST_CASE("ha_parse_token_response extracts tokens and expiry") {
+  HaTokens t;
+  bool ok = ha_parse_token_response(
+      "{\"access_token\":\"AT\",\"refresh_token\":\"RT\","
+      "\"expires_in\":1800,\"token_type\":\"Bearer\"}", t);
+  CHECK(ok);
+  CHECK(t.access_token == "AT");
+  CHECK(t.refresh_token == "RT");
+  CHECK(t.expires_in == 1800);
+}
+
+TEST_CASE("ha_parse_token_response: refresh response without refresh_token is ok") {
+  HaTokens t;
+  bool ok = ha_parse_token_response(
+      "{\"access_token\":\"AT2\",\"expires_in\":1800}", t);
+  CHECK(ok);
+  CHECK(t.access_token == "AT2");
+  CHECK(t.refresh_token.empty());
+}
+
+TEST_CASE("ha_parse_token_response fails on error / malformed bodies") {
+  HaTokens t;
+  CHECK_FALSE(ha_parse_token_response("{\"error\":\"invalid_grant\"}", t));
+  CHECK_FALSE(ha_parse_token_response("not json", t));
+  CHECK_FALSE(ha_parse_token_response("{\"expires_in\":1800}", t)); // no access_token
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: FAIL — undefined reference to `ha_parse_token_response`.
+
+- [ ] **Step 3: Implement**
+
+Add the include at the top of `src/ha_oauth.cpp` (below the existing includes):
+
+```cpp
+#include <ArduinoJson.h>
+```
+
+Append:
+
+```cpp
+bool ha_parse_token_response(const std::string &json, HaTokens &out) {
+  StaticJsonDocument<512> doc;
+  DeserializationError err = deserializeJson(doc, json);
+  if (err) {
+    return false;
+  }
+  if (!doc["access_token"].is<const char *>()) {
+    return false;
+  }
+  out.access_token = doc["access_token"].as<const char *>();
+  if (doc["refresh_token"].is<const char *>()) {
+    out.refresh_token = doc["refresh_token"].as<const char *>();
+  } else {
+    out.refresh_token.clear();
+  }
+  out.expires_in = doc["expires_in"] | 0L;
+  return true;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): parse /auth/token JSON response
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Expiry / refresh-due helpers
+
+**Files:**
+- Modify: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+- [ ] **Step 1: Add failing tests**
+
+Append:
+
+```cpp
+TEST_CASE("ha_compute_expiry adds expires_in to now") {
+  CHECK(ha_compute_expiry(1000, 1800) == 2800);
+  CHECK(ha_compute_expiry(1000, 0) == 0);    // unknown expiry
+  CHECK(ha_compute_expiry(1000, -5) == 0);
+}
+
+TEST_CASE("ha_refresh_due triggers within the margin") {
+  // expiry at 2800, margin 300 -> refresh due at >= 2500
+  CHECK_FALSE(ha_refresh_due(2800, 2499, 300));
+  CHECK(ha_refresh_due(2800, 2500, 300));
+  CHECK(ha_refresh_due(2800, 3000, 300));    // already expired
+  CHECK(ha_refresh_due(0, 5, 300));          // unknown expiry -> always due
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: FAIL — undefined references.
+
+- [ ] **Step 3: Implement**
+
+Append to `src/ha_oauth.cpp`:
+
+```cpp
+uint64_t ha_compute_expiry(uint64_t now_unix, long expires_in) {
+  if (expires_in <= 0) return 0;
+  return now_unix + (uint64_t)expires_in;
+}
+
+bool ha_refresh_due(uint64_t expiry_unix, uint64_t now_unix, uint64_t margin_sec) {
+  if (expiry_unix == 0) return true; // unknown expiry -> refresh
+  uint64_t threshold = (expiry_unix > margin_sec) ? (expiry_unix - margin_sec) : 0;
+  return now_unix >= threshold;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS — entire `ha_oauth` suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): token expiry + refresh-due calculators
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Config fields + service flag + dispatch
+
+**Files:**
+- Modify: `src/app_config.h` (service-flag defines + accessor)
+- Modify: `src/app_config.cpp` (variable decls, ConfigOpt registrations, dispatch)
+
+No unit test (config is glue with no native harness); verified by the firmware build in Task 7 and the `.http` script in Task 10.
+
+- [ ] **Step 1: Add the service-flag define and accessor in `src/app_config.h`**
+
+After the line `#define CONFIG_SERVICE_CUR_SHAPER   (1 << 19)` add:
+
+```cpp
+#define CONFIG_SERVICE_HOMEASSISTANT (1 << 20)
+```
+
+After the existing `config_current_shaper_enabled()` inline accessor (near the other `config_*_enabled()` helpers), add:
+
+```cpp
+inline bool config_home_assistant_enabled() {
+  return CONFIG_SERVICE_HOMEASSISTANT == (flags & CONFIG_SERVICE_HOMEASSISTANT);
+}
+```
+
+Also add `extern` declarations alongside the other `extern String ...;` config externs in `app_config.h` (find the block that declares `extern String tesla_access_token;` etc.; if Tesla externs are not present there, add these next to the other `extern String` lines):
+
+```cpp
+// Home Assistant settings
+extern String ha_url;
+extern String ha_access_token;
+extern String ha_refresh_token;
+extern uint64_t ha_token_expires;
+extern String ha_client_id;   // the device URL advertised at authorize; replayed on refresh
+```
+
+- [ ] **Step 2: Declare the storage variables in `src/app_config.cpp`**
+
+After the Tesla settings variable block (the lines `String tesla_access_token; ...`), add:
+
+```cpp
+// Home Assistant settings
+String ha_url;
+String ha_access_token;
+String ha_refresh_token;
+uint64_t ha_token_expires;
+String ha_client_id;
+```
+
+- [ ] **Step 3: Register the ConfigOpt entries in `src/app_config.cpp`**
+
+In the config options list (the `ConfigOpt *opts[] = { ... }` array — find it by the existing `new ConfigOptSecret(tesla_access_token, ...)` lines), add after the Tesla block:
+
+```cpp
+// Home Assistant settings
+  new ConfigOptDefinition<String>(ha_url, "", "ha_url", "hau"),
+  new ConfigOptSecret(ha_access_token, "", "ha_access_token", "haa"),
+  new ConfigOptSecret(ha_refresh_token, "", "ha_refresh_token", "har"),
+  new ConfigOptDefinition<uint64_t>(ha_token_expires, 0, "ha_token_expires", "hax"),
+  new ConfigOptDefinition<String>(ha_client_id, "", "ha_client_id", "hac"),
+  new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_HOMEASSISTANT, CONFIG_SERVICE_HOMEASSISTANT, "home_assistant_enabled", "hae"),
+```
+
+- [ ] **Step 4: Add the change-dispatch branch in `src/app_config.cpp`**
+
+Add `#include "home_assistant.h"` near the top with the other includes (e.g. after `#include "tesla_client.h"`).
+
+In `config_changed(String name)` (the function with the `} else if(name.startsWith("tesla_")) {` branch), add before the closing of that if/else chain:
+
+```cpp
+  } else if(name.startsWith("ha_") || name == "home_assistant_enabled") {
+    homeAssistant.notifyConfigChanged();
+```
+
+- [ ] **Step 5: Verify it compiles (build deferred to Task 7)**
+
+`home_assistant.h` / `homeAssistant` do not exist yet — this task does not build on its own. It is completed together with Task 7; do not commit until Task 7's build passes. (Mark this task's checkboxes done, then proceed straight to Task 7.)
+
+---
+
+## Task 7: `HomeAssistantClient` skeleton + config wiring + build
+
+**Files:**
+- Create: `src/home_assistant.h`
+- Create: `src/home_assistant.cpp`
+- Modify: `src/main.cpp`
+
+- [ ] **Step 1: Create `src/home_assistant.h`**
+
+```cpp
+#ifndef HOME_ASSISTANT_H
+#define HOME_ASSISTANT_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <MicroTasks.h>
+#include <MongooseHttpClient.h>
+
+#include "ha_oauth.h"
+
+class HomeAssistantClient : public MicroTasks::Task {
+  public:
+    HomeAssistantClient();
+
+    void begin();
+
+    // True if enabled and we hold a usable (or refreshable) token.
+    bool isConnected();
+
+    // Fill {enabled, connected, ha_url, expires} for the /ha/status endpoint.
+    void getStatus(JsonDocument &doc);
+
+    // Build the HA authorize URL for a browser redirect. `host` is the request
+    // Host header, `secure` whether the request arrived over TLS. Generates and
+    // stashes a fresh CSRF state + the derived client_id. Returns "" if ha_url is
+    // not configured.
+    String beginAuthorize(const String &host, bool secure);
+
+    // Handle the /ha_callback: verify state, exchange the code for tokens.
+    // Returns true if the exchange request was dispatched (async result completes
+    // later). Sets `error` on synchronous validation failure.
+    bool handleCallback(const String &code, const String &state, String &error);
+
+    // Clear tokens + pending auth; cancels refresh.
+    void disconnect();
+
+    // Re-read credentials from config (called from config_changed dispatch).
+    void notifyConfigChanged();
+
+    // Reusable authed GET seam for future consumers. Attaches Bearer header.
+    // (Present in v1; no callers yet.)
+    void get(const String &path, MongooseHttpResponseHandler onResponse);
+
+  protected:
+    void setup();
+    unsigned long loop(MicroTasks::WakeReason reason);
+
+  private:
+    MongooseHttpClient _client;
+
+    // pending auth (single slot)
+    String _pendingState;
+    String _pendingClientId;
+    uint32_t _pendingStateTime; // millis() when issued; 0 = none
+
+    bool _refreshInFlight;
+    unsigned long _lastRefreshAttempt;
+
+    void exchangeCode(const String &code);
+    void refreshTokens();
+    void storeTokens(const HaTokens &t);
+};
+
+extern HomeAssistantClient homeAssistant;
+
+#endif // HOME_ASSISTANT_H
+```
+
+- [ ] **Step 2: Create `src/home_assistant.cpp` (skeleton: lifecycle, status, config, no flow yet)**
+
+```cpp
+#if defined(ENABLE_DEBUG) && !defined(ENABLE_DEBUG_HOME_ASSISTANT)
+#undef ENABLE_DEBUG
+#endif
+
+#include <Arduino.h>
+#include <time.h>
+
+#include "home_assistant.h"
+#include "app_config.h"
+#include "debug.h"
+#include "event.h"
+
+#define HA_PENDING_STATE_TTL_MS   (5 * 60 * 1000UL) // 5 min to complete the browser flow
+#define HA_REFRESH_MARGIN_SEC     300               // refresh 5 min before expiry
+#define HA_REFRESH_RETRY_MS       (60 * 1000UL)     // backoff after a failed refresh
+#define HA_LOOP_INTERVAL_MS       (30 * 1000UL)
+
+HomeAssistantClient homeAssistant;
+
+static uint64_t ha_now_unix() {
+  time_t now = time(nullptr);
+  return (now > 0) ? (uint64_t)now : 0;
+}
+
+HomeAssistantClient::HomeAssistantClient() :
+  MicroTasks::Task(),
+  _pendingStateTime(0),
+  _refreshInFlight(false),
+  _lastRefreshAttempt(0)
+{
+}
+
+void HomeAssistantClient::begin() {
+  MicroTask.startTask(this);
+}
+
+void HomeAssistantClient::setup() {
+}
+
+bool HomeAssistantClient::isConnected() {
+  if (!config_home_assistant_enabled()) return false;
+  if (ha_refresh_token.length() == 0) return false;
+  // Connected if we have an access token that is not past expiry, OR we can refresh.
+  return ha_access_token.length() > 0 || ha_refresh_token.length() > 0;
+}
+
+void HomeAssistantClient::getStatus(JsonDocument &doc) {
+  doc["enabled"] = config_home_assistant_enabled();
+  doc["connected"] = isConnected();
+  doc["ha_url"] = ha_url;
+  doc["expires"] = ha_token_expires;
+}
+
+void HomeAssistantClient::notifyConfigChanged() {
+  // Credentials/url live in the global config vars; nothing to cache.
+  // Wake so loop() re-evaluates refresh scheduling immediately.
+  MicroTask.wakeTask(this);
+}
+
+void HomeAssistantClient::disconnect() {
+  ha_access_token = "";
+  ha_refresh_token = "";
+  ha_token_expires = 0;
+  _pendingStateTime = 0;
+  _pendingState = "";
+  _pendingClientId = "";
+  config_commit(); // persist cleared secrets
+  StaticJsonDocument<128> ev;
+  ev["home_assistant"] = "disconnected";
+  event_send(ev);
+}
+
+unsigned long HomeAssistantClient::loop(MicroTasks::WakeReason reason) {
+  // Expire a stale pending auth.
+  if (_pendingStateTime != 0 &&
+      (millis() - _pendingStateTime) > HA_PENDING_STATE_TTL_MS) {
+    _pendingStateTime = 0;
+    _pendingState = "";
+    _pendingClientId = "";
+  }
+
+  // Refresh scheduling (implemented in Task 9).
+  return HA_LOOP_INTERVAL_MS;
+}
+
+// --- flow methods are implemented in Tasks 8 & 9 ---
+String HomeAssistantClient::beginAuthorize(const String &host, bool secure) {
+  (void)host; (void)secure;
+  return "";
+}
+
+bool HomeAssistantClient::handleCallback(const String &code, const String &state, String &error) {
+  (void)code; (void)state;
+  error = "not implemented";
+  return false;
+}
+
+void HomeAssistantClient::exchangeCode(const String &code) { (void)code; }
+void HomeAssistantClient::refreshTokens() {}
+void HomeAssistantClient::storeTokens(const HaTokens &t) { (void)t; }
+
+void HomeAssistantClient::get(const String &path, MongooseHttpResponseHandler onResponse) {
+  (void)path; (void)onResponse;
+}
+```
+
+Notes for the implementer:
+- `config_commit()` is the existing persist call used elsewhere in the firmware (confirm its exact name in `app_config.h` — search for how other code saves config after mutating a config var, e.g. in `web_server_config.cpp`; use the same call).
+- `event_send(JsonDocument&)` is declared in `event.h`.
+
+- [ ] **Step 3: Wire into `src/main.cpp`**
+
+Add the include near the other integration includes (e.g. after `#include "tesla_client.h"`):
+
+```cpp
+#include "home_assistant.h"
+```
+
+In `setup()`, alongside the other `*.begin()` calls for integration tasks (search for `teslaClient` / `mqtt.begin()` style init), add:
+
+```cpp
+  homeAssistant.begin();
+```
+
+(The MicroTask scheduler pumps `loop()` automatically once started; no per-loop call needed — confirm by checking that other `MicroTasks::Task`-derived integrations are not manually pumped in the main `loop()`.)
+
+- [ ] **Step 4: Build the firmware (this also validates Task 6)**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS. (`nodemcu-32s` is a fast core-2 ESP32 env; it exercises the new files and config without P4 build time.)
+
+- [ ] **Step 5: Run the native tests to confirm no regression**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 6: Commit (includes Task 6's changes)**
+
+```bash
+git add src/app_config.h src/app_config.cpp src/home_assistant.h src/home_assistant.cpp src/main.cpp
+git commit -m "feat(ha): config fields + HomeAssistantClient skeleton wired into setup
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Authorize + callback (code→token exchange)
+
+**Files:**
+- Modify: `src/home_assistant.cpp`
+
+- [ ] **Step 1: Implement `beginAuthorize`**
+
+Replace the stub `beginAuthorize` with:
+
+```cpp
+String HomeAssistantClient::beginAuthorize(const String &host, bool secure) {
+  if (ha_url.length() == 0 || host.length() == 0) {
+    return "";
+  }
+
+  std::string scheme = secure ? "https" : "http";
+  std::string base = ha_derive_base_url(scheme, std::string(host.c_str()));
+  std::string clientId = base + "/";
+  std::string redirectUri = ha_build_redirect_uri(base);
+
+  // 16 hex chars of CSRF state from the HW RNG.
+  char stateBuf[17];
+  for (int i = 0; i < 16; i++) {
+    stateBuf[i] = "0123456789abcdef"[esp_random() & 0xF];
+  }
+  stateBuf[16] = '\0';
+
+  _pendingState = stateBuf;
+  _pendingClientId = clientId.c_str();
+  _pendingStateTime = millis();
+  if (_pendingStateTime == 0) _pendingStateTime = 1; // 0 means "none"
+
+  // Persist the client_id so token refresh can replay it after a reboot
+  // (it is derived from the device Host, which we don't otherwise know later).
+  ha_client_id = clientId.c_str();
+  config_commit();
+
+  std::string url = ha_build_authorize_url(
+      std::string(ha_url.c_str()), clientId, redirectUri, _pendingState.c_str());
+  return String(url.c_str());
+}
+```
+
+Add `#include <esp_random.h>` near the top of `src/home_assistant.cpp` (below `#include <time.h>`).
+
+- [ ] **Step 2: Implement `handleCallback` + `exchangeCode` + `storeTokens`**
+
+Replace the stub `handleCallback`, `exchangeCode`, and `storeTokens` with:
+
+```cpp
+bool HomeAssistantClient::handleCallback(const String &code, const String &state, String &error) {
+  if (_pendingStateTime == 0) {
+    error = "no pending authorization";
+    return false;
+  }
+  if (state.length() == 0 || state != _pendingState) {
+    error = "state mismatch";
+    return false;
+  }
+  if (code.length() == 0) {
+    error = "missing code";
+    return false;
+  }
+  // Consume the pending state (single use); keep _pendingClientId for the exchange.
+  _pendingStateTime = 0;
+  _pendingState = "";
+  exchangeCode(code);
+  return true;
+}
+
+void HomeAssistantClient::storeTokens(const HaTokens &t) {
+  ha_access_token = t.access_token.c_str();
+  if (!t.refresh_token.empty()) {
+    ha_refresh_token = t.refresh_token.c_str();
+  }
+  ha_token_expires = ha_compute_expiry(ha_now_unix(), t.expires_in);
+  config_commit();
+
+  StaticJsonDocument<128> ev;
+  ev["home_assistant"] = "connected";
+  event_send(ev);
+}
+
+void HomeAssistantClient::exchangeCode(const String &code) {
+  if (ha_url.length() == 0 || _pendingClientId.length() == 0) {
+    return;
+  }
+  std::string body = ha_build_token_exchange_body(
+      std::string(_pendingClientId.c_str()), std::string(code.c_str()));
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += "/auth/token";
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_POST);
+  req->addHeader("Content-Type", "application/x-www-form-urlencoded");
+  req->setContent((const uint8_t *)body.c_str(), body.length());
+  req->onResponse([this](MongooseHttpClientResponse *response) {
+    if (response->respCode() == 200) {
+      HaTokens t;
+      std::string json((const char *)response->body(), response->body().length());
+      if (ha_parse_token_response(json, t)) {
+        storeTokens(t);
+        return;
+      }
+    }
+    StaticJsonDocument<128> ev;
+    ev["home_assistant"] = "error";
+    ev["home_assistant_error"] = "token exchange failed";
+    event_send(ev);
+  });
+  _client.send(req);
+}
+```
+
+- [ ] **Step 2b: Confirm `esp_random.h` is acceptable on core-2 builds**
+
+`esp_random()` is available on all ESP32 targets. The include `<esp_random.h>` resolves on core-2 (IDF4) and core-3 (IDF5). No gating needed (unlike the P4-only path in `net_manager.cpp`).
+
+- [ ] **Step 3: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Native tests still pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS (no pure-logic changes, but confirms nothing broke the shared header).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/home_assistant.cpp
+git commit -m "feat(ha): authorize-URL generation + callback code->token exchange
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Refresh scheduling + Bearer `get()` seam
+
+**Files:**
+- Modify: `src/home_assistant.cpp`
+
+(The persisted `ha_client_id` config field this task relies on was added in Task 6 and is set in Task 8.)
+
+The persisted `ha_client_id` field (added in Task 6, set in Task 8's `beginAuthorize`) supplies the `client_id` for refresh, which must match the one used at authorize and survives reboots.
+
+- [ ] **Step 1: Implement `refreshTokens`**
+
+Replace the stub `refreshTokens` with:
+
+```cpp
+void HomeAssistantClient::refreshTokens() {
+  if (_refreshInFlight) return;
+  if (ha_url.length() == 0 || ha_refresh_token.length() == 0) return;
+  if (ha_client_id.length() == 0) return; // never authorized
+
+  _refreshInFlight = true;
+  _lastRefreshAttempt = millis();
+
+  std::string clientId = std::string(ha_client_id.c_str());
+  std::string body = ha_build_refresh_body(clientId, std::string(ha_refresh_token.c_str()));
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += "/auth/token";
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_POST);
+  req->addHeader("Content-Type", "application/x-www-form-urlencoded");
+  req->setContent((const uint8_t *)body.c_str(), body.length());
+  req->onResponse([this](MongooseHttpClientResponse *response) {
+    _refreshInFlight = false;
+    if (response->respCode() == 200) {
+      HaTokens t;
+      std::string json((const char *)response->body(), response->body().length());
+      if (ha_parse_token_response(json, t)) {
+        storeTokens(t);
+        return;
+      }
+    }
+    if (response->respCode() == 400) {
+      // invalid_grant: refresh token revoked -> disconnect.
+      disconnect();
+    }
+    // transient errors: leave tokens; loop() retries after backoff.
+  });
+  _client.send(req);
+}
+```
+
+- [ ] **Step 1b: Drive refresh from `loop()`**
+
+In `loop()`, replace the comment `// Refresh scheduling (implemented in Task 9).` with:
+
+```cpp
+  if (config_home_assistant_enabled() && ha_refresh_token.length() > 0 && !_refreshInFlight) {
+    bool due = ha_refresh_due(ha_token_expires, ha_now_unix(), HA_REFRESH_MARGIN_SEC);
+    bool backoffElapsed = (millis() - _lastRefreshAttempt) > HA_REFRESH_RETRY_MS;
+    if (due && (_lastRefreshAttempt == 0 || backoffElapsed)) {
+      refreshTokens();
+    }
+  }
+```
+
+- [ ] **Step 2: Implement the `get()` seam**
+
+Replace the stub `get` with:
+
+```cpp
+void HomeAssistantClient::get(const String &path, MongooseHttpResponseHandler onResponse) {
+  if (!isConnected() || ha_url.length() == 0) return;
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += path; // caller passes a leading-slash path, e.g. "/api/states/sensor.x"
+
+  String bearer = "Bearer ";
+  bearer += ha_access_token;
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_GET);
+  req->addHeader("Authorization", bearer.c_str());
+  req->addHeader("Content-Type", "application/json");
+  req->onResponse(onResponse);
+  _client.send(req);
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Native tests pass**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/home_assistant.cpp
+git commit -m "feat(ha): token refresh scheduling + Bearer get() seam
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Web endpoints + route registration + .http script
+
+**Files:**
+- Create: `src/web_server_home_assistant.cpp`
+- Modify: `src/web_server.cpp` (declare handlers + register routes)
+- Create: `test/homeassistant.http`
+
+- [ ] **Step 1: Create `src/web_server_home_assistant.cpp`**
+
+```cpp
+#include "emonesp.h"
+#include "web_server.h"
+#include "app_config.h"
+#include "home_assistant.h"
+#include "debug.h"
+
+#include <ArduinoJson.h>
+#include <MongooseHttpServer.h>
+
+// GET /ha/auth/start  -> 302 to HA authorize URL
+void handleHomeAssistantAuthStart(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, JSON_CONTENT_TYPE)) {
+    return;
+  }
+
+  String host = request->host().toString();
+  bool secure = request->isSecure(); // confirm exact accessor in MongooseHttpServerRequest
+  String url = homeAssistant.beginAuthorize(host, secure);
+
+  if (url.length() == 0) {
+    response->setCode(400);
+    response->print("{\"msg\":\"ha_url not configured\"}");
+    request->send(response);
+    return;
+  }
+
+  // Redirect the browser to Home Assistant's login/authorize page.
+  request->redirect(url);
+  // requestPreProcess allocated `response`; if redirect() consumes the request,
+  // free the unused stream per the pattern used by other redirecting handlers.
+  delete response;
+}
+
+// GET /ha_callback?code=..&state=..  -> exchange, then redirect to settings
+void handleHomeAssistantCallback(MongooseHttpServerRequest *request)
+{
+  // NOTE: no requestPreProcess/basic-auth here — HA's browser redirect cannot
+  // carry HTTP auth. Protected by the unguessable single-use `state`.
+  String code = request->getParam("code");
+  String state = request->getParam("state");
+
+  String error;
+  bool ok = homeAssistant.handleCallback(code, state, error);
+
+  // Redirect back into the UI with a result flag for the toast.
+  String dest = "/#/settings/home-assistant?ha=";
+  dest += ok ? "connected" : "error";
+  request->redirect(dest);
+}
+
+// GET /ha/status -> {enabled, connected, ha_url, expires}
+void handleHomeAssistantStatus(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, JSON_CONTENT_TYPE)) {
+    return;
+  }
+  const size_t capacity = JSON_OBJECT_SIZE(4) + 256;
+  DynamicJsonDocument doc(capacity);
+  homeAssistant.getStatus(doc);
+  serializeJson(doc, *response);
+  request->send(response);
+}
+
+// POST /ha/disconnect -> clear tokens
+void handleHomeAssistantDisconnect(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, JSON_CONTENT_TYPE)) {
+    return;
+  }
+  homeAssistant.disconnect();
+  response->print("{\"msg\":\"done\"}");
+  request->send(response);
+}
+```
+
+Implementer notes (verify against `MongooseHttpServer.h`, which is already open in this plan's research):
+- `request->host()` returns a `MongooseString`; `.toString()` or constructing `String(request->host().c_str())` — match how other handlers convert. (`MongooseString` has `c_str()`.)
+- `request->isSecure()` — confirm the exact accessor name for "did this arrive on the TLS server". If absent, derive `secure` by checking which `MongooseHttpServer` instance served it, or default `false` (LAN http is the common case) and revisit. Do NOT block the task on TLS detection; `false` is a safe default for v1.
+- `requestPreProcess`, `JSON_CONTENT_TYPE`, and the redirect/`delete response` idiom: copy exactly from an existing handler that redirects (e.g. `handleAPOff` or the update handlers in `web_server.cpp`). Match the established freeing pattern rather than guessing.
+
+- [ ] **Step 2: Declare handlers + register routes in `src/web_server.cpp`**
+
+Near the other `void handleX(MongooseHttpServerRequest *request);` forward declarations (around line 73), add:
+
+```cpp
+void handleHomeAssistantAuthStart(MongooseHttpServerRequest *request);
+void handleHomeAssistantCallback(MongooseHttpServerRequest *request);
+void handleHomeAssistantStatus(MongooseHttpServerRequest *request);
+void handleHomeAssistantDisconnect(MongooseHttpServerRequest *request);
+```
+
+In `web_server_setup()` near the other `server.on(...)` calls (around line 1203), add:
+
+```cpp
+  server.on("/ha/auth/start$", handleHomeAssistantAuthStart);
+  server.on("/ha_callback", handleHomeAssistantCallback);
+  server.on("/ha/status$", handleHomeAssistantStatus);
+  server.on("/ha/disconnect$", handleHomeAssistantDisconnect);
+```
+
+(Note: `/ha_callback` has no `$` anchor so it matches with the query string, consistent with how `/schedule`, `/claims` are registered without anchors.)
+
+- [ ] **Step 3: Create `test/homeassistant.http` integration script**
+
+```http
+# Home Assistant OAuth endpoints (manual integration test).
+# Replace HOST + auth as in the other .http scripts in this dir.
+@host = 10.75.1.143
+@auth = Basic <base64 user:pass>
+
+### status (expect {enabled, connected, ha_url, expires})
+GET http://{{host}}/ha/status
+Authorization: {{auth}}
+
+### start auth (expect 302 Location: <ha_url>/auth/authorize?...)
+# Use a browser for the real flow; curl -i shows the redirect.
+GET http://{{host}}/ha/auth/start
+Authorization: {{auth}}
+
+### disconnect (expect {"msg":"done"})
+POST http://{{host}}/ha/disconnect
+Authorization: {{auth}}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/web_server_home_assistant.cpp src/web_server.cpp test/homeassistant.http
+git commit -m "feat(ha): web endpoints for OAuth start/callback/status/disconnect
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: gui-nightshift — connection helper + unit tests
+
+**Files (in `gui-nightshift/`):**
+- Create: `src/lib/config/homeassistant.js`
+- Test: `src/lib/config/__tests__/homeassistant.test.js`
+
+Work in the `gui-nightshift` submodule directory. Commit there separately.
+
+- [ ] **Step 1: Write the failing test `src/lib/config/__tests__/homeassistant.test.js`**
+
+```js
+// src/lib/config/__tests__/homeassistant.test.js
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isHaConnected, startHaAuth } from '../homeassistant.js'
+
+describe('isHaConnected', () => {
+  it('is true only when status reports connected', () => {
+    expect(isHaConnected({ enabled: true, connected: true })).toBe(true)
+    expect(isHaConnected({ enabled: true, connected: false })).toBe(false)
+    expect(isHaConnected({})).toBe(false)
+    expect(isHaConnected(undefined)).toBe(false)
+  })
+})
+
+describe('startHaAuth', () => {
+  beforeEach(() => {
+    // jsdom: make location assignable
+    delete window.location
+    window.location = { href: '' }
+  })
+  it('navigates the browser to the firmware start endpoint', () => {
+    startHaAuth()
+    expect(window.location.href).toContain('/ha/auth/start')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run (in `gui-nightshift/`): `npm test -- homeassistant`
+Expected: FAIL — cannot resolve `../homeassistant.js`.
+
+- [ ] **Step 3: Implement `src/lib/config/homeassistant.js`**
+
+```js
+// src/lib/config/homeassistant.js
+// Home Assistant connection helpers.
+import { httpAPI } from '../api/httpAPI.js'
+
+export function isHaConnected(status) {
+  return !!(status && status.connected)
+}
+
+// Full browser navigation so HA's login page + redirect chain run in the
+// real browser (not via fetch). In dev, httpAPI prefixes /api; for a top-level
+// navigation we hit the firmware path directly.
+export function startHaAuth() {
+  const base = import.meta.env.DEV ? '/api' : ''
+  window.location.href = base + '/ha/auth/start'
+}
+
+export async function fetchHaStatus() {
+  const res = await httpAPI('GET', '/ha/status')
+  return res && res !== 'error' ? res : null
+}
+
+export async function disconnectHa() {
+  const res = await httpAPI('POST', '/ha/disconnect')
+  return res && (res.msg === 'done')
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npm test -- homeassistant`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (in gui-nightshift)**
+
+```bash
+cd gui-nightshift
+git add src/lib/config/homeassistant.js src/lib/config/__tests__/homeassistant.test.js
+git commit -m "feat(ha): connection helpers (status/connect/disconnect) + tests
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+cd ..
+```
+
+---
+
+## Task 12: gui-nightshift — settings page + registration
+
+**Files (in `gui-nightshift/`):**
+- Create: `src/routes/settings/HomeAssistant.svelte`
+- Test: `src/routes/settings/__tests__/HomeAssistant.test.js`
+- Modify: `src/lib/config/pages.js`
+
+- [ ] **Step 1: Inspect `src/lib/config/pages.js` and `src/routes/settings/Mqtt.svelte`**
+
+Read both to copy the exact registration shape (route, icon, labelKey, section, component mapping) and the settings-page scaffold (Card, FormField, save-on-change). The HomeAssistant page mirrors `Mqtt.svelte`.
+
+- [ ] **Step 2: Write the failing component test `src/routes/settings/__tests__/HomeAssistant.test.js`**
+
+```js
+// src/routes/settings/__tests__/HomeAssistant.test.js
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+import HomeAssistant from '../HomeAssistant.svelte'
+
+// Mock the connection helpers so the component renders without a backend.
+vi.mock('../../lib/config/homeassistant.js', () => ({
+  isHaConnected: (s) => !!(s && s.connected),
+  startHaAuth: vi.fn(),
+  fetchHaStatus: vi.fn().mockResolvedValue({ enabled: true, connected: false, ha_url: '' }),
+  disconnectHa: vi.fn().mockResolvedValue(true),
+}))
+
+describe('HomeAssistant settings page', () => {
+  it('renders a URL field and a Connect control', async () => {
+    render(HomeAssistant)
+    expect(await screen.findByLabelText(/home assistant url/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /connect/i })).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `npm test -- HomeAssistant`
+Expected: FAIL — cannot resolve `../HomeAssistant.svelte`.
+
+- [ ] **Step 4: Implement `src/routes/settings/HomeAssistant.svelte`**
+
+Use the existing settings-page conventions (Card, the config_store, FormField/PasswordInput components, `svelte-i18n`). Concrete starting implementation:
+
+```svelte
+<!-- src/routes/settings/HomeAssistant.svelte -->
+<script>
+  import { _ } from 'svelte-i18n'
+  import { onMount } from 'svelte'
+  import Card from '../../lib/components/ui/Card.svelte'
+  import { config_store } from '../../lib/stores/config.js'
+  import {
+    isHaConnected, startHaAuth, fetchHaStatus, disconnectHa,
+  } from '../../lib/config/homeassistant.js'
+
+  let url = ''
+  let status = null
+  let saving = false
+
+  $: connected = isHaConnected(status)
+
+  onMount(async () => {
+    const cfg = $config_store
+    url = (cfg && cfg.ha_url) || ''
+    status = await fetchHaStatus()
+  })
+
+  async function saveUrl() {
+    saving = true
+    await config_store.saveParam('ha_url', url)
+    saving = false
+    status = await fetchHaStatus()
+  }
+
+  async function onConnect() {
+    await saveUrl()      // ensure the URL is persisted before redirecting
+    startHaAuth()
+  }
+
+  async function onDisconnect() {
+    await disconnectHa()
+    status = await fetchHaStatus()
+  }
+</script>
+
+<section class="p-4">
+  <h1 class="mb-4 text-lg font-semibold text-text">{$_('config.homeassistant.title')}</h1>
+  <Card class="mb-4 p-4 space-y-4">
+    <label class="block">
+      <span class="text-sm text-text-dim">{$_('config.homeassistant.url')}</span>
+      <input
+        class="mt-1 w-full rounded border border-border bg-surface p-2 text-text"
+        type="url"
+        aria-label={$_('config.homeassistant.url')}
+        bind:value={url}
+        placeholder="http://homeassistant.local:8123"
+        on:change={saveUrl}
+      />
+    </label>
+
+    <div class="flex items-center gap-3">
+      <span class="text-sm">
+        {connected ? $_('config.homeassistant.connected') : $_('config.homeassistant.disconnected')}
+      </span>
+      {#if connected}
+        <button class="rounded bg-surface px-3 py-1 text-sm" on:click={onDisconnect}>
+          {$_('config.homeassistant.disconnect')}
+        </button>
+      {:else}
+        <button
+          class="rounded bg-accent px-3 py-1 text-sm text-black disabled:opacity-50"
+          disabled={!url || saving}
+          on:click={onConnect}
+        >
+          {$_('config.homeassistant.connect')}
+        </button>
+      {/if}
+    </div>
+  </Card>
+</section>
+```
+
+Add the i18n strings to the locale file(s) the app uses (find where `config.sections.*` keys live — likely `src/lib/i18n/en.json` or similar; add a `config.homeassistant` block: `title`, `url`, `connect`, `disconnect`, `connected`, `disconnected`). Match the existing locale file structure exactly.
+
+- [ ] **Step 5: Register the page in `src/lib/config/pages.js`**
+
+Add an entry to the settings pages list following the existing shape (copy a sibling entry such as the MQTT one and adjust):
+
+```js
+// within the pages array, in the appropriate section group:
+{
+  route: 'settings/home-assistant',
+  component: HomeAssistant,            // import at top of pages.js
+  icon: 'mdi:home-assistant',
+  labelKey: 'config.homeassistant.title',
+  section: 'integrations',             // use whatever section MQTT/Tesla use
+},
+```
+
+Add the matching import at the top of `pages.js`:
+
+```js
+import HomeAssistant from '../../routes/settings/HomeAssistant.svelte'
+```
+
+(Confirm the exact path-depth and the section key by copying the sibling MQTT/Tesla registration.)
+
+- [ ] **Step 6: Run the component test + full suite**
+
+Run: `npm test -- HomeAssistant`
+Expected: PASS.
+
+Run: `npm test`
+Expected: PASS — no existing tests regressed.
+
+- [ ] **Step 7: Build the GUI to confirm it compiles**
+
+Run: `npm run build`
+Expected: SUCCESS.
+
+- [ ] **Step 8: Commit (in gui-nightshift)**
+
+```bash
+cd gui-nightshift
+git add src/routes/settings/HomeAssistant.svelte \
+        src/routes/settings/__tests__/HomeAssistant.test.js \
+        src/lib/config/pages.js src/lib/i18n/
+git commit -m "feat(ha): Home Assistant settings page + nav registration
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+cd ..
+```
+
+---
+
+## Task 13: Full build + hardware validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the P4 firmware (core-3) with the GUI bundled**
+
+Run: `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4`
+Expected: SUCCESS. (Confirm the exact `GUI_NAME` mechanism from `docs`/memory `p4-ota-and-custom-gui-build`; bundle the freshly built `gui-nightshift/dist`.)
+
+- [ ] **Step 2: Build a core-2 env as a regression check**
+
+Run: `pio run -e nodemcu-32s`
+Expected: SUCCESS.
+
+- [ ] **Step 3: Native tests green**
+
+Run: `pio test -e native -f test_ha_oauth`
+Expected: PASS.
+
+- [ ] **Step 4: Flash + on-hardware click-through (manual)**
+
+Flash the P4 (`--upload-port /dev/ttyACM5`), then verify against a real HA instance via the UI / `/ha/status` (serial console is not readable from the build host):
+- Set HA URL on the settings page; click **Connect**; complete HA login in the browser; confirm redirect back to the settings page shows **Connected** and `GET /ha/status` returns `connected:true`.
+- Reboot the EVSE; confirm `/ha/status` still `connected:true` (refresh-token persistence).
+- Click **Disconnect**; confirm `/ha/status` `connected:false` and the `ha_*` secrets are cleared in `/config`.
+- In HA, revoke the token (Profile → Security); wait for the next refresh cycle; confirm `/ha/status` flips to `connected:false`.
+
+- [ ] **Step 5: Commit any fixes found during validation, then push the branch**
+
+```bash
+git push -u origin feature/home-assistant-oauth
+# In gui-nightshift, push its branch too if the submodule tracks one.
+```
+
+---
+
+## Notes for the implementer
+
+- **Async HTTP:** `MongooseHttpClient` callbacks (`onResponse`) fire later on the Mongoose poll loop; never block waiting for them. State transitions happen inside the callback (see `storeTokens`).
+- **`config_commit()` name:** verify the exact persist function by grepping how `web_server_config.cpp` saves after a POST `/config`; use that call everywhere this plan writes `config_commit()`.
+- **`requestPreProcess` + redirect freeing:** copy the exact idiom from an existing redirecting handler in `web_server.cpp`; the `delete response` line in Task 10 is a placeholder for "follow the existing pattern."
+- **`request->isSecure()`:** if no such accessor exists, default `secure=false` for v1 (LAN http). The device scheme only affects the `client_id`/`redirect_uri` it advertises; revisit when the EVSE is served over TLS.
+- **No PKCE:** HA's auth flow is used without PKCE here. If a future HA version requires it, add `code_challenge` (S256) at authorize and `code_verifier` at exchange in `ha_oauth` (unit-testable) — out of scope for v1.

--- a/docs/superpowers/plans/2026-06-03-ha-data-sources-phase1-display.md
+++ b/docs/superpowers/plans/2026-06-03-ha-data-sources-phase1-display.md
@@ -1,0 +1,623 @@
+# HA Data Sources — Phase 1 (Display-Only) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Poll two home-battery entities and two vehicle-extra entities from Home Assistant and surface them as display-only `/status` fields, by generalizing the existing vehicle poll chain into a reusable poll table.
+
+**Architecture:** Replace the hardcoded `switch(field)` in `HomeAssistantClient::pollVehicleField` with a static poll table (`{entity, gate, type, sinkId}`) that the existing single-in-flight chain iterates. Value coercion is centralized by type (numeric / bool / string); numeric vehicle values keep flowing through `evse.setVehicle*()` unchanged, while the four new display-only values are held in the client and merged into `/status` via a new `addStatusFields()`. The new fields are **omitted when absent** (never emitted as `0`).
+
+**Tech Stack:** C++ (Arduino-ESP32 core 2.x and ESP-IDF 5.x core 3.x), MicroTasks cooperative tasks, ArduinoJson 6, ArduinoMongoose HTTP client, doctest native unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-ha-data-sources-firmware-design.md`
+
+**Working directory / branch:** `/home/rar/oevse/openevse_esp32_firmware`, branch `feature/ha-data-sources` (already created; the design doc is committed there as `934d807`).
+
+**Scope of THIS plan (Phase 1 — display-only):** home-battery SoC/power + vehicle plugged/charging-state. The poll-table refactor lands here. Phase 2 (solar/grid/shaper control-path + MQTT arbitration + `divert_data_src`/`shaper_data_src`) is a separate plan.
+
+**Key conventions to respect:**
+- Pure, host-testable helpers live in `src/ha_oauth.cpp` — the `[env:native]` test build compiles **only** that file (`build_src_filter = -<*> +<ha_oauth.cpp>`), so anything tested by `pio test -e native` must be declared in `src/ha_oauth.h` and defined in `src/ha_oauth.cpp`.
+- Config keys starting with `ha_` already auto-dispatch to `homeAssistant.notifyConfigChanged()` (`src/app_config.cpp:440`) — Phase 1 adds only `ha_*` keys, so no dispatch change is needed.
+- `ha_parse_entity_state()` already rejects `""` / `unavailable` / `unknown` / non-string / bad-JSON (verified in `test/test_ha_oauth/test_ha_oauth.cpp`).
+- Display-only fields are emitted into `/status` **only when a valid reading exists** — `0`/`false` are legitimate values, so use an explicit per-field "valid" flag (the same lesson as the energy-logger SoC `-1` sentinel), not a magic number.
+- NVS short keys must be unique. Phase 1 uses `hbs`, `hbp`, `hvp`, `hcs` (all verified free).
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/ha_oauth.h` / `src/ha_oauth.cpp` | New pure helper `ha_parse_bool()` | 1 |
+| `test/test_ha_oauth/test_ha_oauth.cpp` | Native tests for `ha_parse_bool` | 1 |
+| `src/app_config.h` / `src/app_config.cpp` | 4 new `ha_*` String config keys | 2 |
+| `src/home_assistant.h` / `src/home_assistant.cpp` | Poll-table refactor (Task 3); display-only members, new sinks, table rows, clear-on-disconnect (Task 4) | 3, 4 |
+| `src/web_server.cpp` | `homeAssistant.addStatusFields(doc)` in `buildStatus()` | 5 |
+
+---
+
+## Task 1: `ha_parse_bool` pure helper + native tests
+
+**Files:**
+- Modify: `src/ha_oauth.h`
+- Modify: `src/ha_oauth.cpp`
+- Test: `test/test_ha_oauth/test_ha_oauth.cpp`
+
+Maps a Home Assistant entity *state string* (already extracted and validated by `ha_parse_entity_state`) to a bool. Recognized truthy/falsey tokens set `out` and return `true`; anything unrecognized returns `false` (caller skips, keeping last good).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test/test_ha_oauth/test_ha_oauth.cpp`:
+```cpp
+TEST_CASE("ha_parse_bool recognizes truthy and falsey states") {
+  bool b = false;
+  CHECK(ha_parse_bool("on", b));        CHECK(b == true);
+  CHECK(ha_parse_bool("ON", b));        CHECK(b == true);
+  CHECK(ha_parse_bool("true", b));      CHECK(b == true);
+  CHECK(ha_parse_bool("1", b));         CHECK(b == true);
+  CHECK(ha_parse_bool("home", b));      CHECK(b == true);
+  CHECK(ha_parse_bool("off", b));       CHECK(b == false);
+  CHECK(ha_parse_bool("OFF", b));       CHECK(b == false);
+  CHECK(ha_parse_bool("false", b));     CHECK(b == false);
+  CHECK(ha_parse_bool("0", b));         CHECK(b == false);
+  CHECK(ha_parse_bool("not_home", b));  CHECK(b == false);
+  CHECK(ha_parse_bool("unplugged", b)); CHECK(b == false);
+}
+
+TEST_CASE("ha_parse_bool rejects unrecognized states") {
+  bool b = true;
+  CHECK_FALSE(ha_parse_bool("charging", b));
+  CHECK_FALSE(ha_parse_bool("", b));
+  CHECK_FALSE(ha_parse_bool("42.5", b));
+  CHECK_FALSE(ha_parse_bool("maybe", b));
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pio test -e native`
+Expected: FAIL to compile — `ha_parse_bool` is not declared.
+
+- [ ] **Step 3: Declare the helper**
+
+In `src/ha_oauth.h`, after the `ha_parse_entity_state` declaration (line ~47), add:
+```cpp
+// Map a Home Assistant state string (e.g. a binary_sensor's "on"/"off") to a bool.
+// Recognized: on/true/1/home/open/yes -> true; off/false/0/not_home/closed/no/unplugged
+// -> false (case-insensitive). Returns false (and leaves `out` untouched) for any
+// other state, so callers skip it and keep the last good value.
+bool ha_parse_bool(const std::string &state, bool &out);
+```
+
+- [ ] **Step 4: Implement the helper**
+
+In `src/ha_oauth.cpp`, append:
+```cpp
+bool ha_parse_bool(const std::string &state, bool &out) {
+  std::string s;
+  s.reserve(state.size());
+  for (char c : state) s += (char)tolower((unsigned char)c);
+
+  if (s == "on" || s == "true" || s == "1" || s == "home" ||
+      s == "open" || s == "yes" || s == "plugged" || s == "connected") {
+    out = true;
+    return true;
+  }
+  if (s == "off" || s == "false" || s == "0" || s == "not_home" ||
+      s == "closed" || s == "no" || s == "unplugged" || s == "disconnected") {
+    out = false;
+    return true;
+  }
+  return false;
+}
+```
+Ensure `#include <cctype>` is present near the top of `src/ha_oauth.cpp` (for `tolower`); add it if missing.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `pio test -e native`
+Expected: PASS — all `ha_parse_bool` cases plus every existing `test_ha_oauth` case.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/ha_oauth.h src/ha_oauth.cpp test/test_ha_oauth/test_ha_oauth.cpp
+git commit -m "feat(ha): ha_parse_bool helper for binary entity states
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Phase-1 config fields (4 `ha_*` entity strings)
+
+**Files:**
+- Modify: `src/app_config.h` (declarations, after `ha_vehicle_charge_limit` ~line 86)
+- Modify: `src/app_config.cpp` (definitions ~line 142; `ConfigOptDefinition` registrations ~line 272)
+
+No unit test — config plumbing is verified by a successful firmware build (Task 6). Dispatch is automatic because all four keys start with `ha_`.
+
+- [ ] **Step 1: Declare the four new globals**
+
+In `src/app_config.h`, immediately after `extern String ha_vehicle_charge_limit;` (line ~86), add:
+```cpp
+extern String ha_battery_soc;
+extern String ha_battery_power;
+extern String ha_vehicle_plugged;
+extern String ha_vehicle_charging_state;
+```
+
+- [ ] **Step 2: Define the four globals**
+
+In `src/app_config.cpp`, immediately after `String ha_vehicle_charge_limit;` (line ~142), add:
+```cpp
+String ha_battery_soc;
+String ha_battery_power;
+String ha_vehicle_plugged;
+String ha_vehicle_charging_state;
+```
+
+- [ ] **Step 3: Register the four config options**
+
+In `src/app_config.cpp`, immediately after the `ha_vehicle_charge_limit` registration line (`new ConfigOptDefinition<String>(ha_vehicle_charge_limit, "", "ha_vehicle_charge_limit", "hvc"),` ~line 272), add:
+```cpp
+  new ConfigOptDefinition<String>(ha_battery_soc, "", "ha_battery_soc", "hbs"),
+  new ConfigOptDefinition<String>(ha_battery_power, "", "ha_battery_power", "hbp"),
+  new ConfigOptDefinition<String>(ha_vehicle_plugged, "", "ha_vehicle_plugged", "hvp"),
+  new ConfigOptDefinition<String>(ha_vehicle_charging_state, "", "ha_vehicle_charging_state", "hcs"),
+```
+
+- [ ] **Step 4: Verify it compiles (native config sanity)**
+
+Run: `pio test -e native`
+Expected: PASS — `app_config.cpp` isn't in the native build, but this confirms Task 1 still green and nothing in `ha_oauth` broke. (Full firmware compile of `app_config.cpp` happens in Task 6; if you want an early check, `pio run -e openevse_wifi_v1` also works here.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/app_config.h src/app_config.cpp
+git commit -m "feat(ha): config keys for home-battery + vehicle-extra entities
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Refactor the vehicle chain into a generic poll table (no behavior change)
+
+**Files:**
+- Modify: `src/home_assistant.h` (private section + add `pollNext`, remove `pollVehicleField`)
+- Modify: `src/home_assistant.cpp` (`loop()` gating ~114-122; replace `pollVehicle`/`pollVehicleField` ~302-362)
+
+This task is a pure structural refactor: it reproduces today's behavior (poll the 4 vehicle numeric entities when `vehicle_data_src == HOMEASSISTANT`) through a table-driven chain. No new feeds yet. Correctness is verified by build (Task 6) plus the reasoning that the table's vehicle rows map 1:1 to the old `switch`.
+
+- [ ] **Step 1: Add the poll-table types and declarations to the header**
+
+In `src/home_assistant.h`, inside `class HomeAssistantClient`, in the `private:` section, replace:
+```cpp
+    unsigned long _lastVehiclePoll;
+    bool _vehicleInFlight;
+    unsigned long _vehiclePollStart;
+
+    void exchangeCode(const String &code);
+    void refreshTokens();
+    void storeTokens(const HaTokens &t);
+    void pollVehicle();
+    void pollVehicleField(int field); // 0=soc, 1=range, 2=eta; chains to the next
+```
+with:
+```cpp
+    unsigned long _lastPoll;
+    bool _pollInFlight;
+    unsigned long _pollStart;
+
+    void exchangeCode(const String &code);
+    void refreshTokens();
+    void storeTokens(const HaTokens &t);
+
+    bool anyPollActive();          // true if at least one table row is active+configured
+    void pollNext(int index);      // walk the poll table from `index`
+    void applyEntity(int sinkId, int type, const String &state);
+```
+Also rename the constructor-initialised members in `src/home_assistant.cpp` (Step 3) to match.
+
+- [ ] **Step 2: Add the value-type and sink enums + the table (top of `home_assistant.cpp`)**
+
+In `src/home_assistant.cpp`, after the `#include` block and before `HomeAssistantClient homeAssistant;` (~line 25), add:
+```cpp
+enum HaValueType { HA_NUMERIC, HA_BOOL, HA_STRING };
+
+enum HaSink {
+  SINK_VEHICLE_SOC = 0,
+  SINK_VEHICLE_RANGE,
+  SINK_VEHICLE_ETA,
+  SINK_VEHICLE_CHARGE_LIMIT,
+};
+
+struct HaPollEntry {
+  const String *entity;   // config string; empty => skip
+  bool (*gate)();         // is this row active right now?
+  int  type;              // HaValueType
+  int  sinkId;            // HaSink
+};
+
+static bool gateVehicleHA() {
+  return vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT;
+}
+
+static const HaPollEntry HA_POLL_TABLE[] = {
+  { &ha_vehicle_soc,          gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_SOC },
+  { &ha_vehicle_range,        gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_RANGE },
+  { &ha_vehicle_eta,          gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_ETA },
+  { &ha_vehicle_charge_limit, gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_CHARGE_LIMIT },
+};
+static const int HA_POLL_TABLE_LEN = sizeof(HA_POLL_TABLE) / sizeof(HA_POLL_TABLE[0]);
+```
+
+- [ ] **Step 3: Update the constructor initialisers**
+
+In `src/home_assistant.cpp`, in the `HomeAssistantClient::HomeAssistantClient()` initialiser list (~32-40), replace:
+```cpp
+  _lastVehiclePoll(0),
+  _vehicleInFlight(false),
+  _vehiclePollStart(0)
+```
+with:
+```cpp
+  _lastPoll(0),
+  _pollInFlight(false),
+  _pollStart(0)
+```
+
+- [ ] **Step 4: Rewrite the `loop()` poll-trigger block**
+
+In `src/home_assistant.cpp` `loop()`, replace the stuck-chain recovery + vehicle-poll trigger block (~106-122):
+```cpp
+  // Recover a stuck vehicle-poll chain (e.g. a request that never completed and
+  // no onResponse fired) -- otherwise _vehicleInFlight would block polling forever.
+  if (_vehicleInFlight && _vehiclePollStart != 0 &&
+      (millis() - _vehiclePollStart) > HA_VEHICLE_TIMEOUT_MS) {
+    DBUGLN("[ha] vehicle poll timed out, clearing in-flight flag");
+    _vehicleInFlight = false;
+  }
+
+  // Poll HA vehicle entities when HA is the selected vehicle-data source.
+  if (isConnected()
+      && vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT
+      && !_vehicleInFlight
+      && (_lastVehiclePoll == 0 || (millis() - _lastVehiclePoll) >= HA_VEHICLE_POLL_MS)) {
+    _lastVehiclePoll = millis();
+    if (_lastVehiclePoll == 0) _lastVehiclePoll = 1; // 0 means "never polled"
+    pollVehicle();
+  }
+```
+with:
+```cpp
+  // Recover a stuck poll chain (a request that never completed and no onResponse
+  // fired) -- otherwise _pollInFlight would block polling forever.
+  if (_pollInFlight && _pollStart != 0 &&
+      (millis() - _pollStart) > HA_VEHICLE_TIMEOUT_MS) {
+    DBUGLN("[ha] poll chain timed out, clearing in-flight flag");
+    _pollInFlight = false;
+  }
+
+  // Poll HA entities when connected and at least one configured feed selects HA.
+  if (isConnected()
+      && anyPollActive()
+      && !_pollInFlight
+      && (_lastPoll == 0 || (millis() - _lastPoll) >= HA_VEHICLE_POLL_MS)) {
+    _lastPoll = millis();
+    if (_lastPoll == 0) _lastPoll = 1; // 0 means "never polled"
+    _pollInFlight = true;
+    _pollStart = millis();
+    pollNext(0);
+  }
+```
+
+- [ ] **Step 5: Replace `pollVehicle`/`pollVehicleField` with the generic chain**
+
+In `src/home_assistant.cpp`, delete the entire `pollVehicle()` and `pollVehicleField(int field)` definitions (~302-362) and replace with:
+```cpp
+bool HomeAssistantClient::anyPollActive() {
+  for (int i = 0; i < HA_POLL_TABLE_LEN; i++) {
+    const HaPollEntry &e = HA_POLL_TABLE[i];
+    if (e.entity->length() > 0 && e.gate()) return true;
+  }
+  return false;
+}
+
+// Apply one parsed entity state to its sink, dispatched by sinkId.
+void HomeAssistantClient::applyEntity(int sinkId, int type, const String &state) {
+  if (type == HA_NUMERIC) {
+    char *endp = nullptr;
+    double v = strtod(state.c_str(), &endp);
+    if (endp == state.c_str()) {
+      DBUGF("[ha] sink %d: non-numeric state, skipping", sinkId);
+      return;
+    }
+    switch (sinkId) {
+      case SINK_VEHICLE_SOC:          evse.setVehicleStateOfCharge((int)lround(v)); break;
+      case SINK_VEHICLE_RANGE:        evse.setVehicleRange((int)lround(v));         break;
+      case SINK_VEHICLE_ETA:          evse.setVehicleEta((int)lround(v));           break;
+      case SINK_VEHICLE_CHARGE_LIMIT: evse.setVehicleChargeLimit((int)lround(v));   break;
+      default: break;
+    }
+  }
+  // HA_BOOL and HA_STRING sinks are added in Task 4.
+}
+
+// Fetch one active+configured entity, apply it, then chain to the next. Sequential
+// (one in-flight request at a time) to stay safe on the shared MongooseHttpClient.
+// An empty entity, inactive gate, failed request, or unparseable state simply skips
+// that row (keeps the last good value).
+void HomeAssistantClient::pollNext(int index) {
+  for (int i = index; i < HA_POLL_TABLE_LEN; i++) {
+    const HaPollEntry &e = HA_POLL_TABLE[i];
+    if (e.entity->length() == 0 || !e.gate()) {
+      continue; // not configured / not active -> skip
+    }
+
+    String path = "/api/states/" + *e.entity; // entity IDs are URL-safe (sensor.x_y)
+    int next = i + 1;
+    int sinkId = e.sinkId;
+    int type = e.type;
+    bool sent = get(path, [this, sinkId, type, next](MongooseHttpClientResponse *response) {
+      if (response->respCode() == 200) {
+        MongooseString body = response->body();
+        std::string state;
+        if (ha_parse_entity_state(std::string((const char *)body, body.length()), state)) {
+          applyEntity(sinkId, type, String(state.c_str()));
+        } else {
+          DBUGF("[ha] sink %d: state unavailable/unparseable", sinkId);
+        }
+      } else {
+        DBUGF("[ha] sink %d: HTTP %d", sinkId, response->respCode());
+      }
+      pollNext(next); // advance regardless of this row's outcome
+    });
+
+    if (!sent) {
+      // get() declined (refresh due / not connected): onResponse won't fire, so end
+      // the chain now rather than stranding _pollInFlight until the timeout.
+      _pollInFlight = false;
+    }
+    return; // one in-flight request at a time; the callback resumes the walk
+  }
+
+  // Walked off the end with nothing left to send -> chain complete.
+  _pollInFlight = false;
+}
+```
+
+- [ ] **Step 6: Build to verify the refactor compiles**
+
+Run: `pio run -e openevse_wifi_v1`
+Expected: SUCCESS (links). This is the core-2.x board; it exercises the default (non-P4) code path the same as the S3/standard builds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/home_assistant.h src/home_assistant.cpp
+git commit -m "refactor(ha): generic poll table replaces hardcoded vehicle chain
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the four display-only feeds (bool/string coercion + new sinks + rows)
+
+**Files:**
+- Modify: `src/home_assistant.h` (public `addStatusFields` + private display-only members)
+- Modify: `src/home_assistant.cpp` (sink enum, gates, table rows, `applyEntity` bool/string branches, `addStatusFields`, clear-on-disconnect)
+
+- [ ] **Step 1: Add the display-only members and the status method to the header**
+
+In `src/home_assistant.h`, in the `public:` section after `void getStatus(JsonDocument &doc);` (line ~18), add:
+```cpp
+    void addStatusFields(JsonDocument &doc); // merge display-only HA values into /status
+```
+In the `private:` section, after the `_pollStart;` member, add:
+```cpp
+    // Display-only values polled from HA (omitted from /status until a valid read).
+    int    _homeBatterySoc = 0;       bool _homeBatterySocValid = false;
+    int    _homeBatteryPower = 0;     bool _homeBatteryPowerValid = false;
+    bool   _vehiclePlugged = false;   bool _vehiclePluggedValid = false;
+    String _vehicleChargingState;     // empty => absent
+```
+
+- [ ] **Step 2: Extend the sink enum and add gates + table rows**
+
+In `src/home_assistant.cpp`, extend the `HaSink` enum:
+```cpp
+enum HaSink {
+  SINK_VEHICLE_SOC = 0,
+  SINK_VEHICLE_RANGE,
+  SINK_VEHICLE_ETA,
+  SINK_VEHICLE_CHARGE_LIMIT,
+  SINK_VEHICLE_PLUGGED,
+  SINK_VEHICLE_CHARGING_STATE,
+  SINK_HOME_BATTERY_SOC,
+  SINK_HOME_BATTERY_POWER,
+};
+```
+Add a second gate next to `gateVehicleHA()`:
+```cpp
+// Home-battery feeds poll whenever the entity is configured; the loop already
+// gates on isConnected(), which implies HA is enabled and authorized.
+static bool gateAlways() { return true; }
+```
+Add the four rows to `HA_POLL_TABLE` (after the vehicle rows, before the closing `};`):
+```cpp
+  { &ha_vehicle_plugged,         gateVehicleHA, HA_BOOL,    SINK_VEHICLE_PLUGGED },
+  { &ha_vehicle_charging_state,  gateVehicleHA, HA_STRING,  SINK_VEHICLE_CHARGING_STATE },
+  { &ha_battery_soc,             gateAlways,    HA_NUMERIC, SINK_HOME_BATTERY_SOC },
+  { &ha_battery_power,           gateAlways,    HA_NUMERIC, SINK_HOME_BATTERY_POWER },
+```
+
+- [ ] **Step 3: Extend `applyEntity` for the new numeric sinks + bool + string**
+
+In `src/home_assistant.cpp` `applyEntity`, add the two home-battery cases to the existing `HA_NUMERIC` switch:
+```cpp
+      case SINK_HOME_BATTERY_SOC:
+        _homeBatterySoc = (int)lround(v); _homeBatterySocValid = true; break;
+      case SINK_HOME_BATTERY_POWER:
+        _homeBatteryPower = (int)lround(v); _homeBatteryPowerValid = true; break;
+```
+Then replace the trailing comment `// HA_BOOL and HA_STRING sinks are added in Task 4.` with:
+```cpp
+  else if (type == HA_BOOL) {
+    bool b;
+    if (!ha_parse_bool(std::string(state.c_str()), b)) {
+      DBUGF("[ha] sink %d: unrecognized bool state, skipping", sinkId);
+      return;
+    }
+    switch (sinkId) {
+      case SINK_VEHICLE_PLUGGED: _vehiclePlugged = b; _vehiclePluggedValid = true; break;
+      default: break;
+    }
+  }
+  else if (type == HA_STRING) {
+    // ha_parse_entity_state already rejected ""/unavailable/unknown, so `state` is real.
+    switch (sinkId) {
+      case SINK_VEHICLE_CHARGING_STATE: _vehicleChargingState = state; break;
+      default: break;
+    }
+  }
+```
+(The `if (type == HA_NUMERIC) { ... }` block must close before this `else if` chain; keep the `return` inside the numeric non-numeric-skip path so it doesn't fall through.)
+
+- [ ] **Step 4: Implement `addStatusFields` (omit-when-absent)**
+
+In `src/home_assistant.cpp`, add (e.g. after `getStatus`):
+```cpp
+void HomeAssistantClient::addStatusFields(JsonDocument &doc) {
+  if (_homeBatterySocValid)   doc["home_battery_soc"] = _homeBatterySoc;
+  if (_homeBatteryPowerValid) doc["home_battery_power"] = _homeBatteryPower;
+  if (_vehiclePluggedValid)   doc["vehicle_plugged"] = _vehiclePlugged;
+  if (_vehicleChargingState.length() > 0)
+    doc["vehicle_charging_state"] = _vehicleChargingState;
+}
+```
+
+- [ ] **Step 5: Clear display-only values on disconnect**
+
+In `src/home_assistant.cpp` `disconnect()`, after the existing token/state clears (before the `event_send`), add:
+```cpp
+  _homeBatterySocValid = false;
+  _homeBatteryPowerValid = false;
+  _vehiclePluggedValid = false;
+  _vehicleChargingState = "";
+```
+
+- [ ] **Step 6: Build to verify it compiles**
+
+Run: `pio run -e openevse_wifi_v1`
+Expected: SUCCESS (links). Confirms the bool/string branches, new members, and table rows all compile.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/home_assistant.h src/home_assistant.cpp
+git commit -m "feat(ha): poll home-battery + vehicle plugged/charging-state (display-only)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Surface the display-only fields in `/status`
+
+**Files:**
+- Modify: `src/web_server.cpp` (include + `buildStatus()` ~302)
+
+- [ ] **Step 1: Include the HA client header**
+
+In `src/web_server.cpp`, add to the include block (near the other module includes, e.g. after `#include "current_shaper.h"` line ~44):
+```cpp
+#include "home_assistant.h"
+```
+
+- [ ] **Step 2: Call `addStatusFields` in `buildStatus()`**
+
+In `src/web_server.cpp` `buildStatus()`, immediately after the vehicle `else { ... }` block closes (line ~302, right before `DBUGF("/status ArduinoJson size: %dbytes", doc.size());`), add:
+```cpp
+  homeAssistant.addStatusFields(doc);
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `pio run -e openevse_wifi_v1`
+Expected: SUCCESS (links).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/web_server.cpp
+git commit -m "feat(ha): emit home-battery + vehicle-extra fields in /status
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full build + hardware validation on the P4
+
+**Files:** none (build/flash/validate only).
+
+The P4 is the bench board with a working HA connection (used for VD/CL HW validation). It runs the core-3.x build and the gui-nightshift bundle.
+
+- [ ] **Step 1: Build both target cores**
+
+Run:
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+pio run -e openevse_wifi_v1            # core-2.x, default path
+GUI_NAME=gui-nightshift pio run -e openevse_p4   # core-3.x, P4 bench board
+```
+Expected: both SUCCESS. (If the P4 build throws a transient `FRAMEWORK_DIR is None` on a fresh framework install, re-run — see the core-3 migration notes.)
+
+- [ ] **Step 2: Flash the P4**
+
+Run: `GUI_NAME=gui-nightshift pio run -e openevse_p4 -t upload --upload-port /dev/ttyACM5`
+Expected: upload completes, board reboots.
+
+- [ ] **Step 3: Configure the four entities (one of two ways)**
+
+Either set them in the gui-nightshift Solar/Vehicle settings pages (once the GUI branch is flashed), or POST config directly:
+```bash
+curl -s -X POST http://10.75.1.143/config \
+  -H 'Content-Type: application/json' \
+  -d '{"ha_battery_soc":"sensor.home_battery_soc","ha_battery_power":"sensor.home_battery_power","ha_vehicle_plugged":"binary_sensor.car_plugged_in","ha_vehicle_charging_state":"sensor.car_charging_state"}'
+```
+Use entity IDs that actually exist on the bench HA instance (substitute real ones). `vehicle_data_src` must be `4` (HOMEASSISTANT) for the two vehicle-extra rows to be active; the home-battery rows poll regardless.
+
+- [ ] **Step 4: Confirm the fields appear in `/status`**
+
+Wait ~30 s for a poll cycle, then:
+```bash
+curl -s http://10.75.1.143/status | python3 -m json.tool | grep -E "home_battery_soc|home_battery_power|vehicle_plugged|vehicle_charging_state"
+```
+Expected: the configured fields appear with live values. **Crucially**, before configuring (or for an unconfigured field), confirm the field is **absent** from `/status` — not present as `0`/`false`.
+
+- [ ] **Step 5: Confirm a bad/unavailable entity is handled**
+
+Temporarily set one entity to a nonexistent ID (e.g. `sensor.does_not_exist`), wait a cycle, and confirm `/status` keeps the **last good** value (or stays absent if never read) rather than emitting `0` — and that the poll chain keeps running for the other fields (check the serial log via `pio device monitor` for `HTTP 404`/`unavailable` skips without a stuck chain).
+
+- [ ] **Step 6: Record validation result**
+
+No commit (validation only). Note the observed `/status` values and absent-when-unconfigured behavior in the task tracker / PR description.
+
+---
+
+## Final Verification
+
+- [ ] `pio test -e native` — all green (`ha_parse_bool` + existing).
+- [ ] `pio run -e openevse_wifi_v1` and `GUI_NAME=gui-nightshift pio run -e openevse_p4` — both build clean.
+- [ ] `/status` on the P4 shows the four fields with live values when configured, and **omits** each field when its entity is unconfigured/unavailable (never `0`/`false`).
+- [ ] Vehicle numeric values (`battery_level`, `battery_range`, `time_to_full_charge`, `vehicle_charge_limit`) still behave exactly as before the refactor (the poll table reproduces the old chain).
+- [ ] Backward compatibility: with none of the new `ha_*` keys set (all default `""`), the new rows are skipped and `/status` is unchanged from today.

--- a/docs/superpowers/plans/2026-06-03-ha-data-sources-phase2-control.md
+++ b/docs/superpowers/plans/2026-06-03-ha-data-sources-phase2-control.md
@@ -1,0 +1,357 @@
+# HA Data Sources — Phase 2 (Control-Path) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the eco-divert solar/grid feeds and the shaper whole-home live-power feed be sourced from Home Assistant entities (the GUI already offers this; the firmware config keys don't exist yet, so the GUI's writes silently don't persist).
+
+**Architecture:** Add the control-path config keys (`divert_data_src`, `shaper_data_src`, `ha_solar`, `ha_grid_ie`, `ha_live_pwr`) and three more rows to the existing HA poll table whose sinks write the SAME globals/objects the MQTT path writes (`solar`/`grid_ie` globals + `shaper.setLivePwr()`), triggering the same divert/shaper recalcs. MQTT⇄HA arbitration mirrors the existing vehicle pattern — the MQTT message handlers are guarded by a per-feature data-source check, so when HA is the source the MQTT message is ignored (no source thrash).
+
+**Tech Stack:** C++ (Arduino-ESP32 core 2.x + ESP-IDF 5.x core 3.x), MicroTasks, ArduinoJson 6, ArduinoMongoose.
+
+**Spec:** `docs/superpowers/specs/2026-06-03-ha-data-sources-firmware-design.md` (Phase 2 sections). **Phase 1 (display-only) is already merged** to `feature/esp32-modernization` — the poll table, `pollNext`, `applyEntity`, gates (`gateVehicleHA`/`gateAlways`), and `HaSink` enum already exist in `src/home_assistant.cpp`.
+
+**Working directory / branch:** `/home/rar/oevse/openevse_esp32_firmware`, branch `feature/ha-data-sources` (currently == `feature/esp32-modernization` at `671f32a`).
+
+**Key conventions:**
+- `0` = MQTT (default), `1` = Home Assistant for both `*_data_src` keys. A new `enum data_src { DATA_SRC_MQTT = 0, DATA_SRC_HOMEASSISTANT = 1 };` makes this readable.
+- The `*_data_src` keys do NOT start with `ha_`, so they need an explicit line in the config-change dispatcher (`app_config.cpp`).
+- **Arbitration = handler guard, NOT subscription teardown.** The vehicle MQTT handlers already use `&& vehicle_data_src == VEHICLE_DATA_SRC_MQTT` (`mqtt.cpp`); mirror that exactly. This needs no MQTT reconnect.
+- Short keys (verified free): `divert_data_src`=`dvs` (NB `dds` is taken by `divert_decay_smoothing_time`), `shaper_data_src`=`shs`, `ha_solar`=`hso`, `ha_grid_ie`=`hgi`, `ha_live_pwr`=`hlp`.
+- No new pure helpers → no new native tests; the control rows reuse the proven `HA_NUMERIC` path. Verification is build + HW (Task 4), consistent with Phase 1's integration tasks.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/app_config.h` / `src/app_config.cpp` | 5 new config keys + `data_src` enum + dispatch line | 1 |
+| `src/home_assistant.cpp` | 3 new sinks + gates + table rows + applyEntity cases (+ divert/shaper includes) | 2 |
+| `src/mqtt.cpp` | guard solar/grid/live-pwr handlers (+ subscriptions) on `*_data_src == MQTT` | 3 |
+| — | full build (core-2 + P4) + HW validation | 4 |
+
+(`home_assistant.h` needs no signature changes — the new sinks reuse `applyEntity(int,int,String)`.)
+
+---
+
+## Task 1: Control-path config keys + `data_src` enum + dispatch
+
+**Files:**
+- Modify: `src/app_config.h`
+- Modify: `src/app_config.cpp`
+
+- [ ] **Step 1: Add the `data_src` enum + extern declarations**
+
+In `src/app_config.h`, immediately AFTER the existing `enum vehicle_data_src { ... };` block (ends ~line 132), add:
+```cpp
+// Per-feature data source for divert/shaper feeds (solar, grid, live power).
+enum data_src {
+  DATA_SRC_MQTT = 0,          // default: MQTT topic (existing behavior)
+  DATA_SRC_HOMEASSISTANT = 1, // poll a Home Assistant entity instead
+};
+
+extern uint8_t divert_data_src;
+extern uint8_t shaper_data_src;
+extern String ha_solar;
+extern String ha_grid_ie;
+extern String ha_live_pwr;
+```
+
+- [ ] **Step 2: Define the globals**
+
+In `src/app_config.cpp`, immediately after the `String ha_vehicle_charging_state;` definition (added in Phase 1, ~line 146), add:
+```cpp
+uint8_t divert_data_src;
+uint8_t shaper_data_src;
+String ha_solar;
+String ha_grid_ie;
+String ha_live_pwr;
+```
+
+- [ ] **Step 3: Register the config options**
+
+In `src/app_config.cpp`, immediately after the `ha_vehicle_charging_state` `ConfigOptDefinition` line (the `"hvg"` entry added in Phase 1), add:
+```cpp
+  new ConfigOptDefinition<uint8_t>(divert_data_src, 0, "divert_data_src", "dvs"),
+  new ConfigOptDefinition<uint8_t>(shaper_data_src, 0, "shaper_data_src", "shs"),
+  new ConfigOptDefinition<String>(ha_solar, "", "ha_solar", "hso"),
+  new ConfigOptDefinition<String>(ha_grid_ie, "", "ha_grid_ie", "hgi"),
+  new ConfigOptDefinition<String>(ha_live_pwr, "", "ha_live_pwr", "hlp"),
+```
+
+- [ ] **Step 4: Notify HA when a source flips**
+
+In `src/app_config.cpp`, find the dispatch branch (~line 448):
+```cpp
+  } else if(name.startsWith("ha_") || name == "home_assistant_enabled" || name == "vehicle_data_src") {
+    homeAssistant.notifyConfigChanged();
+```
+and replace its condition with:
+```cpp
+  } else if(name.startsWith("ha_") || name == "home_assistant_enabled" || name == "vehicle_data_src"
+            || name == "divert_data_src" || name == "shaper_data_src") {
+    homeAssistant.notifyConfigChanged();
+```
+(The MQTT side reads `divert_data_src`/`shaper_data_src` live on each message, so it needs no notification; only the HA poll task must re-arm.)
+
+- [ ] **Step 5: Verify short-key uniqueness + build**
+
+Run: `grep -oE '"[a-z0-9]{1,3}"\)' src/app_config.cpp | sort | uniq -d` — must print NOTHING (no duplicate short keys).
+Run: `pio run -e openevse_wifi_v1` — expect SUCCESS. (Transient `FRAMEWORK_DIR is None` → re-run once.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/app_config.h src/app_config.cpp
+git commit -m "feat(ha): control-path config keys (divert/shaper data source + entities)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: HA poll sinks for solar / grid / shaper-live-power
+
+**Files:**
+- Modify: `src/home_assistant.cpp`
+
+Adds three rows to the existing poll table and the matching `applyEntity` sinks, writing the SAME globals/objects the MQTT handlers write and triggering the identical divert/shaper recalcs.
+
+- [ ] **Step 1: Add the divert + shaper includes**
+
+In `src/home_assistant.cpp`, after the existing `#include "input.h"` line (~line 15), add:
+```cpp
+#include "divert.h"          // global `solar`/`grid_ie` ints + `divert`; DIVERT_TYPE_*
+#include "current_shaper.h"  // global `shaper`
+```
+
+- [ ] **Step 2: Extend the `HaSink` enum**
+
+In `src/home_assistant.cpp`, add three values to the end of the `HaSink` enum (before the closing `};`):
+```cpp
+  SINK_SOLAR,
+  SINK_GRID_IE,
+  SINK_SHAPER_LIVE_PWR,
+```
+
+- [ ] **Step 3: Add the three gate functions**
+
+In `src/home_assistant.cpp`, immediately after the existing `gateAlways()` definition, add:
+```cpp
+// Control-path feeds mirror the MQTT subscription conditions: only active when the
+// feature is enabled, the source is HA, and (for divert) the divert type matches.
+static bool gateSolarHA() {
+  return config_divert_enabled() && divert_data_src == DATA_SRC_HOMEASSISTANT
+         && divert_type == DIVERT_TYPE_SOLAR;
+}
+static bool gateGridHA() {
+  return config_divert_enabled() && divert_data_src == DATA_SRC_HOMEASSISTANT
+         && divert_type == DIVERT_TYPE_GRID;
+}
+static bool gateShaperHA() {
+  return config_current_shaper_enabled() && shaper_data_src == DATA_SRC_HOMEASSISTANT;
+}
+```
+
+- [ ] **Step 4: Add the three table rows**
+
+In `src/home_assistant.cpp`, add these rows to `HA_POLL_TABLE` after the existing `ha_battery_power` row (before the closing `};`):
+```cpp
+  { &ha_solar,    gateSolarHA,  HA_NUMERIC, SINK_SOLAR },
+  { &ha_grid_ie,  gateGridHA,   HA_NUMERIC, SINK_GRID_IE },
+  { &ha_live_pwr, gateShaperHA, HA_NUMERIC, SINK_SHAPER_LIVE_PWR },
+```
+
+- [ ] **Step 5: Add the three sinks to `applyEntity`**
+
+In `src/home_assistant.cpp` `applyEntity`, in the `HA_NUMERIC` `switch (sinkId)` block, add these cases (before `default: break;`). They mirror the MQTT handlers in `mqtt.cpp` (solar/grid drive divert + a shaper recompute; live-power feeds the shaper):
+```cpp
+      case SINK_SOLAR:
+        solar = (int)lround(v);
+        divert.update_state();
+        if (shaper.getState()) shaper.shapeCurrent();
+        break;
+      case SINK_GRID_IE:
+        grid_ie = (int)lround(v);
+        divert.update_state();
+        break;
+      case SINK_SHAPER_LIVE_PWR:
+        shaper.setLivePwr((int)lround(v));
+        break;
+```
+
+- [ ] **Step 6: Build**
+
+Run: `pio run -e openevse_wifi_v1` — expect SUCCESS (links). If `solar`/`grid_ie`/`divert`/`shaper`/`DIVERT_TYPE_*`/`config_divert_enabled` are unresolved, recheck the Step 1 includes. (Transient `FRAMEWORK_DIR is None` → re-run once.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/home_assistant.cpp
+git commit -m "feat(ha): poll solar/grid/live-power from HA into divert + shaper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: MQTT⇄HA arbitration (handler guards)
+
+**Files:**
+- Modify: `src/mqtt.cpp`
+
+When a feed's source is HA, the MQTT message for that feed must be ignored so the two sources don't fight. Mirror the existing vehicle pattern (`&& vehicle_data_src == VEHICLE_DATA_SRC_MQTT`). Also gate the matching subscriptions so HA-sourced feeds don't needlessly subscribe.
+
+- [ ] **Step 1: Guard the message handlers**
+
+In `src/mqtt.cpp`, in the message-handling chain (~line 299), change the three handler conditions.
+
+Change:
+```cpp
+  if (topic_string == mqtt_solar){
+```
+to:
+```cpp
+  if (topic_string == mqtt_solar && divert_data_src == DATA_SRC_MQTT){
+```
+
+Change:
+```cpp
+  else if (topic_string == mqtt_grid_ie) {
+```
+to:
+```cpp
+  else if (topic_string == mqtt_grid_ie && divert_data_src == DATA_SRC_MQTT) {
+```
+
+Change:
+```cpp
+  else if (topic_string == mqtt_live_pwr) {
+```
+to:
+```cpp
+  else if (topic_string == mqtt_live_pwr && shaper_data_src == DATA_SRC_MQTT) {
+```
+
+- [ ] **Step 2: Gate the subscriptions**
+
+In `src/mqtt.cpp`, in the subscription block (~line 207), add the source check to each condition.
+
+Change:
+```cpp
+  // Divert mode related
+  if (config_divert_enabled()) {
+    if (divert_type == DIVERT_TYPE_SOLAR && mqtt_solar != "") {
+      _mqttclient.subscribe(mqtt_solar); yield();
+    }
+    if (divert_type == DIVERT_TYPE_GRID && mqtt_grid_ie != "") {
+      _mqttclient.subscribe(mqtt_grid_ie); yield();
+    }
+  }
+
+  // Current shaper related
+  if (config_current_shaper_enabled()) {
+    if (mqtt_live_pwr != "" && mqtt_live_pwr != mqtt_grid_ie) {
+      _mqttclient.subscribe(mqtt_live_pwr); yield();
+    }
+  }
+```
+to:
+```cpp
+  // Divert mode related (skip when the feed is sourced from Home Assistant)
+  if (config_divert_enabled() && divert_data_src == DATA_SRC_MQTT) {
+    if (divert_type == DIVERT_TYPE_SOLAR && mqtt_solar != "") {
+      _mqttclient.subscribe(mqtt_solar); yield();
+    }
+    if (divert_type == DIVERT_TYPE_GRID && mqtt_grid_ie != "") {
+      _mqttclient.subscribe(mqtt_grid_ie); yield();
+    }
+  }
+
+  // Current shaper related (skip when sourced from Home Assistant)
+  if (config_current_shaper_enabled() && shaper_data_src == DATA_SRC_MQTT) {
+    if (mqtt_live_pwr != "" && mqtt_live_pwr != mqtt_grid_ie) {
+      _mqttclient.subscribe(mqtt_live_pwr); yield();
+    }
+  }
+```
+(The handler guard in Step 1 is the correctness mechanism; this subscription gate is a traffic optimization. Like all MQTT topic-config changes in this firmware, the subscription set only re-evaluates on the next MQTT (re)connect — the handler guard covers the interim, so flipping the source takes effect immediately regardless.)
+
+- [ ] **Step 3: Build**
+
+Run: `pio run -e openevse_wifi_v1` — expect SUCCESS. (Transient `FRAMEWORK_DIR is None` → re-run once.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+git add src/mqtt.cpp
+git commit -m "feat(ha): arbitrate MQTT vs HA for solar/grid/live-power feeds
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full build (core-2 + P4) + hardware validation
+
+**Files:** none (build/flash/validate only).
+
+- [ ] **Step 1: Build both cores**
+
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+pio run -e openevse_wifi_v1
+GUI_NAME=gui-nightshift pio run -e openevse_p4
+```
+Expected: both SUCCESS. (P4 first build may throw the transient `FRAMEWORK_DIR is None` — re-run.)
+
+- [ ] **Step 2: Restore web_static + flash the P4**
+
+The P4 build regenerates `src/web_static/*.h` to the gui-nightshift bundle (build-time only — never commit). After flashing, restore the committed gui-v2 default so the tree stays clean:
+```bash
+cd /home/rar/oevse/openevse_esp32_firmware
+GUI_NAME=gui-nightshift pio run -e openevse_p4 -t upload --upload-port /dev/ttyACM5
+git checkout -- src/web_static/
+```
+Expected: upload completes, board reboots.
+
+- [ ] **Step 3: Confirm the config keys now persist (the reported bug)**
+
+After the board is back up (~30 s), set the solar feed to HA and read it back:
+```bash
+curl -s -X POST http://10.75.1.143/config -H 'Content-Type: application/json' \
+  -d '{"divert_data_src":1,"ha_solar":"sensor.luxpower_lxp_x_2_pv_power"}'
+sleep 2
+curl -s http://10.75.1.143/config | python3 -c "import sys,json;c=json.load(sys.stdin);print({k:c.get(k,'ABSENT') for k in ['divert_data_src','ha_solar']})"
+```
+Expected: `{'divert_data_src': 1, 'ha_solar': 'sensor.luxpower_lxp_x_2_pv_power'}` — they now STICK (this is the bug fix). `divert_enabled` and `divert_type` must be set for solar to actually poll (`divert_type=0`).
+
+- [ ] **Step 4: Confirm `/status` solar tracks the HA entity**
+
+With divert enabled and `divert_type=0` (solar), wait ~30 s for a poll cycle:
+```bash
+curl -s http://10.75.1.143/status | python3 -c "import sys,json;s=json.load(sys.stdin);print('solar:', s.get('solar'), '| divert_active:', s.get('divert_active'), '| charge_rate:', s.get('charge_rate'))"
+```
+Expected: `solar` reflects the live value of `sensor.luxpower_lxp_x_2_pv_power` (not stuck at 0), proving the HA poll writes the `solar` global and drives divert. Cross-check against the value of that entity in Home Assistant.
+
+- [ ] **Step 5: Confirm MQTT no longer fights (arbitration)**
+
+If an MQTT solar topic is configured and publishing, confirm that with `divert_data_src=1` the `/status` `solar` follows the HA entity, not the MQTT topic (the MQTT message is ignored by the guarded handler). Then flip `divert_data_src` back to `0` and confirm `solar` returns to the MQTT-sourced value (or its prior behavior). If no MQTT solar source is configured on the bench, note that and skip the live comparison.
+
+- [ ] **Step 6: Record validation result**
+
+No commit (validation only). Note the observed persistence + `/status` tracking in the task tracker / PR description.
+
+---
+
+## Final Verification
+
+- [ ] `pio run -e openevse_wifi_v1` and `GUI_NAME=gui-nightshift pio run -e openevse_p4` — both build clean.
+- [ ] `grep -oE '"[a-z0-9]{1,3}"\)' src/app_config.cpp | sort | uniq -d` — no duplicate short keys.
+- [ ] On HW: `divert_data_src`/`ha_solar`/`ha_grid_ie`/`ha_live_pwr`/`shaper_data_src` persist across a `/config` POST (the reported bug is fixed).
+- [ ] On HW: with `divert_data_src=1` + divert enabled + `divert_type=0`, `/status.solar` tracks the configured HA entity.
+- [ ] Backward compatibility: with `divert_data_src`/`shaper_data_src` absent/0 (default), MQTT solar/grid/live-power behaves exactly as before (handlers fire, subscriptions made).
+- [ ] No regression to the Phase 1 display-only feeds (`home_battery_*`, `vehicle_plugged`, `vehicle_charging_state` still poll/emit).

--- a/docs/superpowers/specs/2026-06-01-ha-gating-and-vehicle-charge-limit-design.md
+++ b/docs/superpowers/specs/2026-06-01-ha-gating-and-vehicle-charge-limit-design.md
@@ -1,0 +1,175 @@
+# HA Firmware-Capability Gating + Vehicle Charge-Limit — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); implementation plan to follow.
+**Builds on:** the HA OAuth connection + HA vehicle-data source (both on `feature/home-assistant-oauth`).
+
+## Goal
+
+Two small, independent additions to the Home Assistant integration:
+
+1. **Firmware-capability gating (gui-nightshift):** hide the HA-specific UI (the Home
+   Assistant settings page and the Vehicle "Home Assistant" data-source option) when the
+   running firmware doesn't support HA — so the web UI never shows dead controls on older
+   firmware.
+2. **Vehicle charge-limit (firmware):** read the **vehicle's own charge limit** — the
+   percent the car stops charging *itself* at (like Tesla's `charge_limit_soc`) — from a
+   configurable HA entity, and surface it **informationally** in `/status` and on the
+   original TFT display. It is display-only: the car enforces it; the EVSE does NOT stop on
+   it (that is the separate, already-existing `limitSoc` cutoff).
+
+**Explicitly out of scope this round** (deferred): a web dashboard vehicle card, and the
+P4 EEZ/LVGL on-device vehicle display (the latter needs EEZ model-binding groundwork that
+is still a TODO — its own later effort).
+
+## Context (existing mechanisms)
+
+- Vehicle data sources feed the EVSE manager via `setVehicleStateOfCharge/Range/Eta`;
+  validity is a bitmask (`_vehicleValid |= EVSE_VEHICLE_SOC`, `_vehicleUpdated`,
+  `_vehicleLastUpdated = millis()`, `wakeTask`) — see `evse_man.cpp:581`.
+- The HA vehicle poll (`HomeAssistantClient::pollVehicleField`, `home_assistant.cpp`)
+  already chains `ha_vehicle_soc`/`range`/`eta` (fields 0/1/2) via the `get()` seam +
+  `ha_parse_entity_state`, with an `_vehicleInFlight` + timeout guard and a `strtod`
+  numeric guard.
+- The original TFT (`lcd.cpp`) already cycles **Charge level / Range / ETA** from the
+  vehicle getters; the **`LcdInfoLine::ChargeLimit`** line (`lcd.cpp:565`) is a stub with
+  no value.
+- `/status` (`web_server.cpp:281`) exposes `battery_level`/`battery_range`/
+  `time_to_full_charge` only when the matching `isVehicle*Valid()` is true.
+- The gui-nightshift config store (`src/lib/stores/config.js`) already augments the config
+  object with derived flags (`firmware_is_eu`, `max_current_firmware`) via `withDerived()`.
+- Settings pages come from a flat `SETTINGS_PAGES` list + `pagesBySection()`
+  (`src/lib/config/pages.js`); no capability gating exists yet.
+- `ConfigOpt` entries always serialize their key, so a firmware WITH the HA feature
+  includes `ha_url` (and the other `ha_*` keys) in `/config`; firmware WITHOUT it does not.
+  Presence of `ha_url` is therefore a reliable capability signal.
+
+## Section 1 — Firmware-capability gating (gui-nightshift only)
+
+**Detection:** add a derived flag in `src/lib/stores/config.js` `withDerived()`:
+`ha_supported: !!(obj && obj.ha_url !== undefined)`. (Mirrors how `firmware_is_eu` is
+derived.) When `/config` hasn't loaded yet (`obj` undefined) or lacks `ha_url`,
+`ha_supported` is false → HA UI hidden until proven supported.
+
+**Apply gating in two places:**
+
+- **Settings nav** (`src/lib/config/pages.js`): give the `home-assistant` entry a
+  `requires: 'ha_supported'` field. Change `pagesBySection()` to accept the config object
+  and filter out any entry whose `requires` flag is falsy in that config; entries with no
+  `requires` always show:
+  ```js
+  export function pagesBySection(config) {
+    return SECTIONS.map((section) => ({
+      section,
+      pages: SETTINGS_PAGES.filter(
+        (p) => p.section === section && (!p.requires || (config && config[p.requires])),
+      ),
+    }))
+  }
+  ```
+  `src/routes/Settings.svelte` passes `$config_store`: `pagesBySection($config_store)`.
+
+- **Vehicle source option** (`src/routes/settings/Vehicle.svelte`): build `srcOptions` so
+  the `{ value: '4', label: src_homeassistant }` entry is included only when
+  `$config_store?.ha_supported` — e.g. start from the base options and conditionally
+  append the HA entry. (The existing `{:else if src === 4}` reveal block can stay as-is;
+  on unsupported firmware `vehicle_data_src` can't be 4 anyway since the option is hidden.)
+
+**Routes:** the `routes.js` route for `/settings/home-assistant` stays (harmless — not
+reachable from the hidden nav entry). Gating the nav entry + the source option is
+sufficient for v1.
+
+**Tests (vitest):**
+- `pages.test.js` (or a new case): `pagesBySection({})` (no `ha_supported`) omits the
+  home-assistant page; `pagesBySection({ ha_supported: true })` includes it. Pages without
+  `requires` are unaffected either way.
+- `Vehicle.test.js`: with `config_store.set({ ha_supported: true, ... })` the source
+  `<select>` offers the HA option; with `ha_supported` falsy it does not.
+
+## Section 2 — Vehicle charge-limit field (firmware + TFT + /status)
+
+**EVSE manager (`src/evse_man.h` / `evse_man.cpp`):** add the field mirroring SoC exactly.
+- A new validity/updated bit `EVSE_VEHICLE_CHARGE_LIMIT` (next free bit alongside
+  `EVSE_VEHICLE_SOC`/`_RANGE`/`_ETA` — implementer finds the bit definitions and adds the
+  next one).
+- `int _vehicleChargeLimit;`
+- `void setVehicleChargeLimit(int v)` — body mirrors `setVehicleStateOfCharge`:
+  ```cpp
+  _vehicleChargeLimit = v;
+  _vehicleValid |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleUpdated |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleLastUpdated = millis();
+  MicroTask.wakeTask(this);
+  ```
+- `int getVehicleChargeLimit() { return _vehicleChargeLimit; }`
+- `int isVehicleChargeLimitValid() { return 0 != (_vehicleValid & EVSE_VEHICLE_CHARGE_LIMIT); }`
+  (mirror the exact form of `isVehicleStateOfChargeValid`).
+- Initialize `_vehicleChargeLimit` in the constructor like the other vehicle members.
+
+**Config (`src/app_config.{h,cpp}`):** add `ha_vehicle_charge_limit` (String), registered
+`new ConfigOptDefinition<String>(ha_vehicle_charge_limit, "", "ha_vehicle_charge_limit", "hvc")`
+next to the other `ha_vehicle_*` entries; extern + definition added. (The existing
+`config_changed` `name.startsWith("ha_")` branch already covers it.)
+
+**HA poll (`src/home_assistant.cpp`):** extend `pollVehicleField` to a 4th field:
+- `case 3: entity = ha_vehicle_charge_limit; break;`
+- `default: _vehicleInFlight = false; return;` (now reached at `field == 4`).
+- In the response handler, the field-3 branch: `evse.setVehicleChargeLimit((int)lround(v));`
+- Everything else (blank-skip, numeric guard, chain-advance, in-flight/timeout) is the
+  existing logic, unchanged.
+
+**/status (`src/web_server.cpp`):** alongside the `battery_level`/etc. block:
+```cpp
+if (evse.isVehicleChargeLimitValid()) {
+  doc["vehicle_charge_limit"] = evse.getVehicleChargeLimit();
+}
+```
+Key name `vehicle_charge_limit` (deliberately distinct from the EVSE-side `/limit`
+endpoint; not reusing Tesla's `charge_limit_soc` to avoid implying the Tesla event).
+
+**TFT (`src/lcd.cpp`):** fill in the `LcdInfoLine::ChargeLimit` case (line 565):
+```cpp
+case LcdInfoLine::ChargeLimit:
+  displayNumberValue(1, "Charge limit", _evse->getVehicleChargeLimit(), 0, "%");
+  break;
+```
+Ensure that info-line is included in the cycling set when the value is valid — mirror
+exactly how the `BatterySOC` line is added to the rotation (the implementer must locate
+where the info-line sequence is built / gated on vehicle-data validity and add
+`ChargeLimit` there the same way `BatterySOC` is). If `BatterySOC` is unconditionally in
+the rotation, match that; if it is gated on `isVehicleStateOfChargeValid()`, gate
+`ChargeLimit` on `isVehicleChargeLimitValid()`.
+
+## Error handling & edge cases
+
+- **Charge-limit poll** reuses the existing per-field guards: blank
+  `ha_vehicle_charge_limit` → field skipped; HTTP error / `unavailable` / non-numeric →
+  skipped, last good value retained; the in-flight + 30 s timeout guard already covers the
+  4-field chain (the `default` clear just moves from `case 3` to `case 4`).
+- **Never set** → `isVehicleChargeLimitValid()` false → absent from `/status`; the TFT
+  line shows nothing (consistent with SoC behavior before first read).
+- **Gating with config not loaded:** `ha_supported` is false until `/config` is fetched,
+  so the HA UI is hidden during the brief load window rather than flashing then vanishing.
+- **Old firmware + stale saved config:** if a device's saved `vehicle_data_src` were 4 on
+  firmware lacking HA, the option is hidden but the value persists harmlessly (the firmware
+  wouldn't act on an unknown source).
+
+## Testing
+
+- **Firmware:** builds green (native `pio test -e native -f test_ha_oauth`,
+  `pio run -e nodemcu-32s`, `GUI_NAME=gui-nightshift ./scripts/pio run -e openevse_p4`).
+  No new pure logic (reuses `ha_parse_entity_state`), so the charge-limit field is verified
+  by build + on-hardware: set `ha_vehicle_charge_limit` to an HA entity reporting the car's
+  target %, confirm `/status.vehicle_charge_limit` matches and the TFT "Charge limit" line
+  shows it.
+- **gui-nightshift (vitest):** the two gating tests above (pages filter + Vehicle option),
+  plus the full suite + `npm run build` stay green; locale parity unaffected (no new i18n
+  keys required — `src_homeassistant` etc. already exist).
+
+## Out of scope (deferred)
+
+- Web dashboard vehicle card (SoC/range/ETA/charge-limit readout).
+- P4 EEZ/LVGL on-device vehicle display (needs EEZ model-binding groundwork — separate
+  larger effort).
+- Feeding the charge-limit field from Tesla/MQTT (this round wires HA only; the evse field
+  is source-agnostic so other sources can adopt it later without refactoring).

--- a/docs/superpowers/specs/2026-06-01-ha-vehicle-data-source-design.md
+++ b/docs/superpowers/specs/2026-06-01-ha-vehicle-data-source-design.md
@@ -1,0 +1,153 @@
+# Home Assistant as a Vehicle-Data Source — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); implementation plan to follow.
+**Builds on:** the Home Assistant OAuth connection
+(`docs/superpowers/specs/2026-06-01-home-assistant-oauth-design.md`) — specifically the
+`homeAssistant.get(path, onResponse)` Bearer-authenticated seam and `isConnected()`.
+
+## Goal
+
+Let the user select **Home Assistant** as the charger's vehicle-data source (alongside
+the existing None/Tesla/MQTT/HTTP options) and configure HA entity IDs for vehicle
+state-of-charge, range, and time-to-full. The firmware periodically reads those entities
+via the HA connection and feeds them into the EVSE manager
+(`setVehicleStateOfCharge/Range/Eta`), exactly as the Tesla and MQTT sources do.
+
+## Existing mechanism (context)
+
+- `vehicle_data_src` (uint8_t config, `app_config.h`) selects the source; enum currently
+  `NONE, TESLA, MQTT, HTTP`.
+- Every source converges on `evse.setVehicleStateOfCharge(int %)`,
+  `evse.setVehicleRange(int)`, `evse.setVehicleEta(int seconds)`.
+  - Tesla: `teslaClient.loop()` pumped from `main.cpp` when src==TESLA; pulls charge_state.
+  - MQTT (`mqtt.cpp`): when a configured topic (`mqtt_vehicle_soc/range/eta`) arrives AND
+    src==MQTT, sets the values. Topic names are **optional free-text** config strings.
+  - HTTP (`web_server.cpp`): accepts a POST of battery_level/battery_range/
+    time_to_full_charge when src==HTTP (push model).
+- Range units: the existing `mqtt_vehicle_range_miles` flag is the EVSE's single
+  range-unit setting; reused as-is (no new units config).
+- `/status` already exposes `battery_level`/`battery_range` read from the EVSE manager, so
+  HA-sourced values reach the UI without new plumbing.
+
+## Architecture (Approach A — poll inside HomeAssistantClient)
+
+Chosen over (B) main.cpp dispatch and (C) a separate module: the HA client already owns
+the 30 s `loop()`, the `get()` Bearer seam, and `isConnected()`; reusing them is the
+least-friction path and matches how the Tesla client bundles its own polling and sets the
+EVSE values. The source→EVSE coupling already exists for Tesla/MQTT, so adding an
+`evse_man` dependency to the HA client is consistent.
+
+### Files
+
+- **`src/ha_oauth.{h,cpp}` + `test/test_ha_oauth/test_ha_oauth.cpp`** — add one pure,
+  natively-tested helper:
+  `bool ha_parse_entity_state(const std::string &json, std::string &out)` — extracts
+  `.state` from HA's `/api/states/<entity>` JSON. Returns false if the body doesn't
+  parse, `state` is missing/non-string, or `state` is `"unknown"` / `"unavailable"`.
+- **`src/home_assistant.{h,cpp}`** — vehicle polling:
+  - `loop()` gains a gated section: when
+    `isConnected() && vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT` and a 30 s
+    `_lastVehiclePoll` interval has elapsed, call `pollVehicle()`.
+  - private `pollVehicle()` + per-field response handlers (sequential chain, below).
+  - new `#include "evse_man.h"` (uses the global `evse`).
+  - new member `unsigned long _lastVehiclePoll`.
+- **`src/app_config.{h,cpp}`** — enum value `VEHICLE_DATA_SRC_HOMEASSISTANT` appended (=4);
+  three optional config strings.
+- **`main.cpp`** — no change (the HA client's own loop drives polling; it is not pumped
+  from main like Tesla).
+
+### Config
+
+`enum vehicle_data_src { VEHICLE_DATA_SRC_NONE, VEHICLE_DATA_SRC_TESLA,
+VEHICLE_DATA_SRC_MQTT, VEHICLE_DATA_SRC_HTTP, VEHICLE_DATA_SRC_HOMEASSISTANT };`
+(append HA last to preserve existing numeric values.)
+
+| key | short | type | meaning |
+|---|---|---|---|
+| `ha_vehicle_soc` | `hvs` | String | entity_id for state-of-charge (%) |
+| `ha_vehicle_range` | `hvr` | String | entity_id for range |
+| `ha_vehicle_eta` | `hve` | String | entity_id for time-to-full (numeric state read as seconds) |
+
+All optional; blank = that field is not polled. Default "".
+
+## Polling flow
+
+Driven by the HA client's existing 30 s `loop()`. Each tick:
+
+```
+if (isConnected()
+    && vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT
+    && (millis() - _lastVehiclePoll) >= 30000) {
+  _lastVehiclePoll = millis();
+  pollVehicle();
+}
+```
+
+`pollVehicle()` fetches the configured entities **sequentially chained** on the shared
+`MongooseHttpClient` (only one in-flight request at a time — avoids overlap with itself or
+a concurrent token refresh):
+
+1. If `ha_vehicle_soc` non-empty → `get("/api/states/" + ha_vehicle_soc, cb_soc)`.
+2. `cb_soc`: `ha_parse_entity_state(body, state)`; on success
+   `evse.setVehicleStateOfCharge((int)lround(atof(state)))`. Then chain to range.
+3. range step: if `ha_vehicle_range` non-empty → `get(..., cb_range)`; on success
+   `evse.setVehicleRange((int)lround(atof(state)))`. Then chain to eta.
+4. eta step: if `ha_vehicle_eta` non-empty → `get(..., cb_eta)`; on success
+   `evse.setVehicleEta((int)atof(state))` (seconds). End of chain.
+
+Blank fields are skipped (the chain advances). A failed/`unavailable`/`unknown`/non-200
+response for one field skips just that field (keeps the last good value) and still chains
+to the next. URL-encode the entity ID in the path (`/api/states/<encoded>`), reusing
+`ha_url_encode` (entity IDs are normally safe, but encode defensively).
+
+Note on `get()`: it currently passes a raw `MongooseHttpResponseHandler`. The chaining is
+implemented by having each handler invoke the next `get()` for the following field. Since
+`homeAssistant` is a program-lifetime global, capturing member context in the handlers is
+safe (same basis as the existing exchange/refresh callbacks).
+
+## GUI (gui-nightshift)
+
+`src/routes/settings/Vehicle.svelte` already renders the data-source selector and reveals
+per-source fields (e.g. the MQTT topic fields). Add:
+- a **"Home Assistant"** option to the source selector (maps to the new enum value);
+- when selected, three free-text entity-ID inputs bound to `ha_vehicle_soc`/`range`/`eta`,
+  saved via the existing config form — mirroring the MQTT field-reveal pattern;
+- a short hint linking to **Settings → Home Assistant** (the connection must be set up
+  first; these fields do nothing until HA is connected);
+- i18n strings across all four locale files (en/es/fr/hu) for label/fields/hint;
+- a vitest test asserting that selecting the HA source reveals the three entity fields.
+
+## Error handling & edge cases
+
+- **HA not connected** (src=HA, no tokens): `pollVehicle()` is gated on `isConnected()`,
+  so it simply doesn't run — no crash, no clobbering of existing values.
+- **Entity unavailable / unknown / 404 / non-200 / unparseable**: that field is skipped,
+  last good value retained, debug-logged. Validity is never cleared on a transient blip.
+- **Blank entity field**: skipped; chain continues to the next configured field.
+- **Source switched away from HA**: the loop stops polling on the next tick (gated);
+  existing EVSE vehicle values persist, same as the other sources.
+- **Shared `MongooseHttpClient`**: sequential chaining guarantees a single in-flight
+  request; no concurrent-request hazard.
+- **NTP/time**: irrelevant here (no expiry math in the poll path).
+
+## Testing
+
+- **Native doctest** (`ha_parse_entity_state`): valid numeric state extracted;
+  `"unavailable"` and `"unknown"` → false; missing/`null` `state` → false; state present
+  alongside an `attributes` object still parses.
+- **Firmware**: builds green (native, nodemcu-32s, openevse_p4 with GUI bundled).
+  On-hardware: select source = Home Assistant, set `ha_vehicle_soc` to a real HA
+  `sensor.*` (battery %), confirm `battery_level` appears in `/status` and on the display;
+  set range/eta entities and confirm likewise; set an entity to a down sensor and confirm
+  the last good value is retained (no clobber).
+- **GUI**: vitest — selecting the HA source reveals the three entity fields and they bind
+  to the correct config keys.
+
+## Out of scope (deferred)
+
+- Dropdown entity picker populated from HA (`/api/states`) — v1 uses free-text entity IDs
+  (matches the MQTT source).
+- Reading arbitrary non-vehicle HA entities / a generic entity reader.
+- ETA timestamp/duration-string parsing — the ETA entity's numeric state is read as
+  seconds (pass-through, same as the MQTT source).

--- a/docs/superpowers/specs/2026-06-01-home-assistant-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-01-home-assistant-oauth-design.md
@@ -1,0 +1,222 @@
+# Home Assistant OAuth Connection — Design
+
+**Date:** 2026-06-01
+**Status:** Approved (design); implementation plan to follow.
+
+## Goal
+
+Add a **global Home Assistant connection** to the OpenEVSE ESP32 firmware that
+authenticates via Home Assistant's OAuth2 (IndieAuth) **browser-redirect flow**, with
+the ESP32 acting as its own `client_id` and `redirect_uri` on the LAN. v1 establishes
+and maintains the authenticated connection and surfaces it as a "Connect to Home
+Assistant" control on the main settings page. Reading entity data and wiring values
+into existing features (divert grid power, vehicle SoC, a generic entity reader) is
+explicitly **deferred** to follow-on work — but v1 leaves a clean seam for it.
+
+User chose OAuth over a long-lived access token, and an on-device automatic callback
+(ESP32 captures `?code=` on `/ha_callback`) over manual code-paste.
+
+## Scope
+
+**In scope (v1):**
+- OAuth browser-redirect login, end to end, initiated from the main settings page.
+- On-device authorization-code → token exchange and automatic refresh.
+- Token persistence across reboots; connection status; disconnect.
+- A reusable, bearer-attaching firmware seam (`homeAssistant.get(...)`) — present but
+  with no callers yet.
+- gui-nightshift settings block: HA URL, Connect/Disconnect, status.
+
+**Out of scope (deferred):**
+- Reading/polling entity states.
+- Wiring HA values into divert / current-shaper / EVSE-manager SoC.
+- A generic configurable entity reader.
+- mDNS auto-discovery of the HA instance.
+- PKCE (only if HA's auth endpoint is confirmed to support it during implementation;
+  otherwise omitted — see Security).
+
+## Reference
+
+evcc's HA integration was the study reference (`util/homeassistant/{oauth2,connection,
+instance,zeroconf}.go`). It uses the same OAuth2 endpoints (`/auth/authorize`,
+`/auth/token`, `AuthStyleInParams`) and attaches `Authorization: Bearer` to plain REST
+calls. evcc is a server with a configured external URL; we instead derive the device
+URL from the request `Host` header (see Data Flow). HA auth API:
+https://developers.home-assistant.io/docs/auth_api
+
+The Tesla client (`src/tesla_client.cpp`, `tesla_*` config in `app_config.cpp`) is the
+in-repo precedent for token storage (`ConfigOptSecret`), the `CONFIG_SERVICE_*` enable
+flag, `config_changed()` dispatch, and the async `MongooseHttpClient` request pattern.
+Note Tesla does its OAuth **off-device**; HA differs by doing it on-device.
+
+## Architecture & Components
+
+Three clean seams: the firmware module knows nothing about the UI or any consumer; the
+UI knows only the REST endpoints; future features know only `homeAssistant.get(...)`.
+
+### Firmware (this repo)
+
+- **`src/home_assistant.{h,cpp}`** — new `HomeAssistantClient`, a `MicroTasks::Task`
+  with a global instance `homeAssistant`, structured like `mqtt` / `tesla_client`.
+  Owns the entire token lifecycle. Public surface (kept small):
+  - `begin()`, `loop(WakeReason)` — refresh scheduling.
+  - `isConnected()` — enabled && have a non-expired or refreshable access token.
+  - `getStatus(JsonDocument&)` — fills `{enabled, connected, ha_url, expires}`.
+  - `beginAuthorize(const String &redirectUri, String &outAuthUrl)` — generates and
+    stashes `state`, builds the HA authorize URL. Used by the web handler.
+  - `handleCallback(const String &code, const String &state)` — validates `state`,
+    performs the token exchange, stores tokens. Used by the web handler.
+  - `disconnect()` — clears tokens, cancels refresh.
+  - `get(const String &path, responseCallback)` — reusable helper that attaches
+    `Authorization: Bearer <token>`. **Present in v1, no callers yet.**
+- **`src/web_server_home_assistant.cpp`** — HTTP handlers, registered with
+  `server.on(...)` in `web_server_setup()` (alongside the existing `/tesla/...` lines).
+- **`src/app_config.cpp` / `app_config.h`** — persisted config + a new
+  `CONFIG_SERVICE_HOMEASSISTANT` service-flag bit; `config_changed()` gains a
+  `name.startsWith("ha_")` / `home_assistant_enabled` branch that pushes values into
+  `homeAssistant`, mirroring the `tesla_` branch.
+- **`src/main.cpp`** — construct/`begin()` the task and pump it like the other
+  integration tasks.
+
+### UI (`gui-nightshift` repo — separate git repo)
+
+- **`src/lib/config/homeassistant.js`** — HA field defs + connect-flow trigger.
+- **Home Assistant block on the main settings page** (conventions from
+  `src/routes/settings/Mqtt.svelte`, `src/lib/config/tesla.js`): HA URL field,
+  Connect/Disconnect buttons, status indicator.
+- vitest + testing-library/svelte tests alongside (like `tesla.test.js`,
+  `Mqtt.test.js`); uses the `dev:mock` harness.
+
+## Data Flow (OAuth)
+
+```
+Browser (on LAN)            ESP32 firmware                 Home Assistant
+─────────────────────────────────────────────────────────────────────────
+1. user clicks "Connect" ─► GET /ha/auth/start
+                            • from request (scheme + Host) build
+                              client_id  = <scheme>://<host>/
+                              redirect_uri = <scheme>://<host>/ha_callback
+                            • gen random `state` (esp_random), stash
+                              {state, redirect_uri} with short TTL
+                            • 302 ───────────────────────────────────────►
+2.                                                         /auth/authorize?
+                                                           client_id&redirect_uri&state
+                          ◄──────────── user logs in, approves ───────────
+3. browser redirected ──► GET /ha_callback?code=…&state=…
+                            • verify `state` matches the stashed value
+                            • POST /auth/token ───────────────────────────►
+                              grant_type=authorization_code, code,
+                              client_id, redirect_uri (replayed from stash)
+                          ◄──── { access_token, refresh_token, expires_in }
+                            • store tokens (ConfigOptSecret) + expiry
+                            • 302 → settings page (?ha=connected | ?ha=error=…)
+4. (ongoing) loop() refresh:    POST /auth/token grant_type=refresh_token ►
+                          ◄──── { access_token, refresh_token, expires_in }
+```
+
+- `client_id` / `redirect_uri` are **derived from the incoming request** at
+  `/ha/auth/start` — the `Host` header gives host:port (so it matches whatever the
+  browser used, `.local` name or raw IP, satisfying HA's same-host rule with zero
+  config) and the **scheme follows how the browser reached the EVSE** (`http`, or
+  `https` if the EVSE is served over TLS per #20) — this is the *device's* scheme and
+  is independent of `ha_url`'s scheme. The **same** `redirect_uri` is replayed at token
+  exchange (OAuth requires it to match).
+- `code`→token exchange and all refreshes are **server-to-server from the ESP32**
+  (`MongooseHttpClient`); secret tokens never enter the browser.
+- `state` is single-use CSRF protection.
+
+## Token Lifecycle & Config
+
+Persisted config (in `app_config.cpp`, following the Tesla block):
+
+| Field | Type | Notes |
+|---|---|---|
+| `ha_url` | `ConfigOptDefinition<String>` | e.g. `http://homeassistant.local:8123`; scheme (http/https) honored |
+| `ha_access_token` | `ConfigOptSecret` | masked in `/config` output, like `tesla_access_token` |
+| `ha_refresh_token` | `ConfigOptSecret` | masked |
+| `ha_token_expires` | `ConfigOptDefinition<uint64_t>` | absolute unix expiry = created + expires_in |
+| `home_assistant_enabled` | `ConfigOptVirtualMaskedBool` on `CONFIG_SERVICE_HOMEASSISTANT` | new service-flag bit |
+
+- **Refresh scheduling**: `loop()` returns a wake interval; when connected it refreshes
+  **~5 minutes before** `ha_token_expires` via `POST /auth/token`
+  (`grant_type=refresh_token`). On success it rewrites the access/refresh tokens (HA
+  rotates the refresh token) and `ha_token_expires`, saves config, and emits a
+  `home_assistant` event.
+- **Reboot persistence**: the refresh token is long-lived. On `begin()`, if a refresh
+  token exists and the service is enabled, the module is connectable and refreshes on
+  first loop if the access token is stale.
+
+## Web Endpoints
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/ha/auth/start` | basic-auth (requestPreProcess) | Build authorize URL, 302 to HA |
+| GET | `/ha_callback` | `state` only (no basic-auth) | Validate state, exchange code, store tokens, 302 to settings |
+| GET | `/ha/status` | basic-auth | JSON `{enabled, connected, ha_url, expires}` |
+| POST | `/ha/disconnect` | basic-auth | Clear tokens, cancel refresh |
+
+`/ha_callback` cannot require basic-auth because HA's browser redirect won't carry it;
+it is protected by the unguessable single-use `state` + immediate exchange instead.
+`/ha/status` may alternatively be folded into the existing `/status` payload the
+dashboard already polls; decided at implementation time.
+
+## UI (gui-nightshift)
+
+- Connect is a **full browser navigation** to `/ha/auth/start` (not a `fetch`), so HA's
+  login page and the redirect chain run in the real browser. On return the firmware
+  redirects to the settings page with `?ha=connected` or `?ha=error=…`, which the page
+  reads to show a toast.
+- HA URL field saved via the normal `/config` store; Connect enabled once a URL is
+  saved.
+- Status indicator (Connected / Not connected) driven by `/ha/status` (or the folded
+  `/status` fields). Disconnect button → `POST /ha/disconnect`, then refresh status.
+- Strings via `svelte-i18n`. The block reads/writes only via documented endpoints.
+
+## Error Handling & Security
+
+- **CSRF**: `state` from `esp_random()` at `/ha/auth/start`, stored with a short TTL
+  (single pending auth), required to match at `/ha_callback`; mismatch/expired → 400,
+  no exchange.
+- **redirect_uri integrity**: the token-exchange `redirect_uri` is the value stashed
+  with `state` at start, not re-derived from the callback request, so a tampered
+  callback Host can't shift it.
+- **Endpoint auth**: `/ha/auth/start`, `/ha/disconnect`, `/ha/status` go through the
+  existing `requestPreProcess` HTTP-auth gate. `/ha_callback` is protected by `state`
+  (see Web Endpoints).
+- **Token exchange failure** (non-200 from `/auth/token`): clear pending state, emit a
+  `home_assistant` error event, leave any existing tokens untouched (a failed *re*-auth
+  must not nuke a working connection).
+- **Refresh failure**: transient (network/5xx) → retry with backoff, stay connected
+  until expiry actually lapses; hard failure (`400 invalid_grant` = refresh token
+  revoked in HA) → clear tokens, flip to disconnected, surface in status.
+- **Secrets**: tokens stored as `ConfigOptSecret` (masked in `/config`); server-to-
+  server exchange keeps them out of the browser; if `ha_url` is `https`, exchange and
+  refresh use the existing Mongoose TLS stack (relates to tasks #10/#20).
+- **Disable/clear**: toggling `home_assistant_enabled` off, or Disconnect, clears
+  tokens and cancels refresh scheduling.
+- **PKCE**: verify during implementation whether HA's authorize endpoint supports it.
+  If yes, add `code_challenge`/`code_verifier` (S256 via mbedtls). If not, rely on
+  `state` + single-use code + immediate server-side exchange. Not promised in v1.
+
+## Testing
+
+- **Firmware host-side unit tests** (pure functions, no network), under `test/` per the
+  repo's native test setup:
+  - authorize-URL builder: (host, ha_url, state) → correct `/auth/authorize?…`.
+  - `client_id` / `redirect_uri` derivation from a request (scheme + `Host` header).
+  - `state` generate/verify (including mismatch/expiry).
+  - token-response parser: JSON → {access, refresh, expiry}.
+  - expiry / refresh-due calculator.
+- **Firmware integration (manual, on hardware)**: full click-through against a real HA
+  instance — Connect → login → callback → `isConnected()` true; reboot persists;
+  Disconnect clears; revoke-in-HA → next refresh flips to disconnected. Verified via
+  `/ha/status` + the UI (serial console is not readable from the build host).
+- **gui-nightshift**: vitest + testing-library/svelte for the settings block — renders
+  fields, Connect disabled until URL saved, status reflects `/ha/status`, Disconnect
+  posts — mirroring `tesla.test.js` / `Mqtt.test.js`; uses `dev:mock`.
+
+## Open Questions / Decided-at-Implementation
+
+- Whether `/ha/status` is a standalone endpoint or folded into the existing `/status`
+  payload.
+- Whether HA supports PKCE (drives the optional PKCE addition).
+- Exact `state` TTL and storage (single pending-auth slot vs small map).

--- a/docs/superpowers/specs/2026-06-03-ha-data-sources-firmware-design.md
+++ b/docs/superpowers/specs/2026-06-03-ha-data-sources-firmware-design.md
@@ -1,0 +1,190 @@
+# Home Assistant Data Sources — Firmware Design
+
+**Goal:** Implement the firmware half of the gui-nightshift "HA data sources" feature: poll four more Home Assistant feeds — solar/grid (eco divert), whole-home live power (shaper), home-battery SoC/power (display-only), and two vehicle attributes (plugged-in, charging state) — reusing the existing vehicle-HA polling engine, and surface the results through the same `status` fields the GUI already reads.
+
+**Approach:** Generalize the existing single-purpose vehicle poll chain in `HomeAssistantClient` into a small **static poll table** driven by value type and a per-row sink. Numeric feeds keep writing the same sinks the MQTT/`/status`-POST paths use today; the two non-numeric (bool/string) and the home-battery feeds are new and surface display-only fields. All new config defaults preserve current behavior (sources default to MQTT).
+
+**Companion GUI spec:** `openevse-gui-nightshift/docs/superpowers/specs/2026-06-03-ha-data-sources-design.md`
+**Companion GUI plan:** `openevse-gui-nightshift/docs/superpowers/plans/2026-06-03-ha-data-sources.md`
+
+This design is the authoritative source for the firmware-side **contract** (config keys the GUI writes, status fields the GUI reads). The GUI is inert without it.
+
+---
+
+## Scope
+
+In scope (firmware, two phases — see Phasing):
+1. **Solar / Eco divert** — solar production or grid import/export from HA.
+2. **Shaper** — whole-home live power from HA.
+3. **Home battery** — SoC and power from HA, **display-only** (no charging-logic change).
+4. **Vehicle extras** — plugged-in state and charging state from HA.
+
+Out of scope (mirrors the GUI spec):
+- Home battery influencing divert/eco/shaper logic.
+- Odometer, battery state-of-health, vehicle location.
+- Staleness/timeout tracking or UI for any feed (keep-last-good, like the vehicle path today).
+- Any new files — every change is additive to existing HA/config/web/mqtt modules.
+
+---
+
+## Background: what exists today
+
+`HomeAssistantClient` (`src/home_assistant.cpp`) is a `MicroTasks::Task` with a working poll engine added in the vehicle-data work (tasks VD/CL):
+
+- `loop()` runs every `HA_LOOP_INTERVAL_MS` (30 s); when `isConnected()` and `vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT`, and no poll is in flight, it kicks `pollVehicle()` every `HA_VEHICLE_POLL_MS` (30 s).
+- `pollVehicleField(field)` walks a hardcoded chain (0=soc,1=range,2=eta,3=charge_limit), issuing **one in-flight GET at a time** on the shared `MongooseHttpClient`, parsing via `ha_parse_entity_state()`, and writing numeric values through `evse.setVehicle*()`. It explicitly **skips non-numeric states** (`strtod` failure → keep last good) and chains to the next field in the `onResponse` handler.
+- `get(path, onResponse)` is refresh-aware (declines and returns `false` when a token refresh is due), Bearer-authenticated, against `<ha_url>/api/states/<entity>`.
+- In-flight guard (`_vehicleInFlight`) + a `HA_VEHICLE_TIMEOUT_MS` recovery clear a stuck chain.
+
+The sinks for the new feeds already exist for the MQTT and `/status`-POST paths:
+- `solar` / `grid_ie` — globals in `app_config`/`mqtt.cpp`, read by the divert algorithm; emitted at `web_server.cpp:258-259`. Written by MQTT (`mqtt.cpp:300/308`) and `/status` POST (`web_server.cpp:472-489`).
+- `shaper.setLivePwr(double)` / `shaper.getLivePwr()` — emitted at `web_server.cpp:264`.
+- Vehicle numerics — `evse.setVehicle*()`; emitted as `battery_level`/`battery_range`/`vehicle_charge_limit` at `web_server.cpp:291-300`.
+- **Home battery + vehicle extras — no sink exists.** New.
+
+`divert_type` enum (`divert.h`): `DIVERT_TYPE_UNSET=-1`, `DIVERT_TYPE_SOLAR=0`, `DIVERT_TYPE_GRID=1` — matches the GUI's `divert_type===0`=production / `1`=grid.
+
+Config-change dispatch (`app_config.cpp:440`) already routes any key starting with `ha_` (and `vehicle_data_src`) to `homeAssistant.notifyConfigChanged()`.
+
+---
+
+## Architecture: unified poll table
+
+Replace the hardcoded `switch(field)` in `pollVehicleField` with a static table the chain walks generically. Each row:
+
+```c
+enum HaValueType { HA_NUMERIC, HA_BOOL, HA_STRING };
+
+struct HaPollEntry {
+  const String *entity;   // pointer to the config string, e.g. &ha_vehicle_soc
+  bool (*gate)();         // is this row active right now?
+  HaValueType type;       // how to parse the state
+  int sinkId;             // selects the write target in applyValue()
+};
+```
+
+A single static `_pollTable[]` lists every pollable entity. `loop()` polls when **`isConnected()` AND at least one row is active** (its `gate()` true and `*entity` non-empty). The existing sequential single-in-flight chain, in-flight guard, timeout recovery, and refresh-aware `get()` are **unchanged** — `pollVehicleField` becomes `pollNext(index)` and iterates the table, skipping rows whose gate is false or whose entity is empty, advancing in `onResponse` exactly as today.
+
+### Value coercion (centralized by `type`)
+
+- **`HA_NUMERIC`** — `strtod`; on non-numeric state, skip (keep last good) — today's exact behavior.
+- **`HA_BOOL`** — new pure helper `ha_parse_bool(state, bool &out)`: `on`/`true`/`1`/`home` → `true`; `off`/`false`/`0`/`not_home`/`unplugged` → `false`; anything else (incl. `unavailable`/`unknown`) → skip. (HA `binary_sensor` reports `on`/`off`.)
+- **`HA_STRING`** — pass the raw state through **only if** `ha_parse_entity_state()` accepts it (it already rejects `unavailable`/`unknown`) and it is non-empty; otherwise skip.
+
+### Sinks (`applyValue(sinkId, ...)` — one small switch)
+
+| sinkId | Row | Gate | Type | Sink |
+|---|---|---|---|---|
+| soc | `ha_vehicle_soc` | `vehicle_data_src==HA` | numeric | `evse.setVehicleStateOfCharge()` (unchanged) |
+| range | `ha_vehicle_range` | `vehicle_data_src==HA` | numeric | `evse.setVehicleRange()` (unchanged) |
+| eta | `ha_vehicle_eta` | `vehicle_data_src==HA` | numeric | `evse.setVehicleEta()` (unchanged) |
+| chargeLimit | `ha_vehicle_charge_limit` | `vehicle_data_src==HA` | numeric | `evse.setVehicleChargeLimit()` (unchanged) |
+| vehiclePlugged | `ha_vehicle_plugged` | `vehicle_data_src==HA` | bool | HA-client member → `/status` |
+| vehicleChargingState | `ha_vehicle_charging_state` | `vehicle_data_src==HA` | string | HA-client member → `/status` |
+| homeBatterySoc | `ha_battery_soc` | `ha_supported` (always) | numeric | HA-client member → `/status` |
+| homeBatteryPower | `ha_battery_power` | `ha_supported` (always) | numeric | HA-client member → `/status` |
+| solar | `ha_solar` | `divert_data_src==1 && divert_type==DIVERT_TYPE_SOLAR` | numeric | global `solar` (+ shaper recalc) |
+| gridIe | `ha_grid_ie` | `divert_data_src==1 && divert_type==DIVERT_TYPE_GRID` | numeric | global `grid_ie` (+ shaper recalc) |
+| shaperLivePwr | `ha_live_pwr` | `shaper_data_src==1` | numeric | `shaper.setLivePwr()` |
+
+**Display-only values live in the HA client, not the EVSE manager.** Vehicle numerics keep going through `evse.setVehicle*()` because the EVSE *consumes* them (charge-limit logic, TFT). Home-battery and the two vehicle-extras are display-only — the EVSE never reads them — so they live as `HomeAssistantClient` members and are merged into `/status` via a new `homeAssistant.addStatusFields(JsonDocument &doc)` called from `buildStatus()` in `web_server.cpp` (near the existing vehicle block).
+
+**Solar/grid recalc:** after writing the `solar`/`grid_ie` global, trigger the same "recalculate shaper" step the `/status` POST path uses (`if (shaper.getState()) shaper.shapeCurrent();`) so downstream divert/shaper behavior is identical regardless of source.
+
+---
+
+## Contract (authoritative)
+
+### Config keys (GUI writes → firmware reads)
+
+| Key | Short | Type | Default | Notes |
+|---|---|---|---|---|
+| `divert_data_src` | `dvs` | `uint8_t` | `0` | `0`=MQTT, `1`=Home Assistant (NB: `dds` is already taken by `divert_decay_smoothing_time`) |
+| `shaper_data_src` | `shs` | `uint8_t` | `0` | `0`=MQTT, `1`=Home Assistant |
+| `ha_solar` | `hso` | `String` | `""` | entity ID, used when `divert_type==SOLAR` |
+| `ha_grid_ie` | `hgi` | `String` | `""` | entity ID, used when `divert_type==GRID` |
+| `ha_live_pwr` | `hlp` | `String` | `""` | entity ID (shaper live power) |
+| `ha_battery_soc` | `hbs` | `String` | `""` | entity ID (home battery %) |
+| `ha_battery_power` | `hbp` | `String` | `""` | entity ID (home battery W) |
+| `ha_vehicle_plugged` | `hvp` | `String` | `""` | binary entity ID |
+| `ha_vehicle_charging_state` | `hvg` | `String` | `""` | entity ID |
+
+The seven `ha_*` keys auto-route to `notifyConfigChanged()` via the existing `app_config.cpp:440` dispatch. The two `*_data_src` keys do **not** match `ha_*`, so add a dispatch branch that calls `homeAssistant.notifyConfigChanged()` (re-arms polling) — and, since changing the source also changes whether MQTT should subscribe, the same branch must re-evaluate MQTT subscriptions (Phase 2; e.g. `mqttClient.notifyConfigChanged()` or equivalent re-subscribe).
+
+(Short keys above are the proposed 3-char NVS codes; confirm uniqueness against `app_config.cpp` at implementation time and adjust if any collide.)
+
+### Status fields (firmware writes → GUI reads)
+
+| Field | Type | Omit when | Notes |
+|---|---|---|---|
+| `solar` | int (W) | — (already emitted) | written from HA when `divert_data_src==1 && divert_type==SOLAR` |
+| `grid_ie` | int (W) | — (already emitted) | written from HA when `divert_data_src==1 && divert_type==GRID` |
+| `shaper_live_pwr` | int (W) | — (already emitted) | written from HA when `shaper_data_src==1` |
+| `home_battery_soc` | number (%) | no valid reading | **NEVER emit `0` as "no data"** — `0` is a valid SoC; the GUI shows the group whenever the field is a finite number. Omit the field entirely until a real reading exists. |
+| `home_battery_power` | number (W) | no valid reading | signed; HA's own sign passes through unchanged. |
+| `vehicle_plugged` | bool | never successfully parsed | emit only after a successful `ha_parse_bool`. |
+| `vehicle_charging_state` | string | empty / `unavailable` / `unknown` | **raw passthrough** — firmware does NO label mapping; the GUI lowercases and maps known values, falling back to the literal. |
+
+The omit-when-absent rule for the four new fields is the load-bearing correctness detail: emit a field only once the HA client holds a value parsed from a successful poll. Before that (unconfigured entity, never-yet-polled, or last poll unavailable) the field is left out of `/status`, matching the GUI's "absent → hide" logic. This is the same lesson as the energy-logger SoC `-1` sentinel: a display-only reading must never collide with a legitimate zero.
+
+---
+
+## MQTT ⇄ HA arbitration (Phase 2)
+
+Today `mqtt.cpp:209-220` subscribes to `mqtt_solar`/`mqtt_grid_ie`/`mqtt_live_pwr` and writes the globals on message. When a feed's source is HA, MQTT must not also write it (they would thrash every cycle). Gate each subscription on its source still being MQTT, mirroring the existing exclusive-source model:
+
+- solar: subscribe `mqtt_solar` only when `divert_data_src == 0 && divert_type == DIVERT_TYPE_SOLAR && mqtt_solar != ""`.
+- grid: subscribe `mqtt_grid_ie` only when `divert_data_src == 0 && divert_type == DIVERT_TYPE_GRID && mqtt_grid_ie != ""`.
+- live power: subscribe `mqtt_live_pwr` only when `shaper_data_src == 0 && mqtt_live_pwr != ""`.
+
+Changing `divert_data_src`/`shaper_data_src` must re-evaluate the subscription set (the dispatch branch added above). The `/status` POST writes (`web_server.cpp:472-489`) stay as-is: an explicit external push is a deliberate act, not a competing background source. The HA poll writes the **same** globals the MQTT path did and reuses the same shaper-recalc trigger, so divert/shaper downstream behavior is unchanged regardless of source.
+
+---
+
+## Phasing (one design, two plans/branches)
+
+**Phase 1 — display-only (low risk; unblocks GUI Monitoring).**
+- Refactor the vehicle chain into the generic poll table (no behavior change; covered by the existing `ha_parse_entity_state` native tests plus new ones).
+- Add the four display-only rows: `home_battery_soc`, `home_battery_power`, `vehicle_plugged`, `vehicle_charging_state`.
+- Add the four config keys (`ha_battery_soc`, `ha_battery_power`, `ha_vehicle_plugged`, `ha_vehicle_charging_state`) — all `ha_*`, so dispatch is automatic.
+- Add `ha_parse_bool` + `HomeAssistantClient` members + `addStatusFields()` + the `buildStatus()` call.
+- Ship + HW-validate on the P4 against a real HA instance.
+
+**Phase 2 — control-path (higher risk; touches charge-current inputs).**
+- Add `divert_data_src`/`shaper_data_src` config + the dispatch branch (notify HA + re-evaluate MQTT subscriptions).
+- Add the three control rows (solar/grid/shaper) + the shaper-recalc trigger.
+- Add MQTT subscription gating.
+- HW-validate divert + shaper behavior with HA as the source (solar/grid/live-power values move the charge current as expected; flipping the selector back to MQTT restores MQTT behavior).
+
+---
+
+## Error handling
+
+- **Poll failure / unavailable state / unconfigured entity:** skip that row, keep last good (numeric/bool/string), and — for the four omit-when-absent fields — simply never start emitting until a real value lands. Matches the vehicle path.
+- **In-flight / stuck chain:** unchanged — `_vehicleInFlight` guard + `HA_VEHICLE_TIMEOUT_MS` recovery (rename to a feed-neutral name, e.g. `_pollInFlight`, but same mechanism).
+- **`get()` declines (refresh due / not connected):** end the chain (as today) so the in-flight flag isn't stranded; next cycle retries after `loop()` refreshes.
+- **Disconnect:** existing `disconnect()` clears tokens; display-only members should also be cleared so stale values stop being emitted after a disconnect.
+
+---
+
+## Testing
+
+Pull value coercion into pure, native-testable helpers so logic isn't trapped behind the network (same `test/test_ha_oauth` doctest env as VD Task 1):
+
+- **`ha_parse_bool(state, out)`** — new pure helper; cases: `on`/`off`/`true`/`false`/`1`/`0`/`home`/`not_home` → expected bool; `unavailable`/`unknown`/`""`/garbage → returns false-to-parse (skip).
+- **String passthrough** — assert `ha_parse_entity_state` rejects `unavailable`/`unknown` (add a case if missing) so `HA_STRING` rows never emit junk.
+- **Existing `ha_parse_entity_state` numeric tests** — must stay green after the table refactor.
+
+The poll chain, sinks, `addStatusFields()`, and MQTT arbitration are network/hardware paths → HW-validated on the P4 against a real HA instance, exactly like VD Task 3/5 and CL Task 5. Build must stay green on both core-2.x (`openevse_wifi_v1`) and the P4 (`openevse_p4`).
+
+---
+
+## File Structure (all additive — no new files)
+
+| File | Change | Phase |
+|---|---|---|
+| `src/home_assistant.{h,cpp}` | poll table + generic `pollNext` chain (replaces `pollVehicleField` switch); display-only members; `addStatusFields()`; `ha_parse_bool`; clear members on disconnect | 1 (+ 3 rows in 2) |
+| `src/app_config.{h,cpp}` | 4 `ha_*` string keys (Phase 1) + 2 `*_data_src` `uint8_t` keys & dispatch branch (Phase 2) | 1 / 2 |
+| `src/web_server.cpp` | call `homeAssistant.addStatusFields(doc)` in `buildStatus()` | 1 |
+| `src/mqtt.cpp` | gate solar/grid/live-pwr subscriptions on `*_data_src == 0` | 2 |
+| `test/test_ha_oauth/test_ha_oauth.cpp` | native cases for `ha_parse_bool` + string filtering | 1 |

--- a/platformio.ini
+++ b/platformio.ini
@@ -518,3 +518,14 @@ build_flags =
 #upload_protocol = custom
 #upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update
 build_type = debug
+
+[env:native]
+; Host-side unit tests for the pure Home Assistant OAuth logic (src/ha_oauth.cpp).
+; Run with: pio test -e native
+platform = native
+framework =
+test_framework = doctest
+test_build_src = true
+build_src_filter = -<*> +<ha_oauth.cpp>
+build_flags = -std=gnu++17
+lib_deps = bblanchon/ArduinoJson@6.20.1

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -16,6 +16,7 @@
 #include "mqtt.h"
 #include "ocpp.h"
 #include "tesla_client.h"
+#include "home_assistant.h"
 #include "emoncms.h"
 #include "input.h"
 #include "LedManagerTask.h"
@@ -113,6 +114,26 @@ uint64_t tesla_created_at;
 uint64_t tesla_expires_in;
 
 String tesla_vehicle_id;
+
+// Home Assistant settings
+String ha_url;
+String ha_access_token;
+String ha_refresh_token;
+uint64_t ha_token_expires;
+String ha_client_id;
+String ha_vehicle_soc;
+String ha_vehicle_range;
+String ha_vehicle_eta;
+String ha_vehicle_charge_limit;
+String ha_vehicle_plugged;
+String ha_vehicle_charging_state;
+String ha_battery_soc;
+String ha_battery_power;
+uint8_t divert_data_src;
+uint8_t shaper_data_src;
+String ha_solar;
+String ha_grid_ie;
+String ha_live_pwr;
 
 // Vehicle
 uint8_t vehicle_data_src;
@@ -225,6 +246,27 @@ ConfigOpt *opts[] =
   new ConfigOptDefinition<uint64_t>(tesla_created_at, -1, "tesla_created_at", "tc"),
   new ConfigOptDefinition<uint64_t>(tesla_expires_in, -1, "tesla_expires_in", "tx"),
   new ConfigOptDefinition<String>(tesla_vehicle_id, "", "tesla_vehicle_id", "ti"),
+
+// Home Assistant settings
+  new ConfigOptDefinition<String>(ha_url, "", "ha_url", "hau"),
+  new ConfigOptSecret(ha_access_token, "", "ha_access_token", "haa"),
+  new ConfigOptSecret(ha_refresh_token, "", "ha_refresh_token", "har"),
+  new ConfigOptDefinition<uint64_t>(ha_token_expires, 0, "ha_token_expires", "hax"),
+  new ConfigOptDefinition<String>(ha_client_id, "", "ha_client_id", "hac"),
+  new ConfigOptDefinition<String>(ha_vehicle_soc, "", "ha_vehicle_soc", "hvs"),
+  new ConfigOptDefinition<String>(ha_vehicle_range, "", "ha_vehicle_range", "hvr"),
+  new ConfigOptDefinition<String>(ha_vehicle_eta, "", "ha_vehicle_eta", "hve"),
+  new ConfigOptDefinition<String>(ha_vehicle_charge_limit, "", "ha_vehicle_charge_limit", "hvc"),
+  new ConfigOptDefinition<String>(ha_vehicle_plugged, "", "ha_vehicle_plugged", "hvp"),
+  new ConfigOptDefinition<String>(ha_vehicle_charging_state, "", "ha_vehicle_charging_state", "hvg"),
+  new ConfigOptDefinition<String>(ha_battery_soc, "", "ha_battery_soc", "hbs"),
+  new ConfigOptDefinition<String>(ha_battery_power, "", "ha_battery_power", "hbp"),
+  new ConfigOptDefinition<uint8_t>(divert_data_src, 0, "divert_data_src", "dvs"),
+  new ConfigOptDefinition<uint8_t>(shaper_data_src, 0, "shaper_data_src", "shs"),
+  new ConfigOptDefinition<String>(ha_solar, "", "ha_solar", "hso"),
+  new ConfigOptDefinition<String>(ha_grid_ie, "", "ha_grid_ie", "hgi"),
+  new ConfigOptDefinition<String>(ha_live_pwr, "", "ha_live_pwr", "hlp"),
+  new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_HOMEASSISTANT, CONFIG_SERVICE_HOMEASSISTANT, "home_assistant_enabled", "hae"),
 
 // RFID storage
   new ConfigOptDefinition<String>(rfid_storage, "", "rfid_storage", "rs"),
@@ -388,6 +430,9 @@ void config_changed(String name)
     teslaClient.setVehicleId(tesla_vehicle_id);
   } else if(name.startsWith("tesla_")) {
     teslaClient.setCredentials(tesla_access_token, tesla_refresh_token, tesla_created_at, tesla_expires_in);
+  } else if(name.startsWith("ha_") || name == "home_assistant_enabled" || name == "vehicle_data_src"
+            || name == "divert_data_src" || name == "shaper_data_src") {
+    homeAssistant.notifyConfigChanged();
 #if RGB_LED
   } else if(name == "led_brightness") {
     ledManager.setBrightness(led_brightness);

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -74,6 +74,21 @@ extern String ocpp_idtag;
 // RFID storage
 extern String rfid_storage;
 
+// Home Assistant settings
+extern String ha_url;
+extern String ha_access_token;
+extern String ha_refresh_token;
+extern uint64_t ha_token_expires;
+extern String ha_client_id;
+extern String ha_vehicle_soc;
+extern String ha_vehicle_range;
+extern String ha_vehicle_eta;
+extern String ha_vehicle_charge_limit;
+extern String ha_vehicle_plugged;
+extern String ha_vehicle_charging_state;
+extern String ha_battery_soc;
+extern String ha_battery_power;
+
 // Time
 extern String time_zone;
 
@@ -100,8 +115,21 @@ enum vehicle_data_src {
   VEHICLE_DATA_SRC_NONE,
   VEHICLE_DATA_SRC_TESLA,
   VEHICLE_DATA_SRC_MQTT,
-  VEHICLE_DATA_SRC_HTTP
+  VEHICLE_DATA_SRC_HTTP,
+  VEHICLE_DATA_SRC_HOMEASSISTANT
 };
+
+// Per-feature data source for divert/shaper feeds (solar, grid, live power).
+enum data_src {
+  DATA_SRC_MQTT = 0,          // default: MQTT topic (existing behavior)
+  DATA_SRC_HOMEASSISTANT = 1, // poll a Home Assistant entity instead
+};
+
+extern uint8_t divert_data_src;
+extern uint8_t shaper_data_src;
+extern String ha_solar;
+extern String ha_grid_ie;
+extern String ha_live_pwr;
 
 // 24-bits of Flags
 extern uint32_t flags;
@@ -129,6 +157,9 @@ extern uint32_t flags;
 #define CONFIG_THREEPHASE           (1 << 24)
 #define CONFIG_WIZARD               (1 << 25)
 #define CONFIG_DEFAULT_STATE        (1 << 26)
+// NOTE: bit 27 is also claimed by CONFIG_TEMP_THROTTLE in the separate energy
+// PR (#1094); to be deduplicated at merge.
+#define CONFIG_SERVICE_HOMEASSISTANT (1 << 27)
 
 #define INITIAL_CONFIG_VERSION  1
 
@@ -186,6 +217,10 @@ inline bool config_divert_enabled() {
 
 inline bool config_current_shaper_enabled() {
   return CONFIG_SERVICE_CUR_SHAPER == (flags & CONFIG_SERVICE_CUR_SHAPER);
+}
+
+inline bool config_home_assistant_enabled() {
+  return CONFIG_SERVICE_HOMEASSISTANT == (flags & CONFIG_SERVICE_HOMEASSISTANT);
 }
 
 inline uint8_t config_charge_mode() {

--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -133,7 +133,8 @@ EvseManager::EvseManager(Stream &port, EventLog &eventLog) :
   _vehicleLastUpdated(0),
   _vehicleStateOfCharge(0),
   _vehicleRange(0),
-  _vehicleEta(0)
+  _vehicleEta(0),
+  _vehicleChargeLimit(0)
 {
 }
 
@@ -601,6 +602,15 @@ void EvseManager::setVehicleEta(int vehicleEta)
   _vehicleEta = vehicleEta;
   _vehicleValid |= EVSE_VEHICLE_ETA;
   _vehicleUpdated |= EVSE_VEHICLE_ETA;
+  _vehicleLastUpdated = millis();
+  MicroTask.wakeTask(this);
+}
+
+void EvseManager::setVehicleChargeLimit(int vehicleChargeLimit)
+{
+  _vehicleChargeLimit = vehicleChargeLimit;
+  _vehicleValid |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleUpdated |= EVSE_VEHICLE_CHARGE_LIMIT;
   _vehicleLastUpdated = millis();
   MicroTask.wakeTask(this);
 }

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -58,6 +58,7 @@ typedef uint32_t EvseClient;
 #define EVSE_VEHICLE_SOC    (1 << 0)
 #define EVSE_VEHICLE_RANGE  (1 << 1)
 #define EVSE_VEHICLE_ETA    (1 << 2)
+#define EVSE_VEHICLE_CHARGE_LIMIT (1 << 3)
 
 #ifndef EVSE_MANAGER_MAX_CLIENT_CLAIMS
 #define EVSE_MANAGER_MAX_CLIENT_CLAIMS 10
@@ -242,6 +243,7 @@ class EvseManager : public MicroTasks::Task
     int _vehicleStateOfCharge;
     int _vehicleRange;
     int _vehicleEta;
+    int _vehicleChargeLimit;
 
     void initialiseEvse();
     bool findClaim(EvseClient client, Claim **claim = NULL);
@@ -471,6 +473,9 @@ class EvseManager : public MicroTasks::Task
     int getVehicleEta() {
       return _vehicleEta;
     }
+    int getVehicleChargeLimit() {
+      return _vehicleChargeLimit;
+    }
     uint32_t getVehicleLastUpdated() {
       return _vehicleLastUpdated;
     }
@@ -483,9 +488,13 @@ class EvseManager : public MicroTasks::Task
     int isVehicleEtaValid() {
       return 0 != (_vehicleValid & EVSE_VEHICLE_ETA);
     }
+    int isVehicleChargeLimitValid() {
+      return 0 != (_vehicleValid & EVSE_VEHICLE_CHARGE_LIMIT);
+    }
     void setVehicleStateOfCharge(int vehicleStateOfCharge);
     void setVehicleRange(int vehicleRange);
     void setVehicleEta(int vehicleEta);
+    void setVehicleChargeLimit(int vehicleChargeLimit);
 
     // Get/set the 'disabled' mode
     bool isSleepForDisable() {

--- a/src/ha_oauth.cpp
+++ b/src/ha_oauth.cpp
@@ -1,0 +1,135 @@
+#include "ha_oauth.h"
+#include <ArduinoJson.h>
+#include <cctype>
+
+std::string ha_url_encode(const std::string &in) {
+  static const char *hex = "0123456789ABCDEF";
+  auto is_unreserved = [](unsigned char c) {
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+           c == '.' || c == '~';
+  };
+  std::string out;
+  out.reserve(in.size() * 3);
+  for (unsigned char c : in) {
+    if (is_unreserved(c)) {
+      out += (char)c;
+    } else {
+      out += '%';
+      out += hex[(c >> 4) & 0xF];
+      out += hex[c & 0xF];
+    }
+  }
+  return out;
+}
+
+std::string ha_derive_base_url(const std::string &scheme, const std::string &host) {
+  std::string s = scheme.empty() ? "http" : scheme;
+  std::string h = host;
+  // strip any trailing slash on host (defensive)
+  while (!h.empty() && h.back() == '/') h.pop_back();
+  return s + "://" + h;
+}
+
+std::string ha_build_redirect_uri(const std::string &base_url) {
+  return base_url + "/ha_callback";
+}
+
+std::string ha_build_authorize_url(const std::string &ha_url,
+                                   const std::string &client_id,
+                                   const std::string &redirect_uri,
+                                   const std::string &state) {
+  std::string base = ha_url;
+  while (!base.empty() && base.back() == '/') base.pop_back();
+  std::string url = base + "/auth/authorize";
+  url += "?response_type=code";
+  url += "&client_id=" + ha_url_encode(client_id);
+  url += "&redirect_uri=" + ha_url_encode(redirect_uri);
+  url += "&state=" + ha_url_encode(state);
+  return url;
+}
+
+std::string ha_build_token_exchange_body(const std::string &client_id,
+                                         const std::string &code) {
+  std::string b = "grant_type=authorization_code";
+  b += "&code=" + ha_url_encode(code);
+  b += "&client_id=" + ha_url_encode(client_id);
+  return b;
+}
+
+std::string ha_build_refresh_body(const std::string &client_id,
+                                  const std::string &refresh_token) {
+  std::string b = "grant_type=refresh_token";
+  b += "&refresh_token=" + ha_url_encode(refresh_token);
+  b += "&client_id=" + ha_url_encode(client_id);
+  return b;
+}
+
+bool ha_parse_token_response(const std::string &json, HaTokens &out) {
+  StaticJsonDocument<512> doc;
+  DeserializationError err = deserializeJson(doc, json);
+  if (err) {
+    return false;
+  }
+  if (!doc["access_token"].is<const char *>()) {
+    return false;
+  }
+  out.access_token = doc["access_token"].as<const char *>();
+  if (doc["refresh_token"].is<const char *>()) {
+    out.refresh_token = doc["refresh_token"].as<const char *>();
+  } else {
+    out.refresh_token.clear();
+  }
+  out.expires_in = doc["expires_in"] | 0L;
+  return true;
+}
+
+uint64_t ha_compute_expiry(uint64_t now_unix, long expires_in) {
+  if (expires_in <= 0) return 0;
+  return now_unix + (uint64_t)expires_in;
+}
+
+bool ha_refresh_due(uint64_t expiry_unix, uint64_t now_unix, uint64_t margin_sec) {
+  if (expiry_unix == 0) return true; // unknown expiry -> refresh
+  uint64_t threshold = (expiry_unix > margin_sec) ? (expiry_unix - margin_sec) : 0;
+  return now_unix >= threshold;
+}
+
+bool ha_parse_entity_state(const std::string &json, std::string &out) {
+  // Filter so only "state" is materialized — entity `attributes` can be large.
+  StaticJsonDocument<32> filter;
+  filter["state"] = true;
+  // 384 bytes covers the HA-spec max 255-char state value plus object overhead on
+  // both 32-bit (ESP32) and 64-bit (native test). The filter keeps `attributes` out.
+  StaticJsonDocument<384> doc;
+  if (deserializeJson(doc, json, DeserializationOption::Filter(filter))) {
+    return false;
+  }
+  if (!doc["state"].is<const char *>()) {
+    return false;
+  }
+  std::string s = doc["state"].as<const char *>();
+  if (s.empty() || s == "unknown" || s == "unavailable") {
+    return false;
+  }
+  out = s;
+  return true;
+}
+
+bool ha_parse_bool(const std::string &state, bool &out) {
+  std::string s;
+  s.reserve(state.size());
+  for (char c : state) s += (char)tolower((unsigned char)c);
+
+  if (s == "on" || s == "true" || s == "1" || s == "home" ||
+      s == "open" || s == "yes" || s == "plugged" || s == "connected") {
+    out = true;
+    return true;
+  }
+  if (s == "off" || s == "false" || s == "0" || s == "not_home" ||
+      s == "closed" || s == "no" || s == "unplugged" || s == "disconnected") {
+    out = false;
+    return true;
+  }
+  return false;
+}

--- a/src/ha_oauth.h
+++ b/src/ha_oauth.h
@@ -1,0 +1,63 @@
+#ifndef HA_OAUTH_H
+#define HA_OAUTH_H
+
+#include <string>
+#include <cstdint>
+
+// Parsed token response from HA's /auth/token endpoint.
+struct HaTokens {
+  std::string access_token;
+  std::string refresh_token;
+  long expires_in = 0; // seconds
+};
+
+// Percent-encode a string for use in a URL query value.
+std::string ha_url_encode(const std::string &in);
+
+// Build "<scheme>://<host>" with no trailing slash.
+// host is the raw HTTP Host header value (may include :port).
+std::string ha_derive_base_url(const std::string &scheme, const std::string &host);
+
+// base_url + "/ha_callback"
+std::string ha_build_redirect_uri(const std::string &base_url);
+
+// HA authorize URL:
+//   <ha_url>/auth/authorize?response_type=code&client_id=..&redirect_uri=..&state=..
+std::string ha_build_authorize_url(const std::string &ha_url,
+                                   const std::string &client_id,
+                                   const std::string &redirect_uri,
+                                   const std::string &state);
+
+// x-www-form-urlencoded body for grant_type=authorization_code.
+std::string ha_build_token_exchange_body(const std::string &client_id,
+                                         const std::string &code);
+
+// x-www-form-urlencoded body for grant_type=refresh_token.
+std::string ha_build_refresh_body(const std::string &client_id,
+                                  const std::string &refresh_token);
+
+// Parse the /auth/token JSON response. Returns true on success
+// (access_token and expires_in present); refresh_token may be empty on refresh.
+bool ha_parse_token_response(const std::string &json, HaTokens &out);
+
+// Extract the `.state` string from a Home Assistant /api/states/<entity> JSON
+// response. Returns false if the body doesn't parse, `state` is missing/non-string,
+// or it is empty / "unknown" / "unavailable". Uses an ArduinoJson filter so it is
+// memory-safe regardless of how large the entity's `attributes` object is.
+bool ha_parse_entity_state(const std::string &json, std::string &out);
+
+// Map a Home Assistant state string (e.g. a binary_sensor's "on"/"off") to a bool.
+// Case-insensitive. Truthy: on/true/1/home/open/yes/plugged/connected.
+// Falsey: off/false/0/not_home/closed/no/unplugged/disconnected. Returns false (and
+// leaves `out` untouched) for any other state, so callers skip it and keep the last
+// good value. NB: plugged/connected/unplugged/disconnected are convenience tokens, not
+// standard HA binary_sensor states (which are on/off) -- a caller may pass either.
+bool ha_parse_bool(const std::string &state, bool &out);
+
+// Absolute expiry = now_unix + expires_in (0 if expires_in <= 0).
+uint64_t ha_compute_expiry(uint64_t now_unix, long expires_in);
+
+// True if the token should be refreshed: now_unix >= expiry_unix - margin_sec.
+bool ha_refresh_due(uint64_t expiry_unix, uint64_t now_unix, uint64_t margin_sec);
+
+#endif // HA_OAUTH_H

--- a/src/home_assistant.cpp
+++ b/src/home_assistant.cpp
@@ -1,0 +1,486 @@
+#if defined(ENABLE_DEBUG) && !defined(ENABLE_DEBUG_HOME_ASSISTANT)
+#undef ENABLE_DEBUG
+#endif
+
+#include <Arduino.h>
+#include <stdlib.h>
+#include <time.h>
+#include <esp_random.h>
+
+#include "home_assistant.h"
+#include "app_config.h"
+#include "debug.h"
+#include "event.h"
+#include <math.h>      // lround
+#include "input.h"     // global EvseManager `evse`
+#include "divert.h"          // global `solar`/`grid_ie` ints + `divert`; DIVERT_TYPE_*
+#include "current_shaper.h"  // global `shaper`
+
+#define HA_PENDING_STATE_TTL_MS   (5 * 60 * 1000UL)
+#define HA_REFRESH_MARGIN_SEC     300
+#define HA_REFRESH_RETRY_MS       (60 * 1000UL)
+#define HA_REFRESH_TIMEOUT_MS     (30 * 1000UL)     // clear a stuck in-flight refresh
+#define HA_LOOP_INTERVAL_MS       (30 * 1000UL)
+#define HA_POLL_MS                (30 * 1000UL)   // poll HA entities every 30 s
+#define HA_POLL_TIMEOUT_MS        (30 * 1000UL)   // clear a stuck poll chain
+
+enum HaValueType { HA_NUMERIC, HA_BOOL, HA_STRING };
+
+enum HaSink {
+  SINK_VEHICLE_SOC = 0,
+  SINK_VEHICLE_RANGE,
+  SINK_VEHICLE_ETA,
+  SINK_VEHICLE_CHARGE_LIMIT,
+  SINK_VEHICLE_PLUGGED,
+  SINK_VEHICLE_CHARGING_STATE,
+  SINK_HOME_BATTERY_SOC,
+  SINK_HOME_BATTERY_POWER,
+  SINK_SOLAR,
+  SINK_GRID_IE,
+  SINK_SHAPER_LIVE_PWR,
+};
+
+struct HaPollEntry {
+  const String *entity;   // config string; empty => skip
+  bool (*gate)();         // is this row active right now?
+  int  type;              // HaValueType
+  int  sinkId;            // HaSink
+};
+
+static bool gateVehicleHA() {
+  return vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT;
+}
+
+// Home-battery feeds poll whenever the entity is configured; the loop already
+// gates on isConnected(), which implies HA is enabled and authorized.
+static bool gateAlways() { return true; }
+
+// Control-path feeds mirror the MQTT subscription conditions: only active when the
+// feature is enabled, the source is HA, and (for divert) the divert type matches.
+static bool gateSolarHA() {
+  return config_divert_enabled() && divert_data_src == DATA_SRC_HOMEASSISTANT
+         && divert_type == DIVERT_TYPE_SOLAR;
+}
+static bool gateGridHA() {
+  return config_divert_enabled() && divert_data_src == DATA_SRC_HOMEASSISTANT
+         && divert_type == DIVERT_TYPE_GRID;
+}
+static bool gateShaperHA() {
+  return config_current_shaper_enabled() && shaper_data_src == DATA_SRC_HOMEASSISTANT;
+}
+
+static const HaPollEntry HA_POLL_TABLE[] = {
+  { &ha_vehicle_soc,             gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_SOC },
+  { &ha_vehicle_range,           gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_RANGE },
+  { &ha_vehicle_eta,             gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_ETA },
+  { &ha_vehicle_charge_limit,    gateVehicleHA, HA_NUMERIC, SINK_VEHICLE_CHARGE_LIMIT },
+  { &ha_vehicle_plugged,         gateVehicleHA, HA_BOOL,    SINK_VEHICLE_PLUGGED },
+  { &ha_vehicle_charging_state,  gateVehicleHA, HA_STRING,  SINK_VEHICLE_CHARGING_STATE },
+  { &ha_battery_soc,             gateAlways,    HA_NUMERIC, SINK_HOME_BATTERY_SOC },
+  { &ha_battery_power,           gateAlways,    HA_NUMERIC, SINK_HOME_BATTERY_POWER },
+  { &ha_solar,    gateSolarHA,  HA_NUMERIC, SINK_SOLAR },
+  { &ha_grid_ie,  gateGridHA,   HA_NUMERIC, SINK_GRID_IE },
+  { &ha_live_pwr, gateShaperHA, HA_NUMERIC, SINK_SHAPER_LIVE_PWR },
+};
+static const int HA_POLL_TABLE_LEN = sizeof(HA_POLL_TABLE) / sizeof(HA_POLL_TABLE[0]);
+
+HomeAssistantClient homeAssistant;
+
+static uint64_t ha_now_unix() {
+  time_t now = time(nullptr);
+  return (now > 0) ? (uint64_t)now : 0;
+}
+
+HomeAssistantClient::HomeAssistantClient() :
+  MicroTasks::Task(),
+  _pendingStateTime(0),
+  _refreshInFlight(false),
+  _lastRefreshAttempt(0),
+  _lastPoll(0),
+  _pollInFlight(false),
+  _pollStart(0)
+{
+}
+
+void HomeAssistantClient::begin() {
+  MicroTask.startTask(this);
+}
+
+void HomeAssistantClient::setup() {
+}
+
+bool HomeAssistantClient::isConnected() {
+  if (!config_home_assistant_enabled()) return false;
+  // Connected once OAuth is complete: a refresh token means the session exists;
+  // the background refresh loop keeps the access token current.
+  return ha_refresh_token.length() > 0;
+}
+
+void HomeAssistantClient::getStatus(JsonDocument &doc) {
+  doc["enabled"] = config_home_assistant_enabled();
+  doc["connected"] = isConnected();
+  doc["ha_url"] = ha_url;
+  doc["expires"] = ha_token_expires;
+}
+
+void HomeAssistantClient::addStatusFields(JsonDocument &doc) {
+  if (_homeBatterySocValid)   doc["home_battery_soc"] = _homeBatterySoc;
+  if (_homeBatteryPowerValid) doc["home_battery_power"] = _homeBatteryPower;
+  // Vehicle extras only while HA is the selected vehicle data source -- avoids
+  // emitting stale plugged/charging values after the source switches away.
+  if (vehicle_data_src == VEHICLE_DATA_SRC_HOMEASSISTANT) {
+    if (_vehiclePluggedValid)   doc["vehicle_plugged"] = _vehiclePlugged;
+    if (_vehicleChargingState.length() > 0)
+      doc["vehicle_charging_state"] = _vehicleChargingState;
+  }
+}
+
+void HomeAssistantClient::notifyConfigChanged() {
+  MicroTask.wakeTask(this);
+}
+
+void HomeAssistantClient::disconnect() {
+  ha_access_token = "";
+  ha_refresh_token = "";
+  ha_token_expires = 0;
+  _pendingStateTime = 0;
+  _pendingState = "";
+  _pendingClientId = "";
+  _homeBatterySocValid = false;
+  _homeBatteryPowerValid = false;
+  _vehiclePluggedValid = false;
+  _vehicleChargingState = "";
+  // Disconnecting turns the integration off too, so isConnected() reads false.
+  config_set("home_assistant_enabled", false);
+  config_commit();
+  StaticJsonDocument<128> ev;
+  ev["home_assistant"] = "disconnected";
+  event_send(ev);
+}
+
+unsigned long HomeAssistantClient::loop(MicroTasks::WakeReason reason) {
+  if (_pendingStateTime != 0 &&
+      (millis() - _pendingStateTime) > HA_PENDING_STATE_TTL_MS) {
+    _pendingStateTime = 0;
+    _pendingState = "";
+    _pendingClientId = "";
+  }
+  // Recover if a refresh request never completed (e.g. connect failed and no
+  // onResponse fired) -- otherwise _refreshInFlight would block refresh forever.
+  if (_refreshInFlight && _lastRefreshAttempt != 0 &&
+      (millis() - _lastRefreshAttempt) > HA_REFRESH_TIMEOUT_MS) {
+    DBUGLN("[ha] refresh timed out, clearing in-flight flag");
+    _refreshInFlight = false;
+  }
+
+  if (config_home_assistant_enabled() && ha_refresh_token.length() > 0 && !_refreshInFlight) {
+    bool due = ha_refresh_due(ha_token_expires, ha_now_unix(), HA_REFRESH_MARGIN_SEC);
+    bool backoffElapsed = (millis() - _lastRefreshAttempt) > HA_REFRESH_RETRY_MS;
+    if (due && (_lastRefreshAttempt == 0 || backoffElapsed)) {
+      refreshTokens();
+    }
+  }
+
+  // Recover a stuck poll chain (a request that never completed and no onResponse
+  // fired) -- otherwise _pollInFlight would block polling forever.
+  if (_pollInFlight && _pollStart != 0 &&
+      (millis() - _pollStart) > HA_POLL_TIMEOUT_MS) {
+    DBUGLN("[ha] poll chain timed out, clearing in-flight flag");
+    _pollInFlight = false;
+  }
+
+  // Poll HA entities when connected and at least one configured feed selects HA.
+  if (isConnected()
+      && anyPollActive()
+      && !_pollInFlight
+      && (_lastPoll == 0 || (millis() - _lastPoll) >= HA_POLL_MS)) {
+    _lastPoll = millis();
+    if (_lastPoll == 0) _lastPoll = 1; // 0 means "never polled"
+    _pollInFlight = true;
+    _pollStart = millis();
+    pollNext(0);
+  }
+
+  return HA_LOOP_INTERVAL_MS;
+}
+
+// --- flow methods implemented in Tasks 8 & 9 ---
+String HomeAssistantClient::beginAuthorize(const String &host, bool secure) {
+  if (ha_url.length() == 0 || host.length() == 0) {
+    return "";
+  }
+
+  std::string scheme = secure ? "https" : "http";
+  std::string base = ha_derive_base_url(scheme, std::string(host.c_str()));
+  std::string clientId = base + "/";
+  std::string redirectUri = ha_build_redirect_uri(base);
+
+  // 16 hex chars of CSRF state from the HW RNG.
+  char stateBuf[17];
+  for (int i = 0; i < 16; i++) {
+    stateBuf[i] = "0123456789abcdef"[esp_random() & 0xF];
+  }
+  stateBuf[16] = '\0';
+
+  _pendingState = stateBuf;
+  _pendingClientId = clientId.c_str();
+  _pendingStateTime = millis();
+  if (_pendingStateTime == 0) _pendingStateTime = 1; // 0 means "none"; millis()==0 at boot/wrap is a benign miss
+
+  // Persist the client_id so token refresh can replay it after a reboot
+  // (it is derived from the device Host, which we don't otherwise know later).
+  ha_client_id = clientId.c_str();
+  config_commit();
+
+  std::string url = ha_build_authorize_url(
+      std::string(ha_url.c_str()), clientId, redirectUri, _pendingState.c_str());
+  return String(url.c_str());
+}
+
+bool HomeAssistantClient::handleCallback(const String &code, const String &state, String &error) {
+  if (_pendingStateTime == 0) {
+    error = "no pending authorization";
+    return false;
+  }
+  if (state.length() == 0 || state != _pendingState) {
+    error = "state mismatch";
+    return false;
+  }
+  if (code.length() == 0) {
+    error = "missing code";
+    return false;
+  }
+  // Consume the pending state (single use); keep _pendingClientId for the exchange.
+  _pendingStateTime = 0;
+  _pendingState = "";
+  exchangeCode(code);
+  return true;
+}
+
+void HomeAssistantClient::storeTokens(const HaTokens &t) {
+  ha_access_token = t.access_token.c_str();
+  if (!t.refresh_token.empty()) {
+    ha_refresh_token = t.refresh_token.c_str();
+  }
+  // If NTP isn't synced yet (ha_now_unix()==0), expiry lands near epoch, causing an
+  // immediate re-refresh once the clock syncs -- safe degradation.
+  ha_token_expires = ha_compute_expiry(ha_now_unix(), t.expires_in);
+  // A successful token grant IS the connection -- enable the service so isConnected()
+  // and the refresh loop treat it as active (the user clicked Connect; there is no
+  // separate enable toggle in v1).
+  config_set("home_assistant_enabled", true);
+  config_commit();
+
+  StaticJsonDocument<128> ev;
+  ev["home_assistant"] = "connected";
+  event_send(ev);
+}
+
+void HomeAssistantClient::exchangeCode(const String &code) {
+  if (ha_url.length() == 0 || _pendingClientId.length() == 0) {
+    DBUGLN("[ha] exchangeCode: missing ha_url or client_id");
+    return;
+  }
+  std::string body = ha_build_token_exchange_body(
+      std::string(_pendingClientId.c_str()), std::string(code.c_str()));
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += "/auth/token";
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_POST);
+  req->addHeader("Content-Type", "application/x-www-form-urlencoded");
+  // Safe: send() -> mg_connect_http_opt() copies the body into the connection's
+  // send buffer synchronously, while `body` is still in scope here.
+  req->setContent((const uint8_t *)body.c_str(), body.length());
+  req->onResponse([this](MongooseHttpClientResponse *response) {
+    if (response->respCode() == 200) {
+      HaTokens t;
+      MongooseString respBody = response->body();
+      std::string json((const char *)respBody, respBody.length());
+      if (ha_parse_token_response(json, t)) {
+        storeTokens(t);
+        return;
+      }
+    }
+    StaticJsonDocument<128> ev;
+    ev["home_assistant"] = "error";
+    ev["home_assistant_error"] = "token exchange failed";
+    event_send(ev);
+  });
+  _client.send(req);
+}
+
+void HomeAssistantClient::refreshTokens() {
+  if (_refreshInFlight) return;
+  if (ha_url.length() == 0 || ha_refresh_token.length() == 0) return;
+  if (ha_client_id.length() == 0) return; // never authorized
+
+  _refreshInFlight = true;
+  _lastRefreshAttempt = millis();
+
+  std::string clientId = std::string(ha_client_id.c_str());
+  std::string body = ha_build_refresh_body(clientId, std::string(ha_refresh_token.c_str()));
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += "/auth/token";
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_POST);
+  req->addHeader("Content-Type", "application/x-www-form-urlencoded");
+  // Safe: send() -> mg_connect_http_opt() copies the body synchronously while `body` is in scope.
+  req->setContent((const uint8_t *)body.c_str(), body.length());
+  req->onResponse([this](MongooseHttpClientResponse *response) {
+    _refreshInFlight = false;
+    if (response->respCode() == 200) {
+      HaTokens t;
+      MongooseString respBody = response->body();
+      std::string json((const char *)respBody, respBody.length());
+      if (ha_parse_token_response(json, t)) {
+        storeTokens(t);
+        return;
+      }
+    }
+    DBUGF("[ha] refresh response: %d", response->respCode());
+    if (response->respCode() == 400) {
+      // invalid_grant: refresh token revoked -> disconnect.
+      disconnect();
+    }
+    // transient errors: leave tokens; loop() retries after backoff.
+  });
+  _client.send(req);
+}
+
+bool HomeAssistantClient::get(const String &path, MongooseHttpResponseHandler onResponse) {
+  if (!isConnected() || ha_url.length() == 0) return false;
+
+  // Don't send a token that's at/near expiry -- HA would reject it and log an
+  // invalid-auth attempt. Skip the request; loop() refreshes when due.
+  if (ha_refresh_due(ha_token_expires, ha_now_unix(), HA_REFRESH_MARGIN_SEC)) {
+    DBUGLN("[ha] get() skipped: token refresh due");
+    return false;
+  }
+
+  String uri = ha_url;
+  while (uri.endsWith("/")) uri.remove(uri.length() - 1);
+  uri += path; // caller passes a leading-slash path, e.g. "/api/states/sensor.x"
+
+  String bearer = "Bearer ";
+  bearer += ha_access_token;
+
+  MongooseHttpClientRequest *req = _client.beginRequest(uri.c_str());
+  req->setMethod(HTTP_GET);
+  req->addHeader("Authorization", bearer.c_str());
+  req->addHeader("Accept", "application/json");
+  req->onResponse(onResponse);
+  _client.send(req);
+  return true;
+}
+
+bool HomeAssistantClient::anyPollActive() {
+  for (int i = 0; i < HA_POLL_TABLE_LEN; i++) {
+    const HaPollEntry &e = HA_POLL_TABLE[i];
+    if (e.entity->length() > 0 && e.gate()) return true;
+  }
+  return false;
+}
+
+// Apply one parsed entity state to its sink, dispatched by sinkId.
+void HomeAssistantClient::applyEntity(int sinkId, int type, const String &state) {
+  if (type == HA_NUMERIC) {
+    char *endp = nullptr;
+    double v = strtod(state.c_str(), &endp);
+    if (endp == state.c_str()) {
+      DBUGF("[ha] sink %d: non-numeric state, skipping", sinkId);
+      return;
+    }
+    switch (sinkId) {
+      case SINK_VEHICLE_SOC:          evse.setVehicleStateOfCharge((int)lround(v)); break;
+      case SINK_VEHICLE_RANGE:        evse.setVehicleRange((int)lround(v));         break;
+      case SINK_VEHICLE_ETA:          evse.setVehicleEta((int)lround(v));           break; // seconds
+      case SINK_VEHICLE_CHARGE_LIMIT: evse.setVehicleChargeLimit((int)lround(v));   break;
+      case SINK_HOME_BATTERY_SOC:
+        _homeBatterySoc = (int)lround(v); _homeBatterySocValid = true; break;
+      case SINK_HOME_BATTERY_POWER:
+        _homeBatteryPower = (int)lround(v); _homeBatteryPowerValid = true; break;
+      case SINK_SOLAR:
+        // solar is a direct shaper input, so recompute immediately (mirrors mqtt.cpp).
+        // grid_ie is not, and live power arrives via SINK_SHAPER_LIVE_PWR's own row,
+        // so SINK_GRID_IE deliberately does not call shapeCurrent().
+        solar = (int)lround(v);
+        divert.update_state();
+        if (shaper.getState()) shaper.shapeCurrent();
+        break;
+      case SINK_GRID_IE:
+        grid_ie = (int)lround(v);
+        divert.update_state();
+        break;
+      case SINK_SHAPER_LIVE_PWR:
+        shaper.setLivePwr((int)lround(v));
+        break;
+      default: break;
+    }
+  } else if (type == HA_BOOL) {
+    bool b;
+    if (!ha_parse_bool(std::string(state.c_str()), b)) {
+      DBUGF("[ha] sink %d: unrecognized bool state, skipping", sinkId);
+      return;
+    }
+    switch (sinkId) {
+      case SINK_VEHICLE_PLUGGED: _vehiclePlugged = b; _vehiclePluggedValid = true; break;
+      default: break;
+    }
+  } else if (type == HA_STRING) {
+    // ha_parse_entity_state already rejected ""/unavailable/unknown, so `state` is real.
+    switch (sinkId) {
+      case SINK_VEHICLE_CHARGING_STATE: _vehicleChargingState = state; break;
+      default: break;
+    }
+  } else {
+    DBUGF("[ha] sink %d: unknown value type %d (bug)", sinkId, type);
+  }
+}
+
+// Fetch one active+configured entity, apply it, then chain to the next. Sequential
+// (one in-flight request at a time) to stay safe on the shared MongooseHttpClient.
+// An empty entity, inactive gate, failed request, or unparseable state simply skips
+// that row (keeps the last good value).
+void HomeAssistantClient::pollNext(int index) {
+  for (int i = index; i < HA_POLL_TABLE_LEN; i++) {
+    const HaPollEntry &e = HA_POLL_TABLE[i];
+    if (e.entity->length() == 0 || !e.gate()) {
+      continue; // not configured / not active -> skip
+    }
+
+    String path = "/api/states/" + *e.entity; // entity IDs are URL-safe (sensor.x_y)
+    int next = i + 1;
+    int sinkId = e.sinkId;
+    int type = e.type;
+    bool sent = get(path, [this, sinkId, type, next](MongooseHttpClientResponse *response) {
+      if (response->respCode() == 200) {
+        MongooseString body = response->body();
+        std::string state;
+        if (ha_parse_entity_state(std::string((const char *)body, body.length()), state)) {
+          applyEntity(sinkId, type, String(state.c_str()));
+        } else {
+          DBUGF("[ha] sink %d: state unavailable/unparseable", sinkId);
+        }
+      } else {
+        DBUGF("[ha] sink %d: HTTP %d", sinkId, response->respCode());
+      }
+      pollNext(next); // advance regardless of this row's outcome
+    });
+
+    if (!sent) {
+      // get() declined (refresh due / not connected): onResponse won't fire, so end
+      // the chain now rather than stranding _pollInFlight until the timeout.
+      _pollInFlight = false;
+    }
+    return; // one in-flight request at a time; the callback resumes the walk
+  }
+
+  // Walked off the end with nothing left to send -> chain complete.
+  _pollInFlight = false;
+}

--- a/src/home_assistant.h
+++ b/src/home_assistant.h
@@ -1,0 +1,65 @@
+#ifndef HOME_ASSISTANT_H
+#define HOME_ASSISTANT_H
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+#include <MicroTasks.h>
+#include <MongooseHttpClient.h>
+
+#include "ha_oauth.h"
+
+class HomeAssistantClient : public MicroTasks::Task {
+  public:
+    HomeAssistantClient();
+
+    void begin();
+
+    bool isConnected();
+    void getStatus(JsonDocument &doc);
+    void addStatusFields(JsonDocument &doc); // merge display-only HA values into /status
+
+    String beginAuthorize(const String &host, bool secure);
+    bool handleCallback(const String &code, const String &state, String &error);
+    void disconnect();
+    void notifyConfigChanged();
+
+    // Returns true if the request was dispatched. Returns false (and sends nothing)
+    // when not connected or when a token refresh is due -- callers must not assume
+    // onResponse will fire in that case.
+    bool get(const String &path, MongooseHttpResponseHandler onResponse);
+
+  protected:
+    void setup() override;
+    unsigned long loop(MicroTasks::WakeReason reason) override;
+
+  private:
+    MongooseHttpClient _client;
+
+    String _pendingState;
+    String _pendingClientId;
+    unsigned long _pendingStateTime; // millis() when issued; 0 = none
+
+    bool _refreshInFlight;
+    unsigned long _lastRefreshAttempt;
+    unsigned long _lastPoll;
+    bool _pollInFlight;
+    unsigned long _pollStart;
+
+    // Display-only values polled from HA (omitted from /status until a valid read).
+    int    _homeBatterySoc = 0;       bool _homeBatterySocValid = false;
+    int    _homeBatteryPower = 0;     bool _homeBatteryPowerValid = false;
+    bool   _vehiclePlugged = false;   bool _vehiclePluggedValid = false;
+    String _vehicleChargingState;     // empty => absent
+
+    void exchangeCode(const String &code);
+    void refreshTokens();
+    void storeTokens(const HaTokens &t);
+
+    bool anyPollActive();          // true if at least one table row is active+configured
+    void pollNext(int index);      // walk the poll table from `index`
+    void applyEntity(int sinkId, int type, const String &state);
+};
+
+extern HomeAssistantClient homeAssistant;
+
+#endif // HOME_ASSISTANT_H

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -367,9 +367,15 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
             return LcdInfoLine::BatterySOC;
           }
         case LcdInfoLine::BatterySOC:
+          if(_evse->isVehicleChargeLimitValid()) {
+            return LcdInfoLine::ChargeLimit;
+          }
+          // fall through
+        case LcdInfoLine::ChargeLimit:
           if(_evse->isVehicleRangeValid()) {
             return LcdInfoLine::Range;
           }
+          // fall through
         case LcdInfoLine::Range:
           if(_evse->isVehicleEtaValid()) {
             return LcdInfoLine::TimeLeft;
@@ -563,7 +569,7 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
       break;
 
     case LcdInfoLine::ChargeLimit:
-      // Charge limit 85%
+      displayNumberValue(1, "Charge limit", _evse->getVehicleChargeLimit(), 0, "%");
       break;
 
     case LcdInfoLine::Range:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@
 #include "espal.h"
 #include "time_man.h"
 #include "tesla_client.h"
+#include "home_assistant.h"
 #include "event.h"
 #include "ocpp.h"
 #include "rfid.h"
@@ -183,6 +184,8 @@ void setup()
   input_setup();
 
   mqtt.begin();
+
+  homeAssistant.begin();
 
   ocpp.begin(evse, lcd, eventLog, rfid);
   DBUGF("After ocpp.begin: %d", ESPAL.getFreeHeap());

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -286,8 +286,10 @@ void Mqtt::handleMqttMessage(MongooseString topic, MongooseString payload) {
   DBUGLN("Topic: " + topic_string);
   DBUGLN("Payload: " + payload_str);
 
+  // Solar/grid/live-power are ignored here when sourced from Home Assistant
+  // (the HA poll engine writes them instead); mirrors the vehicle_data_src guard below.
   // Logic from old mqttmsg_callback
-  if (topic_string == mqtt_solar){
+  if (topic_string == mqtt_solar && divert_data_src == DATA_SRC_MQTT) {
     solar = payload_str.toInt();
     DBUGF("solar:%dW", solar);
     divert.update_state();
@@ -295,7 +297,7 @@ void Mqtt::handleMqttMessage(MongooseString topic, MongooseString payload) {
       shaper.shapeCurrent();
     }
   }
-  else if (topic_string == mqtt_grid_ie) {
+  else if (topic_string == mqtt_grid_ie && divert_data_src == DATA_SRC_MQTT) {
     grid_ie = payload_str.toInt();
     DBUGF("grid:%dW", grid_ie);
     divert.update_state();
@@ -303,7 +305,7 @@ void Mqtt::handleMqttMessage(MongooseString topic, MongooseString payload) {
       shaper.setLivePwr(grid_ie);
     }
   }
-  else if (topic_string == mqtt_live_pwr) {
+  else if (topic_string == mqtt_live_pwr && shaper_data_src == DATA_SRC_MQTT) {
       shaper.setLivePwr(payload_str.toInt());
       DBUGF("shaper: Live Pwr:%dW", shaper.getLivePwr());
   }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -41,6 +41,7 @@ typedef const __FlashStringHelper *fstr_t;
 #include "scheduler.h"
 #include "rfid.h"
 #include "current_shaper.h"
+#include "home_assistant.h"
 #include "evse_man.h"
 #include "limit.h"
 
@@ -82,6 +83,11 @@ void handleUpdateClose(MongooseHttpServerRequest *request);
 
 void handleTime(MongooseHttpServerRequest *request);
 void handleTimePost(MongooseHttpServerRequest *request, MongooseHttpServerResponseStream *response);
+
+void handleHomeAssistantAuthStart(MongooseHttpServerRequest *request);
+void handleHomeAssistantCallback(MongooseHttpServerRequest *request);
+void handleHomeAssistantStatus(MongooseHttpServerRequest *request);
+void handleHomeAssistantDisconnect(MongooseHttpServerRequest *request);
 
 void dumpRequest(MongooseHttpServerRequest *request)
 {
@@ -282,7 +288,12 @@ void buildStatus(DynamicJsonDocument &doc) {
     if(evse.isVehicleEtaValid()) {
       doc["time_to_full_charge"] = evse.getVehicleEta();
     }
+    if(evse.isVehicleChargeLimitValid()) {
+      doc["vehicle_charge_limit"] = evse.getVehicleChargeLimit();
+    }
   }
+
+  homeAssistant.addStatusFields(doc);
 
   DBUGF("/status ArduinoJson size: %dbytes", doc.size());
 }
@@ -446,6 +457,10 @@ void handleStatusPost(MongooseHttpServerRequest *request, MongooseHttpServerResp
       DBUGF("voltage:%.1f", volts);
       evse.setVoltage(volts);
     }
+    // NOTE: these solar/grid/live-power pushes intentionally bypass the
+    // divert_data_src/shaper_data_src arbitration. An explicit POST is a deliberate
+    // override by the caller (unlike the MQTT background source, which is muted when
+    // the feed is HA-sourced). There is no DATA_SRC_HTTP for these feeds, by design.
     if(doc.containsKey("shaper_live_pwr"))
     {
       double shaper_live_pwr = doc["shaper_live_pwr"];
@@ -1158,7 +1173,9 @@ void onWsConnect(MongooseHttpWebSocketConnection *connection)
 {
   DBUGF("New client connected over ws");
   // pushing states to client
-  const size_t capacity = JSON_OBJECT_SIZE(40) + 1024;
+  // headroom for the HA display-only fields (home_battery_soc/power,
+  // vehicle_plugged/charging_state) appended at the end of buildStatus().
+  const size_t capacity = JSON_OBJECT_SIZE(48) + 1024;
   DynamicJsonDocument doc(capacity);
   buildStatus(doc);
   web_server_event(doc);
@@ -1225,6 +1242,11 @@ void web_server_setup()
   server.on("/claims", handleEvseClaims);
 
   server.on("/override$", handleOverride);
+
+  server.on("/ha/auth/start$", handleHomeAssistantAuthStart);
+  server.on("/ha_callback", handleHomeAssistantCallback); // no $ anchor: matched against the path only (query stripped); HA appends ?code=&state=
+  server.on("/ha/status$", handleHomeAssistantStatus);
+  server.on("/ha/disconnect$", handleHomeAssistantDisconnect);
 
   server.on("/logs", handleEventLogs);
   server.on("/certificates", handleCertificates);

--- a/src/web_server_home_assistant.cpp
+++ b/src/web_server_home_assistant.cpp
@@ -1,0 +1,119 @@
+#include "emonesp.h"
+#include "web_server.h"
+#include "app_config.h"
+#include "home_assistant.h"
+#include "debug.h"
+
+#include <ArduinoJson.h>
+#include <MongooseHttpServer.h>
+
+// GET /ha/auth/start  -> 302 to HA authorize URL
+// Protected by HTTP basic auth (same as all other endpoints).
+void handleHomeAssistantAuthStart(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, CONTENT_TYPE_HTML)) {
+    return;
+  }
+
+  // request->host() returns MongooseString; .toString() gives String.
+  String host = request->host().toString();
+
+  // MongooseHttpServerRequest has no TLS/secure accessor; default to false.
+  // LAN HTTP is the common case, and this only affects what redirect_uri we advertise.
+  bool secure = false;
+
+  String url = homeAssistant.beginAuthorize(host, secure);
+
+  if (url.length() == 0) {
+    response->setCode(400);
+    response->setContentType(CONTENT_TYPE_JSON);
+    response->print("{\"msg\":\"ha_url not configured\"}");
+    request->send(response);
+    return;
+  }
+
+  // Defense-in-depth: strip CR/LF so a crafted ha_url cannot inject response headers.
+  url.replace("\r", "");
+  url.replace("\n", "");
+
+  // request->redirect() is a no-op stub in this build of ArduinoMongoose.
+  // Use the manual redirect pattern (same as handleHttpsRedirect in web_server.cpp).
+  response->setCode(302);
+  response->addHeader(F("Location"), url);
+  String s = F("<html><head><meta http-equiv=\"Refresh\" content=\"0; url=");
+  s += url;
+  s += F("\" /></head><body><a href=\"");
+  s += url;
+  s += F("\">Redirecting…</a></body></html>");
+  response->print(s);
+  request->send(response);
+  // Ownership transferred to request->send(); do NOT delete response.
+}
+
+// GET /ha_callback?code=..&state=..  -> exchange code for tokens, then redirect to settings.
+// No requestPreProcess/basic-auth: HA's browser redirect cannot carry HTTP credentials.
+// Protected by the unguessable single-use `state` CSRF token.
+void handleHomeAssistantCallback(MongooseHttpServerRequest *request)
+{
+  String code  = request->getParam("code");
+  String state = request->getParam("state");
+
+  String error;
+  bool ok = homeAssistant.handleCallback(code, state, error);
+  if (!ok) {
+    DBUGF("[ha] callback rejected: %s", error.c_str());
+  }
+
+  // Redirect to the settings page with NO query string: the SPA hash router
+  // exact-matches the route ("/settings/home-assistant"), so a "?ha=..." suffix
+  // would land on a non-existent route. The page reflects the real connection
+  // state by polling /ha/status, so no hint is needed here.
+  String dest = F("/#/settings/home-assistant");
+
+  // Manual redirect — same pattern as handleHttpsRedirect.
+  MongooseHttpServerResponseStream *response = request->beginResponseStream();
+  response->setContentType(CONTENT_TYPE_HTML);
+  response->setCode(302);
+  response->addHeader(F("Location"), dest);
+  String s = F("<html><head><meta http-equiv=\"Refresh\" content=\"0; url=");
+  s += dest;
+  s += F("\" /></head><body><a href=\"");
+  s += dest;
+  s += F("\">Redirecting…</a></body></html>");
+  response->print(s);
+  request->send(response);
+}
+
+// GET /ha/status -> {enabled, connected, ha_url, expires_in}
+void handleHomeAssistantStatus(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, CONTENT_TYPE_JSON)) {
+    return;
+  }
+  const size_t capacity = JSON_OBJECT_SIZE(4) + 512;
+  DynamicJsonDocument doc(capacity);
+  homeAssistant.getStatus(doc);
+  serializeJson(doc, *response);
+  request->send(response);
+}
+
+// POST /ha/disconnect -> clear stored tokens and disconnect
+void handleHomeAssistantDisconnect(MongooseHttpServerRequest *request)
+{
+  MongooseHttpServerResponseStream *response;
+  if (false == requestPreProcess(request, response, CONTENT_TYPE_JSON)) {
+    return;
+  }
+  if (HTTP_POST != request->method()) {
+    response->setCode(405);
+    response->setContentType(CONTENT_TYPE_JSON);
+    response->print("{\"msg\":\"Method not allowed\"}");
+    request->send(response);
+    return;
+  }
+  homeAssistant.disconnect();
+  response->print("{\"msg\":\"done\"}");
+  request->send(response);
+}

--- a/test/homeassistant.http
+++ b/test/homeassistant.http
@@ -1,0 +1,29 @@
+# Name: REST Client
+# Id: humao.rest-client
+# Description: REST Client for Visual Studio Code
+# Version: 0.21.3
+# Publisher: Huachao Mao
+# VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=humao.rest-client
+
+# Home Assistant OAuth endpoints — manual integration tests.
+# Set baseUrl and auth via environment variables or edit below (don't check in credentials).
+
+#@baseUrl = http://openevse.local
+
+###
+
+# Get HA connection status
+# Expect: 200 { "enabled": true/false, "connected": true/false, "ha_url": "...", ... }
+GET {{baseUrl}}/ha/status HTTP/1.1
+
+###
+
+# Start OAuth flow — expect: 302 Location: <ha_url>/auth/authorize?client_id=...&state=...
+# Follow the redirect in a browser; HA will redirect back to /ha_callback?code=...&state=...
+GET {{baseUrl}}/ha/auth/start HTTP/1.1
+
+###
+
+# Disconnect (clear stored tokens)
+# Expect: 200 {"msg":"done"}
+POST {{baseUrl}}/ha/disconnect HTTP/1.1

--- a/test/test_ha_oauth/test_ha_oauth.cpp
+++ b/test/test_ha_oauth/test_ha_oauth.cpp
@@ -1,0 +1,149 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "ha_oauth.h"
+
+TEST_CASE("ha_url_encode percent-encodes reserved characters") {
+  CHECK(ha_url_encode("abc-123_.~") == "abc-123_.~");
+  CHECK(ha_url_encode("http://h:8123/") == "http%3A%2F%2Fh%3A8123%2F");
+  CHECK(ha_url_encode("a b") == "a%20b");
+  CHECK(ha_url_encode("\xFF") == "%FF");                 // high byte always encoded
+  CHECK(ha_url_encode("a=1&b=2+3") == "a%3D1%26b%3D2%2B3"); // OAuth param chars
+}
+
+TEST_CASE("ha_derive_base_url joins scheme and host") {
+  CHECK(ha_derive_base_url("http", "openevse.local") == "http://openevse.local");
+  CHECK(ha_derive_base_url("https", "10.0.0.5:443") == "https://10.0.0.5:443");
+  CHECK(ha_derive_base_url("", "h") == "http://h");          // default scheme
+  CHECK(ha_derive_base_url("http", "h/") == "http://h");     // trailing slash stripped
+}
+
+TEST_CASE("ha_build_redirect_uri appends the callback path") {
+  CHECK(ha_build_redirect_uri("http://openevse.local") ==
+        "http://openevse.local/ha_callback");
+}
+
+TEST_CASE("ha_build_authorize_url builds an encoded query") {
+  std::string url = ha_build_authorize_url(
+      "http://homeassistant.local:8123",
+      "http://openevse.local/",
+      "http://openevse.local/ha_callback",
+      "abc123");
+  CHECK(url ==
+        "http://homeassistant.local:8123/auth/authorize"
+        "?response_type=code"
+        "&client_id=http%3A%2F%2Fopenevse.local%2F"
+        "&redirect_uri=http%3A%2F%2Fopenevse.local%2Fha_callback"
+        "&state=abc123");
+}
+
+TEST_CASE("ha_build_authorize_url strips a trailing slash from ha_url") {
+  std::string url = ha_build_authorize_url(
+      "http://ha:8123/", "cid", "ruri", "s");
+  CHECK(url.rfind("http://ha:8123/auth/authorize", 0) == 0);
+}
+
+TEST_CASE("ha_build_token_exchange_body encodes the form body") {
+  CHECK(ha_build_token_exchange_body("http://openevse.local/", "the+code") ==
+        "grant_type=authorization_code"
+        "&code=the%2Bcode"
+        "&client_id=http%3A%2F%2Fopenevse.local%2F");
+}
+
+TEST_CASE("ha_build_refresh_body encodes the form body") {
+  CHECK(ha_build_refresh_body("cid", "rtok") ==
+        "grant_type=refresh_token"
+        "&refresh_token=rtok"
+        "&client_id=cid");
+}
+
+TEST_CASE("ha_parse_token_response extracts tokens and expiry") {
+  HaTokens t;
+  bool ok = ha_parse_token_response(
+      "{\"access_token\":\"AT\",\"refresh_token\":\"RT\","
+      "\"expires_in\":1800,\"token_type\":\"Bearer\"}", t);
+  CHECK(ok);
+  CHECK(t.access_token == "AT");
+  CHECK(t.refresh_token == "RT");
+  CHECK(t.expires_in == 1800);
+}
+
+TEST_CASE("ha_parse_token_response: refresh response without refresh_token is ok") {
+  HaTokens t;
+  bool ok = ha_parse_token_response(
+      "{\"access_token\":\"AT2\",\"expires_in\":1800}", t);
+  CHECK(ok);
+  CHECK(t.access_token == "AT2");
+  CHECK(t.refresh_token.empty());
+}
+
+TEST_CASE("ha_parse_token_response fails on error / malformed bodies") {
+  HaTokens t;
+  CHECK_FALSE(ha_parse_token_response("{\"error\":\"invalid_grant\"}", t));
+  CHECK_FALSE(ha_parse_token_response("not json", t));
+  CHECK_FALSE(ha_parse_token_response("{\"expires_in\":1800}", t)); // no access_token
+}
+
+TEST_CASE("ha_compute_expiry adds expires_in to now") {
+  CHECK(ha_compute_expiry(1000, 1800) == 2800);
+  CHECK(ha_compute_expiry(1000, 0) == 0);    // unknown expiry
+  CHECK(ha_compute_expiry(1000, -5) == 0);
+}
+
+TEST_CASE("ha_refresh_due triggers within the margin") {
+  // expiry at 2800, margin 300 -> refresh due at >= 2500
+  CHECK_FALSE(ha_refresh_due(2800, 2499, 300));
+  CHECK(ha_refresh_due(2800, 2500, 300));
+  CHECK(ha_refresh_due(2800, 3000, 300));    // already expired
+  CHECK(ha_refresh_due(0, 5, 300));          // unknown expiry -> always due
+}
+
+TEST_CASE("ha_parse_entity_state extracts the state, ignoring attributes") {
+  std::string s;
+  CHECK(ha_parse_entity_state(
+      "{\"entity_id\":\"sensor.car\",\"state\":\"73.5\","
+      "\"attributes\":{\"unit_of_measurement\":\"%\",\"friendly_name\":\"Car\"}}", s));
+  CHECK(s == "73.5");
+
+  // Large attributes blob: would overflow the result doc if not filtered out.
+  std::string big = "{\"state\":\"42\",\"attributes\":{\"blob\":\"";
+  big += std::string(400, 'x');
+  big += "\"}}";
+  std::string s2;
+  CHECK(ha_parse_entity_state(big, s2));
+  CHECK(s2 == "42");
+}
+
+TEST_CASE("ha_parse_entity_state rejects unavailable/unknown/missing/bad") {
+  std::string s;
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"unavailable\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"unknown\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"state\":\"\"}", s));
+  CHECK_FALSE(ha_parse_entity_state("{\"attributes\":{}}", s)); // no state key
+  CHECK_FALSE(ha_parse_entity_state("not json", s));
+}
+
+TEST_CASE("ha_parse_bool recognizes truthy and falsey states") {
+  bool b = false;
+  CHECK(ha_parse_bool("on", b));        CHECK(b == true);
+  CHECK(ha_parse_bool("ON", b));        CHECK(b == true);
+  CHECK(ha_parse_bool("true", b));      CHECK(b == true);
+  CHECK(ha_parse_bool("1", b));         CHECK(b == true);
+  CHECK(ha_parse_bool("home", b));      CHECK(b == true);
+  CHECK(ha_parse_bool("off", b));       CHECK(b == false);
+  CHECK(ha_parse_bool("OFF", b));       CHECK(b == false);
+  CHECK(ha_parse_bool("false", b));     CHECK(b == false);
+  CHECK(ha_parse_bool("0", b));         CHECK(b == false);
+  CHECK(ha_parse_bool("not_home", b));  CHECK(b == false);
+  CHECK(ha_parse_bool("unplugged", b)); CHECK(b == false);
+  CHECK(ha_parse_bool("open", b));          CHECK(b == true);
+  CHECK(ha_parse_bool("connected", b));     CHECK(b == true);
+  CHECK(ha_parse_bool("disconnected", b));  CHECK(b == false);
+}
+
+TEST_CASE("ha_parse_bool rejects unrecognized states") {
+  bool b = true;
+  CHECK_FALSE(ha_parse_bool("charging", b));   CHECK(b == true); // out untouched
+  CHECK_FALSE(ha_parse_bool("", b));            CHECK(b == true);
+  CHECK_FALSE(ha_parse_bool("42.5", b));        CHECK(b == true);
+  CHECK_FALSE(ha_parse_bool("maybe", b));       CHECK(b == true);
+}


### PR DESCRIPTION
## Summary

Adds a **Home Assistant integration** where the ESP32 acts as an OAuth client to Home Assistant and polls HA entities to enrich/drive charging. This is the full feature as one PR — putting it up for the team to decide how much (if any) of it you want upstream.

## What's included

- **OAuth connection** (`src/ha_oauth.*`, `src/home_assistant.*`, `src/web_server_home_assistant.cpp`): ESP32-as-`client_id` browser authorize → callback → token exchange, with refresh scheduling and Bearer-auth GETs. Pure URL/token logic is unit-tested (`test/test_ha_oauth`, runs under `pio test -e native`).
- **Vehicle data**: poll HA entities for vehicle SoC / range / ETA.
- **Vehicle charge-limit**: poll a HA entity into an EVSE charge-limit field, surfaced in `/status` and on the LCD.
- **HA data sources**: solar / grid / battery / shaper feeds, display + control, with **MQTT-vs-HA arbitration** (HA only takes over a feed when configured; MQTT subscriptions stay unconditional).

The GUI side (connection + settings pages) already ships in the gui-nightshift default-UI PR (#1092), so this is firmware-only.

## Notes / merge coordination

- **Independent of the other split PRs**, but pairs naturally with **#1093** (real TLS RNG) — the OAuth token exchanges run over HTTPS to Home Assistant, so the hardware-RNG fix matters here.
- **Config bit:** `CONFIG_SERVICE_HOMEASSISTANT` is `(1 << 27)`. The energy PR (#1094) currently also uses bit 27 for `CONFIG_TEMP_THROTTLE`; whichever lands second should move to bit 28 (one-line change). Noted in the code.
- **`[env:native]`:** this PR adds a minimal host-test env (for the OAuth unit tests). The foundation PR (#1091) adds the same env; trivial to dedupe at merge.

## Validation

- `openevse_wifi_v1` (core-2): builds clean, **94.7%** flash.
- `pio test -e native`: `test_ha_oauth` passes.
- Branch built fresh off `upstream/master`; contains no code from the other split groups (energy/tsdb/FakeEVSE/P4/foundation) — verified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
