### PR TITLE
feat(tsdb): throttle and trim energy logging while idle

### DIFF
--- a/src/tsdb_energy_logger.cpp
+++ b/src/tsdb_energy_logger.cpp
@@ -236,7 +236,12 @@ void TsdbEnergyLogger::rollup_yesterday() {
 }
 
 unsigned long TsdbEnergyLogger::loop(MicroTasks::WakeReason) {
+  // Throttle to the idle cadence whenever we are not actively charging.
+  unsigned long next_ms = TSDB_ENERGY_SAMPLE_MS;
   if (_ready && _evse) {
+    bool charging = _evse->isCharging();
+    if (!charging) next_ms = TSDB_ENERGY_IDLE_SAMPLE_MS;
+
     // Advance the energy baseline every wake (even when we skip the write below),
     // so deltas stay honest once logging resumes. A session reset to 0 on vehicle
     // unplug yields a small positive delta (cur_wh), not a negative one. (Lossy
@@ -266,17 +271,23 @@ unsigned long TsdbEnergyLogger::loop(MicroTasks::WakeReason) {
       }
 
       // -- Write tsdb sample --
+      // Temperature is logged in every sample (slow-moving, useful idle or not).
+      // Charge current, power, pilot and SoC are only meaningful while charging:
+      // when idle they stay at their idle sentinels (0 / SoC -1) so the history
+      // does not show post-charge current or a SoC that drifts as the car drives.
       EnergySample s;
-      s.amps    = _evse->getAmps();
-      s.volts   = _evse->getVoltage();
-      s.power_w = s.amps * s.volts;
-      s.energy_wh_delta = delta;
+      s.energy_wh_delta = delta;   // ~0 while idle; keeps cumulative totals exact
       s.temp_c  = _evse->isTemperatureValid(EVSE_MONITOR_TEMP_MONITOR)
                     ? _evse->getTemperature(EVSE_MONITOR_TEMP_MONITOR) : 0;
-      s.soc     = _evse->isVehicleStateOfChargeValid() ? _evse->getVehicleStateOfCharge() : -1;
-      // getChargeCurrent() with no args returns _monitor.getPilot() (the actual
-      // pilot current in amps); getPilot() is not forwarded directly on EvseManager.
-      s.pilot_a = _evse->getChargeCurrent();
+      if (charging) {
+        s.amps    = _evse->getAmps();
+        s.volts   = _evse->getVoltage();
+        s.power_w = s.amps * s.volts;
+        s.soc     = _evse->isVehicleStateOfChargeValid() ? _evse->getVehicleStateOfCharge() : -1;
+        // getChargeCurrent() with no args returns _monitor.getPilot() (the actual
+        // pilot current in amps); getPilot() is not forwarded directly on EvseManager.
+        s.pilot_a = _evse->getChargeCurrent();
+      }
 
       int16_t row[TSDB_NUM_COLS];
       tsdb_scale_sample(s, row);
@@ -284,6 +295,6 @@ unsigned long TsdbEnergyLogger::loop(MicroTasks::WakeReason) {
       if (e != ESP_OK) DBUGF("tsdb_write failed: %d", e);
     }
   }
-  return TSDB_ENERGY_SAMPLE_MS;
+  return next_ms;
 }
 #endif

--- a/src/tsdb_energy_logger.h
+++ b/src/tsdb_energy_logger.h
@@ -10,7 +10,13 @@
 // build can force a fast ring-wrap (e.g. -DTSDB_ENERGY_SAMPLE_MS=1000
 // -DTSDB_ENERGY_BYTES=4096UL) for bench testing the wrapped-ring query path.
 #ifndef TSDB_ENERGY_SAMPLE_MS
-#define TSDB_ENERGY_SAMPLE_MS     60000                 // 1/min, matches EnergyLogger
+#define TSDB_ENERGY_SAMPLE_MS     60000                 // 1/min while charging
+#endif
+// When the vehicle is not charging we only log slow-moving temperature (charge
+// current and SoC are meaningless, and reading SoC keeps the vehicle awake), so
+// we throttle the write cadence to cut flash wear ~5x during idle periods.
+#ifndef TSDB_ENERGY_IDLE_SAMPLE_MS
+#define TSDB_ENERGY_IDLE_SAMPLE_MS (5UL * 60000UL)      // 1/5min while idle
 #endif
 #ifndef TSDB_ENERGY_BYTES
 #define TSDB_ENERGY_BYTES         (2500UL * 1024UL)     // ~2.5 MB -> ~100 days


### PR DESCRIPTION
## Summary

Addresses review feedback on #1094 about the TSDB energy logger recording full samples (current, SoC, pilot, voltage) every minute even when the vehicle is not charging — visible in KipK's screenshot of temp/SoC history with no charge, and flagged by chris1howell.

When **not charging** (`!isCharging()`), the TSDB logger now:

- **Drops SoC** (`soc = -1`). Recording SoC after a charge ends keeps the vehicle awake (extra range loss, per chris1howell's Tesla experience) and makes the history show SoC drifting as the car drives around.
- **Drops charge current / power / pilot / voltage** — meaningless when idle.
- **Keeps temperature** (slow-moving and useful idle or not) and keeps accumulating the energy delta (~0 while idle) so cumulative daily/monthly/annual rollups stay exact.
- **Throttles the write cadence to 1/5 min** (`TSDB_ENERGY_IDLE_SAMPLE_MS`, build-overridable) instead of 1/min, cutting idle flash wear ~5× — addresses KipK's flash-lifetime concern.

While charging, behavior is unchanged: 1/min full samples.

## Validation

- `openevse_wifi_v1_16mb` (core-3, `ENABLE_TSDB`): builds clean.
- Flashed to a real 16 MB ESP32 and confirmed live via `/energy/raw` while idle:
  - new samples ~301 s apart (5‑min idle cadence)
  - `v:0, p:0, pilot:0, soc:-1` — current/SoC/pilot/volts suppressed
  - temperature/energy slots retained (read 0 here only because the bench module has no temp sensor)
- `tsdb_ready:1 / tsdb_err:0` on hardware.

Charging-path cadence (return to 1/min with real current/SoC) still wants a confirm on a full rig with a vehicle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)