### PR TITLE
Allow feeding vehicle_charge_limit over MQTT (stacked on #1097)

### DIFF
--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -75,6 +75,7 @@ String mqtt_live_pwr;
 String mqtt_vehicle_soc;
 String mqtt_vehicle_range;
 String mqtt_vehicle_eta;
+String mqtt_vehicle_charge_limit;
 String mqtt_announce_topic;
 
 // OCPP 1.6 Settings
@@ -192,6 +193,7 @@ ConfigOpt *opts[] =
   new ConfigOptDefinition<String>(mqtt_vehicle_soc, "", "mqtt_vehicle_soc", "mc"),
   new ConfigOptDefinition<String>(mqtt_vehicle_range, "", "mqtt_vehicle_range", "mr"),
   new ConfigOptDefinition<String>(mqtt_vehicle_eta, "", "mqtt_vehicle_eta", "met"),
+  new ConfigOptDefinition<String>(mqtt_vehicle_charge_limit, "", "mqtt_vehicle_charge_limit", "mcl"),
   new ConfigOptDefinition<String>(mqtt_announce_topic, "openevse/announce/" + ESPAL.getShortId(), "mqtt_announce_topic", "ma"),
 
 // OCPP 1.6 Settings

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -63,6 +63,7 @@ extern String mqtt_live_pwr;
 extern String mqtt_vehicle_soc;
 extern String mqtt_vehicle_range;
 extern String mqtt_vehicle_eta;
+extern String mqtt_vehicle_charge_limit;
 extern String mqtt_announce_topic;
 
 // OCPP 1.6 Settings

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -216,6 +216,7 @@ void Mqtt::subscribeTopics() {
   if (mqtt_vehicle_soc != "") { _mqttclient.subscribe(mqtt_vehicle_soc); yield(); }
   if (mqtt_vehicle_range != "") { _mqttclient.subscribe(mqtt_vehicle_range); yield(); }
   if (mqtt_vehicle_eta != "") { _mqttclient.subscribe(mqtt_vehicle_eta); yield(); }
+  if (mqtt_vehicle_charge_limit != "") { _mqttclient.subscribe(mqtt_vehicle_charge_limit); yield(); }
   if (mqtt_vrms != "") { _mqttclient.subscribe(mqtt_vrms); yield(); }
 
   // Settable topics
@@ -326,6 +327,11 @@ void Mqtt::handleMqttMessage(MongooseString topic, MongooseString payload) {
     int vehicle_eta = payload_str.toInt();
     _evse->setVehicleEta(vehicle_eta);
     StaticJsonDocument<128> event; event["time_to_full_charge"] = vehicle_eta; event_send(event);
+  }
+  else if (topic_string == mqtt_vehicle_charge_limit && vehicle_data_src == VEHICLE_DATA_SRC_MQTT) {
+    int vehicle_charge_limit = payload_str.toInt();
+    _evse->setVehicleChargeLimit(vehicle_charge_limit);
+    StaticJsonDocument<128> event; event["vehicle_charge_limit"] = vehicle_charge_limit; event_send(event);
   }
   else if (topic_string == mqtt_topic + "/divertmode/set") {
     byte newdivert = payload_str.toInt();


### PR DESCRIPTION
## Summary

Adds an optional `mqtt_vehicle_charge_limit` MQTT topic that feeds `vehicle_charge_limit` into the EVSE, exactly like the existing `mqtt_vehicle_soc` / `mqtt_vehicle_range` / `mqtt_vehicle_eta` topics. The handler is gated on `vehicle_data_src == VEHICLE_DATA_SRC_MQTT`.

## ⚠️ Stacked on #1097

This PR is stacked on **#1097** (*Add vehicle_charge_limit to the vehicle data set*), which introduces the `setVehicleChargeLimit` / `/status` plumbing this builds on. **Please merge #1097 first.** Until then this PR's diff includes #1097's commit (`Add vehicle_charge_limit to the vehicle data set`); only the second commit (`Allow feeding vehicle_charge_limit over MQTT`) is unique to this PR. I'll rebase onto `master` once #1097 lands.

## Changes (this PR's own commit)

- New optional config `mqtt_vehicle_charge_limit` (short key `mcl`).
- Subscribe to the topic and, on message, call `setVehicleChargeLimit()` when the MQTT vehicle data source is selected.

## Validation

- `pio run -e openevse_wifi_v1` — builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
