### PR TITLE
Fix heartbeat supervision resync after WiFi module reboot

### DIFF
--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -251,6 +251,14 @@ void EvseMonitor::evseBoot(const char *firmware)
 
   _openevse.heartbeatEnable(EVSE_HEATBEAT_INTERVAL, EVSE_HEARTBEAT_CURRENT, [this](int ret, int interval, int current, int triggered) {
     _heartbeat = RAPI_RESPONSE_OK == ret;
+    // If heartbeat was triggered while WiFi module was rebooting, ack immediately to restore ampacity
+    if (_heartbeat && 2 == triggered) {
+      _openevse.heartbeatPulse([](int ret) {
+        if (RAPI_RESPONSE_OK != ret) {
+          DEBUG_PORT.println("Heartbeat ack failed");
+        }
+      });
+    }
   });
 }
 
@@ -330,6 +338,20 @@ unsigned long EvseMonitor::loop(MicroTasks::WakeReason reason)
     {
       if(RAPI_RESPONSE_OK != ret) {
         DEBUG_PORT.println("Heartbeat failed");
+      }
+    });
+  }
+  else if(0 == _count % EVSE_MONITOR_STATE_TIME)
+  {
+    // Heartbeat enable failed or was never set; retry periodically so WiFi module reboot resyncs
+    _openevse.heartbeatEnable(EVSE_HEATBEAT_INTERVAL, EVSE_HEARTBEAT_CURRENT, [this](int ret, int interval, int current, int triggered) {
+      _heartbeat = RAPI_RESPONSE_OK == ret;
+      if (_heartbeat && 2 == triggered) {
+        _openevse.heartbeatPulse([](int ret) {
+          if (RAPI_RESPONSE_OK != ret) {
+            DEBUG_PORT.println("Heartbeat ack failed");
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes #953 
Fixes #540 

- **Bug:** After the WiFi module reboots, heartbeat supervision never resyncs — the OpenEVSE Controller stays in triggered state with current throttled to the heartbeat fallback (6 A) indefinitely.
- **Root cause:** Two missing code paths in `evse_monitor.cpp`:
  1. On boot, if the OpenEVSE Controller had heartbeat triggered (`triggered == 2`) while the WiFi was away, no immediate ack pulse was sent, so ampacity was never restored.
  2. In `loop()`, when `_heartbeat` is false there was no retry of `heartbeatEnable`, leaving heartbeat permanently disabled until the next full reboot.

## Changes

- `evseBoot()`: check `triggered == 2` in the `heartbeatEnable` callback and send an immediate `heartbeatPulse` to restore ampacity.
- `loop()`: add `else if` retry — when `_heartbeat` is false, periodically re-issue `heartbeatEnable` so the WiFi module resyncs automatically after any reboot or failed enable.

## Testing

- Flash WiFi module, verify heartbeat supervision is established (current not throttled)
- Reboot WiFi module while vehicle is connected and charging; confirm current restores within one `EVSE_MONITOR_STATE_TIME` cycle
- Simulate delayed EVSE boot (WiFi up first): confirm heartbeat enable retries and succeeds
