### PR TITLE
fix(divert): stop publishing tripled 3-phase voltage

### DIFF
--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -160,9 +160,14 @@ void DivertTask::update_state()
   // If divert mode = Eco (2)
   if (_mode == DivertMode::Eco)
   {
+    // voltage = per-phase voltage, kept as the published value (consistent with
+    // evse_monitor's canonical ~240V). calc_voltage = the value used for the divert
+    // current math, which is tripled on 3-phase. Publishing the tripled value here
+    // leaked 720V over /ws and flickered the GUI PowerRing (gui-nightshift#16).
     double voltage = _evse->getVoltage();
+    double calc_voltage = voltage;
     if (config_threephase_enabled()) {
-      voltage = voltage * 3;
+      calc_voltage = voltage * 3;
     }
 
     // Calculate current
@@ -173,8 +178,8 @@ void DivertTask::update_state()
       // grid_ie is negative when exporting
       // If grid feeds is available and exporting (negative)
 
-      DBUGVAR(voltage);
-      double Igrid_ie = (double)grid_ie / voltage;
+      DBUGVAR(calc_voltage);
+      double Igrid_ie = (double)grid_ie / calc_voltage;
       DBUGVAR(Igrid_ie);
 
       // Subtract the current charge the EV is using from the Grid IE
@@ -187,7 +192,7 @@ void DivertTask::update_state()
       if (Igrid_ie < 0)
       {
         // If excess power
-        double reserve = (1000.0 * ((divert_PV_ratio > 1.0) ? (divert_PV_ratio - 1.0) : 0.0)) / voltage;
+        double reserve = (1000.0 * ((divert_PV_ratio > 1.0) ? (divert_PV_ratio - 1.0) : 0.0)) / calc_voltage;
         DBUGVAR(reserve);
         _available_current = (-Igrid_ie - reserve);
       }
@@ -200,8 +205,8 @@ void DivertTask::update_state()
     else if (divert_type == DIVERT_TYPE_SOLAR)
     {
       // if grid feed is not available: charge rate = solar generation
-      DBUGVAR(voltage);
-      _available_current = (double)solar / voltage;
+      DBUGVAR(calc_voltage);
+      _available_current = (double)solar / calc_voltage;
     }
 
     if(_available_current < 0) {


### PR DESCRIPTION
## Problem

On 3-phase setups, the Eco-mode divert event publishes **720 V** in its `voltage` field instead of the real per-phase ~240 V.

In `src/divert.cpp`, the Eco branch reads the per-phase voltage and triples it for the divert **current** calculation:

```cpp
double voltage = _evse->getVoltage();
if (config_threephase_enabled()) {
  voltage = voltage * 3;        // needed for the current math below
}
...
event["voltage"] = voltage;     // but this then leaks the ×3 value (720 V)
```

That event goes out over `/ws` and MQTT. A web UI that merges WS messages into a shared status store ends up with `voltage` bouncing between 240 (from the canonical `evse_monitor` amp/volt event) and 720 (each Eco cycle) — a visible flicker on the dashboard.

`evse_monitor.cpp` is the canonical voltage source: it clamps to `VOLTAGE_MINIMUM..MAXIMUM` and publishes the per-phase value (~240 V); it triples **power**, not voltage. That's the value consumers should always see.

## Fix

Keep `voltage` as the per-phase reading (the published value, consistent with `evse_monitor`) and use a separate `calc_voltage` for the divert current math only:

- `voltage` → published in `event["voltage"]` (per-phase, ~240 V)
- `calc_voltage` (= `voltage * 3` on 3-phase) → used by every divert division: `Igrid_ie`, the PV `reserve` term, and the solar path

Divert charge-current decisions are unchanged — all the current math still uses the tripled value on 3-phase. Only the public `voltage` field changes: it no longer jumps to 720.

`current_shaper.cpp` and `energy_meter.cpp` also apply the 3-phase ×3 but keep it internal and don't publish a tripled voltage, so they're left as-is.

## Verification

- Builds clean (`openevse_wifi_v1`).
- With 3-phase + Eco/divert active, the `voltage` field on `/ws` stays ~240 and never jumps to 720; divert decisions are identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)