### PR TITLE
fix(ota): finalize completed HTTP downloads before socket close

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,6 +35,7 @@ default_envs = openevse_wifi_v1
 platform_core3 = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 lib_deps =
   bblanchon/ArduinoJson@6.20.1
+  # IDF5 / Arduino-core-3 compatibility fixes (pending upstream into jeremypoulter/*):
   jeremypoulter/ArduinoMongoose@0.0.26
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,6 @@ default_envs = openevse_wifi_v1
 platform_core3 = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
 lib_deps =
   bblanchon/ArduinoJson@6.20.1
-  # IDF5 / Arduino-core-3 compatibility fixes (pending upstream into jeremypoulter/*):
   jeremypoulter/ArduinoMongoose@0.0.26
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6

--- a/src/http_update.cpp
+++ b/src/http_update.cpp
@@ -15,6 +15,15 @@ static int lastPercent = -1;
 static size_t update_total_size = 0;
 static size_t update_position = 0;
 
+struct HttpUpdateRequestState
+{
+  bool startedUpdate = false;
+  bool updateComplete = false;
+  bool responseComplete = false;
+  bool redirected = false;
+  bool errorReported = false;
+};
+
 bool http_update_from_url(String url,
   std::function<void(size_t complete, size_t total)> progress,
   std::function<void(int)> success,
@@ -25,71 +34,151 @@ bool http_update_from_url(String url,
   MongooseHttpClientRequest *request = client.beginRequest(url.c_str());
   if(request)
   {
+    HttpUpdateRequestState *state = new HttpUpdateRequestState();
+    if(!state)
+    {
+      delete request;
+      error(HTTP_UPDATE_ERROR_FAILED_TO_START_UPDATE);
+      return false;
+    }
+
     request->setMethod(HTTP_GET);
 
     DBUGF("Trying to fetch firmware from %s", url.c_str());
 
-    request->onBody([url,progress,error,request](MongooseHttpClientResponse *response)
+    request->onBody([url,progress,success,error,request,state](MongooseHttpClientResponse *response)
     {
       DBUGF("Update onBody %d", response->respCode());
+      if(state->updateComplete)
+      {
+        return;
+      }
+
       if(response->respCode() == 200)
       {
         size_t total = response->contentLength();
         DBUGVAR(total);
         if(Update.isRunning() || http_update_start(url, total))
         {
+          state->startedUpdate = true;
           uint8_t *data = (uint8_t *)response->body().c_str();
           size_t len = response->body().length();
           if(http_update_write(data, len))
           {
             progress(len, total);
+
+            // With Mongoose's streaming client the final body chunk is
+            // observable even when MG_EV_HTTP_REPLY is not delivered later.
+            // Finalize as soon as every Content-Length byte is written.
+            if(update_total_size > 0 && update_position == update_total_size)
+            {
+              DEBUG_PORT.printf("Update download complete: %zu bytes, finalizing\n", update_position);
+              if(http_update_end(false))
+              {
+                state->updateComplete = true;
+                success(HTTP_UPDATE_OK);
+                restart_system();
+              } else {
+                state->errorReported = true;
+                error(HTTP_UPDATE_ERROR_FAILED_TO_END_UPDATE);
+              }
+            }
             return;
           } else {
+            state->errorReported = true;
             error(HTTP_UPDATE_ERROR_WRITE_FAILED);
           }
         } else {
+          state->errorReported = true;
           error(HTTP_UPDATE_ERROR_FAILED_TO_START_UPDATE);
         }
       } else if (300 <= response->respCode() && response->respCode() < 400) {
         // handle 3xx redirects (later)
         return;
       } else {
+        state->errorReported = true;
         error(response->respCode());
       }
       request->abort();
     });
 
-    request->onResponse([progress, error, success, request](MongooseHttpClientResponse *response)
+    request->onResponse([progress, error, success, request,state](MongooseHttpClientResponse *response)
     {
       DBUGF("Update onResponse %d", response->respCode());
       if(301 == response->respCode() ||
          302 == response->respCode())
       {
+        state->redirected = true;
         MongooseString location = response->headers("Location");
         DBUGVAR(location.toString());
         http_update_from_url(location.toString(), progress, success, error);
-      }
-    });
+      } else if(200 == response->respCode()) {
+        state->responseComplete = true;
 
-    request->onClose([success, error]()
-    {
-      DBUGLN("Update onClose");
-      if(Update.isRunning())
-      {
-        if(http_update_end())
+        if(state->updateComplete)
         {
+          return;
+        }
+
+        if(!state->startedUpdate || !Update.isRunning())
+        {
+          if(!state->errorReported)
+          {
+            state->errorReported = true;
+            error(HTTP_UPDATE_ERROR_FAILED_TO_START_UPDATE);
+          }
+          return;
+        }
+
+        if(update_total_size > 0)
+        {
+          DEBUG_PORT.printf("Update incomplete: %zu/%zu bytes\n", update_position, update_total_size);
+          Update.abort();
+          state->errorReported = true;
+          error(HTTP_UPDATE_ERROR_INCOMPLETE_DOWNLOAD);
+          return;
+        }
+
+        // MG_EV_HTTP_REPLY means the complete HTTP response has been received.
+        // Finalize here rather than waiting for a later socket-close callback.
+        if(http_update_end(true))
+        {
+          state->updateComplete = true;
           success(HTTP_UPDATE_OK);
           restart_system();
         } else {
+          state->errorReported = true;
           error(HTTP_UPDATE_ERROR_FAILED_TO_END_UPDATE);
         }
       }
     });
-    client.send(request);
 
+    request->onClose([error,state]()
+    {
+      DBUGLN("Update onClose");
+      if(state->startedUpdate && !state->updateComplete && !state->responseComplete)
+      {
+        if(Update.isRunning())
+        {
+          Update.abort();
+        }
+        if(!state->errorReported)
+        {
+          error(HTTP_UPDATE_ERROR_INCOMPLETE_DOWNLOAD);
+        }
+      }
+      else if(!state->redirected && !state->responseComplete && !state->errorReported)
+      {
+        error(HTTP_UPDATE_ERROR_INCOMPLETE_DOWNLOAD);
+      }
+      delete state;
+    });
+
+    client.send(request);
     return true;
   }
 
+  error(HTTP_UPDATE_ERROR_FAILED_TO_START_UPDATE);
   return false;
 }
 
@@ -97,6 +186,7 @@ bool http_update_start(String source, size_t total)
 {
   update_position = 0;
   update_total_size = total;
+  lastPercent = -1;
   // Pass the expected size so the library can (a) reject an oversized binary
   // before erasing the target partition, and (b) validate completeness at end().
   // Fall back to UPDATE_SIZE_UNKNOWN only when Content-Length is absent.
@@ -130,7 +220,8 @@ bool http_update_write(uint8_t *data, size_t len)
     update_position += len;
     if(update_total_size > 0)
     {
-      int percent = update_position / (update_total_size / 100);
+      int percent = (int)((update_position * 100) / update_total_size);
+      percent = min(percent, 100);
       DBUGVAR(percent);
       DBUGVAR(lastPercent);
       if(percent != lastPercent)
@@ -154,10 +245,10 @@ bool http_update_write(uint8_t *data, size_t len)
   return false;
 }
 
-bool http_update_end()
+bool http_update_end(bool evenIfRemaining)
 {
   DBUGLN("Upload finished");
-  if(Update.end(true))
+  if(Update.end(evenIfRemaining))
   {
     DBUGF("Update Success: %u", update_position);
     lcd.display(F("Complete"), 0, 1, 10 * 1000, LCD_CLEAR_LINE | LCD_DISPLAY_NOW);
@@ -167,7 +258,7 @@ bool http_update_end()
     yield();
     return true;
   } else {
-    DBUGF("Update failed: %d", Update.getError());
+    DEBUG_PORT.printf("Update failed: %d (%s)\n", Update.getError(), Update.errorString());
     StaticJsonDocument<128> event;
     event["ota"] = "failed";
     web_server_event(event);

--- a/src/http_update.h
+++ b/src/http_update.h
@@ -11,6 +11,7 @@
 #define HTTP_UPDATE_ERROR_FAILED_TO_START_UPDATE      -1
 #define HTTP_UPDATE_ERROR_WRITE_FAILED                -2
 #define HTTP_UPDATE_ERROR_FAILED_TO_END_UPDATE        -3
+#define HTTP_UPDATE_ERROR_INCOMPLETE_DOWNLOAD         -4
 
 #define HTTP_UPDATE_OK                                 0
 
@@ -21,6 +22,6 @@ bool http_update_from_url(String url,
 
 bool http_update_start(String source, size_t total);
 bool http_update_write(uint8_t *data, size_t len);
-bool http_update_end();
+bool http_update_end(bool evenIfRemaining = true);
 
 #endif // _HTTP_UPDATE_H

--- a/src/web_server_update.cpp
+++ b/src/web_server_update.cpp
@@ -68,14 +68,13 @@ void handleUpdateFileFetch(MongooseHttpServerRequest *request)
     if(http_update_from_url(url,
       [](size_t complete, size_t total) {},
       [](int) { },
-      [](int) {
-        if(!Update.isRunning())
-        {
-          StaticJsonDocument<128> event;
-          event["ota"] = "failed";
-          web_server_event(event);
-          yield();
-        }
+      [](int errorCode) {
+        DEBUG_PORT.printf("HTTP OTA failed: %d\n", errorCode);
+        StaticJsonDocument<128> event;
+        event["ota"] = "failed";
+        event["ota_error"] = errorCode;
+        web_server_event(event);
+        yield();
       }))
     {
       response->setCode(200);


### PR DESCRIPTION
## Summary

Fix URL-based HTTP OTA updates that download the firmware to 100% but never finalize, reboot, or install the new image.

This is a follow-up to #1108 and #1104

ArduinoMongoose PR https://github.com/jeremypoulter/ArduinoMongoose/pull/53 is needed too. 

platformio.ini now points to https://github.com/jeremypoulter/ArduinoMongoose@0.0.26 


---

## Problem

The OTA download progress is updated while HTTP body chunks are written to the inactive OTA partition. Reaching 100% therefore only means that all expected bytes were written — it does not mean that the OTA image has been finalized or selected as the next boot partition.

Finalization was performed from the HTTP client's `onClose` callback:

```cpp
if (Update.isRunning()) {
  if (http_update_end()) {
    restart_system();
  }
}
```

This made successful installation dependent on the socket-close event occurring after the last HTTP body chunk.

When that callback did not complete the expected path:
- the GUI remained at 100%
- `Update.end()` was not called
- the new partition was not activated
- no reboot was scheduled

The previous code also called `Update.end(true)`, which permits finalization even when bytes remain. A prematurely closed connection could therefore attempt to finalize an **incomplete image**.

Finally, errors occurring after progress reached 100% were not clearly propagated to the GUI, making a finalization failure indistinguishable from a stalled update.

---

## Resolution

The update is now finalized from `MG_EV_HTTP_REPLY`, which indicates that the complete HTTP response has been received.

**New flow:**

1. Stream each response body chunk into the OTA partition.
2. Track the number of bytes successfully written.
3. On receipt of the complete HTTP response, verify that the downloaded size matches `Content-Length`.
4. Call `Update.end(false)` so incomplete images are rejected.
5. Activate the new boot partition.
6. Emit the `ota: completed` event.
7. Schedule the system reboot.

The `onClose` callback is now only used to detect an interrupted transfer. If the socket closes before the complete response is received, the update is aborted and reported as failed.

---

## Additional Changes

- Reset OTA progress state when starting a new update.
- Prevent progress calculations from exceeding 100%.
- Add a dedicated incomplete-download error code.
- Include `ota_error` in failure events sent to the GUI.
- Log the underlying Arduino `Update` error when finalization fails.
- Preserve redirect handling for GitHub release assets.

---

## Result

A complete HTTP download no longer waits for a later socket-close callback before being installed. Once the response is fully received and validated, the firmware is finalized and the device reboots into the new image.

Interrupted or invalid downloads now fail explicitly instead of leaving the GUI stuck at 100%.
