### PR TITLE
Add vehicle_charge_limit to the vehicle data set (/status + POST)

### DIFF
--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -133,7 +133,8 @@ EvseManager::EvseManager(Stream &port, EventLog &eventLog) :
   _vehicleLastUpdated(0),
   _vehicleStateOfCharge(0),
   _vehicleRange(0),
-  _vehicleEta(0)
+  _vehicleEta(0),
+  _vehicleChargeLimit(0)
 {
 }
 
@@ -601,6 +602,15 @@ void EvseManager::setVehicleEta(int vehicleEta)
   _vehicleEta = vehicleEta;
   _vehicleValid |= EVSE_VEHICLE_ETA;
   _vehicleUpdated |= EVSE_VEHICLE_ETA;
+  _vehicleLastUpdated = millis();
+  MicroTask.wakeTask(this);
+}
+
+void EvseManager::setVehicleChargeLimit(int vehicleChargeLimit)
+{
+  _vehicleChargeLimit = vehicleChargeLimit;
+  _vehicleValid |= EVSE_VEHICLE_CHARGE_LIMIT;
+  _vehicleUpdated |= EVSE_VEHICLE_CHARGE_LIMIT;
   _vehicleLastUpdated = millis();
   MicroTask.wakeTask(this);
 }

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -58,6 +58,7 @@ typedef uint32_t EvseClient;
 #define EVSE_VEHICLE_SOC    (1 << 0)
 #define EVSE_VEHICLE_RANGE  (1 << 1)
 #define EVSE_VEHICLE_ETA    (1 << 2)
+#define EVSE_VEHICLE_CHARGE_LIMIT (1 << 3)
 
 #ifndef EVSE_MANAGER_MAX_CLIENT_CLAIMS
 #define EVSE_MANAGER_MAX_CLIENT_CLAIMS 10
@@ -242,6 +243,7 @@ class EvseManager : public MicroTasks::Task
     int _vehicleStateOfCharge;
     int _vehicleRange;
     int _vehicleEta;
+    int _vehicleChargeLimit;
 
     void initialiseEvse();
     bool findClaim(EvseClient client, Claim **claim = NULL);
@@ -471,6 +473,9 @@ class EvseManager : public MicroTasks::Task
     int getVehicleEta() {
       return _vehicleEta;
     }
+    int getVehicleChargeLimit() {
+      return _vehicleChargeLimit;
+    }
     uint32_t getVehicleLastUpdated() {
       return _vehicleLastUpdated;
     }
@@ -483,9 +488,13 @@ class EvseManager : public MicroTasks::Task
     int isVehicleEtaValid() {
       return 0 != (_vehicleValid & EVSE_VEHICLE_ETA);
     }
+    int isVehicleChargeLimitValid() {
+      return 0 != (_vehicleValid & EVSE_VEHICLE_CHARGE_LIMIT);
+    }
     void setVehicleStateOfCharge(int vehicleStateOfCharge);
     void setVehicleRange(int vehicleRange);
     void setVehicleEta(int vehicleEta);
+    void setVehicleChargeLimit(int vehicleChargeLimit);
 
     // Get/set the 'disabled' mode
     bool isSleepForDisable() {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -282,6 +282,9 @@ void buildStatus(DynamicJsonDocument &doc) {
     if(evse.isVehicleEtaValid()) {
       doc["time_to_full_charge"] = evse.getVehicleEta();
     }
+    if(evse.isVehicleChargeLimitValid()) {
+      doc["vehicle_charge_limit"] = evse.getVehicleChargeLimit();
+    }
   }
 
   DBUGF("/status ArduinoJson size: %dbytes", doc.size());
@@ -488,6 +491,12 @@ void handleStatusPost(MongooseHttpServerRequest *request, MongooseHttpServerResp
       double vehicle_eta = doc["time_to_full_charge"];
       DBUGF("vehicle_eta:%d", vehicle_eta);
       evse.setVehicleEta(vehicle_eta);
+      doc["vehicle_state_update"] = 0;
+    }
+    if(doc.containsKey("vehicle_charge_limit") && vehicle_data_src == VEHICLE_DATA_SRC_HTTP){
+      int vehicle_charge_limit = doc["vehicle_charge_limit"];
+      DBUGF("vehicle_charge_limit:%d%%", vehicle_charge_limit);
+      evse.setVehicleChargeLimit(vehicle_charge_limit);
       doc["vehicle_state_update"] = 0;
     }
     // send back new value to clients


### PR DESCRIPTION
## Summary

Adds a `vehicle_charge_limit` value to the vehicle data set, mirroring the existing vehicle **state of charge / range / ETA** pattern. This is the vehicle's target charge percentage (e.g. "charge to 80%"), as reported by the vehicle or a connected integration.

## Changes

- `EvseManager` gains `_vehicleChargeLimit` plus `getVehicleChargeLimit()`, `isVehicleChargeLimitValid()` and `setVehicleChargeLimit()`, tracked by a new `EVSE_VEHICLE_CHARGE_LIMIT` validity bit — exactly parallel to SoC/range/eta.
- `/status` emits `vehicle_charge_limit` once a value has been received (omitted until then, like the other vehicle fields).
- `POST /status` accepts `vehicle_charge_limit` under the same `vehicle_data_src == VEHICLE_DATA_SRC_HTTP` gating as `battery_level` / `battery_range` / `time_to_full_charge`.

## Validation

- `pio run -e openevse_wifi_v1` — builds clean (flash 93.8%).

## Notes

Branched off `master`. Small additive change (29 insertions). A follow-up PR adds an MQTT topic for the same value (`mqtt_vehicle_charge_limit`); it is stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
