### PR TITLE
Fix wifi scanning in STA/Wizard mode 

### DIFF
--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -152,6 +152,7 @@ void NetManagerTask::wifiStopAccessPoint()
 // -------------------------------------------------------------------
 void NetManagerTask::wifiStartClient()
 {
+  WiFi.setAutoReconnect(true);
   wifiClientConnect();
 
   _led.setWifiMode(true, false);
@@ -182,9 +183,22 @@ bool NetManagerTask::wifiScanNetworks(WiFiScanCompleteCallback callback)
     return true;
   }
 
+  // A pending STA connection has priority over scanning in ESP-IDF and makes
+  // esp_wifi_scan_start() fail immediately. This is especially visible while
+  // provisioning through the SoftAP. Stop the STA attempt without disabling
+  // the radio (which would also drop the SoftAP), then let the scan run first.
+  if(isWifiModeAp() && !isWifiClientConnected()) {
+    WiFi.setAutoReconnect(false);
+    WiFi.disconnect(false, false);
+    delay(100);
+  }
+
   _scanCompleteCallbacks.push_back(callback);
   if(WiFi.scanNetworks(true, false, false) != WIFI_SCAN_RUNNING) {
     _scanCompleteCallbacks.pop_back();
+    if(esid.length() > 0) {
+      WiFi.setAutoReconnect(true);
+    }
     return false;
   }
 
@@ -474,6 +488,9 @@ void NetManagerTask::onNetEvent(WiFiEvent_t event, arduino_event_info_t &info)
 
       _scanCompleteCallbacks.clear();
       WiFi.scanDelete();
+      if(esid.length() > 0) {
+        WiFi.setAutoReconnect(true);
+      }
     } break;
 #ifdef ENABLE_WIRED_ETHERNET
     case ARDUINO_EVENT_ETH_START:
@@ -688,7 +705,8 @@ unsigned long NetManagerTask::manageState()
       }
       // Intentionally fall through to AP State for the same client reconnect logic
     case NetState::AccessPointConnecting:
-      if(!isWifiClientConnected() && esid != 0 && esid != "" && millis() > _clientRetryTime) {
+      if(!isWifiClientConnected() && esid != 0 && esid != "" &&
+         WiFi.scanComplete() != WIFI_SCAN_RUNNING && millis() > _clientRetryTime) {
         wifiClientConnect();
       }
 

--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -175,12 +175,20 @@ void NetManagerTask::wifiClientConnect()
   _clientRetryTime = millis() + WIFI_CLIENT_RETRY_TIMEOUT;
 }
 
-void NetManagerTask::wifiScanNetworks(WiFiScanCompleteCallback callback)
+bool NetManagerTask::wifiScanNetworks(WiFiScanCompleteCallback callback)
 {
-  if(WiFi.scanComplete() != WIFI_SCAN_RUNNING) {
-    WiFi.scanNetworks(true, false, false);
+  if(WiFi.scanComplete() == WIFI_SCAN_RUNNING) {
+    _scanCompleteCallbacks.push_back(callback);
+    return true;
   }
+
   _scanCompleteCallbacks.push_back(callback);
+  if(WiFi.scanNetworks(true, false, false) != WIFI_SCAN_RUNNING) {
+    _scanCompleteCallbacks.pop_back();
+    return false;
+  }
+
+  return true;
 }
 
 void NetManagerTask::displayState()

--- a/src/net_manager.h
+++ b/src/net_manager.h
@@ -183,7 +183,7 @@ class NetManagerTask : public MicroTasks::Task
     void wifiTurnOffAp();
     void wifiTurnOnAp();
 
-    void wifiScanNetworks(WiFiScanCompleteCallback callback);
+    bool wifiScanNetworks(WiFiScanCompleteCallback callback);
 
     bool isConnected();
     bool isWifiClientConnected();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -317,11 +317,8 @@ void buildStatus(DynamicJsonDocument &doc) {
 }
 
 // -------------------------------------------------------------------
-// Wifi scan /scan not currently used
+// Wifi scan
 // url: /scan
-//
-// First request will return 0 results unless you start scan from somewhere else (loop/setup)
-// Do not request more often than 3-5 seconds
 // -------------------------------------------------------------------
 void
 handleScan(MongooseHttpServerRequest *request) {
@@ -331,23 +328,28 @@ handleScan(MongooseHttpServerRequest *request) {
   }
 
   DBUGF("Starting WiFi scan");
-  net.wifiScanNetworks([request, response](int networksFound) {
+  bool scanStarted = net.wifiScanNetworks([request, response](int networksFound) {
     DBUGF("%d networks found", networksFound);
-    String json = "[";
+    response->print("[");
     for (int i = 0; i < networksFound; ++i) {
-      if(i) json += ",";
-      json += "{";
-      json += "\"rssi\":"+String(WiFi.RSSI(i));
-      json += ",\"ssid\":\""+WiFi.SSID(i)+"\"";
-      json += ",\"bssid\":\""+WiFi.BSSIDstr(i)+"\"";
-      json += ",\"channel\":"+String(WiFi.channel(i));
-      json += ",\"secure\":"+String(WiFi.encryptionType(i));
-      json += "}";
+      if(i) response->print(",");
+      StaticJsonDocument<256> network;
+      network["rssi"] = WiFi.RSSI(i);
+      network["ssid"] = WiFi.SSID(i);
+      network["bssid"] = WiFi.BSSIDstr(i);
+      network["channel"] = WiFi.channel(i);
+      network["secure"] = WiFi.encryptionType(i);
+      serializeJson(network, *response);
     }
-    json += "]";
-    response->print(json);
+    response->print("]");
     request->send(response);
   });
+
+  if(!scanStarted) {
+    DBUGLN("WiFi scan failed to start");
+    response->print("[]");
+    request->send(response);
+  }
 }
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix WiFi network scanning when provisioning an unconfigured module through its access point.

## Problem

WiFi scans worked after a station network was configured, but consistently failed during the first-run wizard in AP mode.

A pending STA connection or automatic reconnect can take priority over scanning and cause `esp_wifi_scan_start()` to fail immediately.

The `/scan` endpoint also did not handle scan startup failures and manually constructed JSON, which could produce invalid responses for SSIDs containing special characters.

## Changes

- Cancel pending STA connection attempts before scanning in AP mode.
- Temporarily disable STA auto-reconnect during the scan.
- Prevent `WiFi.begin()` from running while a scan is active.
- Restore auto-reconnect after the scan completes.
- Return an empty result if the scan cannot start instead of leaving the HTTP request pending.
- Serialize scan results with ArduinoJson so SSIDs are escaped correctly.
