### PR TITLE
Fix HTTP OTA update failing

### DIFF
--- a/src/web_server_update.cpp
+++ b/src/web_server_update.cpp
@@ -32,6 +32,9 @@ static void handleUpdateGet(MongooseHttpServerRequest *request)
 }
 
 static MongooseHttpServerResponseStream *upgradeResponse = NULL;
+// Update.isFinished() is true while idle (0 bytes of 0), so remember the
+// multipart request that actually completed instead.
+static MongooseHttpServerRequest *completedUpdateRequest = NULL;
 
 void handleUpdateFileUpload(MongooseHttpServerRequest *request)
 {
@@ -43,6 +46,8 @@ void handleUpdateFileUpload(MongooseHttpServerRequest *request)
   if(false == requestPreProcess(request, upgradeResponse, CONTENT_TYPE_TEXT)) {
     return;
   }
+
+  completedUpdateRequest = NULL;
 
   // TODO: Add support for returning 100: Continue
 }
@@ -131,6 +136,7 @@ size_t handleUpdateUpload(MongooseHttpServerRequest *request, int ev, MongooseSt
   if(MG_EV_HTTP_PART_END == ev)
   {
     if(http_update_end()) {
+      completedUpdateRequest = request;
       upgradeResponse->setCode(200);
       upgradeResponse->print("OK");
       request->send(upgradeResponse);
@@ -152,7 +158,8 @@ void handleUpdateClose(MongooseHttpServerRequest *request)
     upgradeResponse = NULL;
   }
 
-  if(Update.isFinished() && !Update.hasError()) {
+  if(request == completedUpdateRequest) {
+    completedUpdateRequest = NULL;
     restart_system();
   }
 }


### PR DESCRIPTION
This fix the http ota update failing. It was not crashing but just rebooting because of Update.isFinished() returning true while waiting during the TLS handshake. 

Following https://github.com/OpenEVSE/openevse_esp32_firmware/pull/1061

The /update endpoint handles both multipart uploads and JSON requests containing a firmware URL. Its common onClose callback used:
```
if (Update.isFinished() && !Update.hasError()) {
    restart_system();
}
```
However, Update.isFinished() returns true while idle because both _progress and _size are zero. Consequently, closing the JSON request triggered a restart immediately after starting the remote download, usually during the TLS handshake.

Tracks the specific multipart request that successfully completes http_update_end(). The close callback now restarts only for that request.
JSON-based remote updates no longer cause a false manual-OTA restart.

Fix has been tested and HTTP OTA is now back in buisness.
Bug has been latent since http ota introduction in 2021, but switch to ArduinoMongoose 0.0.22 in fw 5.1.3 probably exposed it as it may have changed connection-closed timing. 

