### PR TITLE
Load sharing: enforce member failsafe, config validation, priority + rotation

### DIFF
--- a/divert_sim/data/scenarios/loadsharing_priority_wins.json
+++ b/divert_sim/data/scenarios/loadsharing_priority_wins.json
@@ -1,0 +1,44 @@
+{
+  "meta": {
+    "id": "loadsharing_priority_wins",
+    "title": "Load Sharing - priority selects the winner under scarcity",
+    "category": "loadsharing",
+    "profile": "default"
+  },
+  "group": {
+    "safety_factor": 1.0,
+    "failsafe_mode": "safe_current",
+    "failsafe_peer_assumed_current": 6.0
+  },
+  "simulation": {
+    "duration": 7200,
+    "tick_interval": 60,
+    "nominal_voltage": 240
+  },
+  "supply": {
+    "max_pwr": 2400,
+    "live_pwr": 0
+  },
+  "peers": [
+    {
+      "id": "evse-001",
+      "min_current": 6,
+      "max_current": 32,
+      "voltage": 240,
+      "priority": 10,
+      "ev": {"battery_capacity_kwh": 75, "initial_soc": 40, "max_charge_rate_kw": 7.2},
+      "initial": {"online": true, "vehicle": true},
+      "events": []
+    },
+    {
+      "id": "evse-002",
+      "min_current": 6,
+      "max_current": 32,
+      "voltage": 240,
+      "priority": 0,
+      "ev": {"battery_capacity_kwh": 75, "initial_soc": 40, "max_charge_rate_kw": 7.2},
+      "initial": {"online": true, "vehicle": true},
+      "events": []
+    }
+  ]
+}

--- a/divert_sim/data/scenarios/loadsharing_scarcity_rotation.json
+++ b/divert_sim/data/scenarios/loadsharing_scarcity_rotation.json
@@ -1,0 +1,45 @@
+{
+  "meta": {
+    "id": "loadsharing_scarcity_rotation",
+    "title": "Load Sharing Scarcity - equal-priority rotation",
+    "category": "loadsharing",
+    "profile": "default"
+  },
+  "group": {
+    "safety_factor": 1.0,
+    "failsafe_mode": "safe_current",
+    "failsafe_peer_assumed_current": 6.0,
+    "rotation_interval": 1800
+  },
+  "simulation": {
+    "duration": 7200,
+    "tick_interval": 60,
+    "nominal_voltage": 240
+  },
+  "supply": {
+    "max_pwr": 2400,
+    "live_pwr": 0
+  },
+  "peers": [
+    {
+      "id": "evse-001",
+      "min_current": 6,
+      "max_current": 32,
+      "voltage": 240,
+      "priority": 0,
+      "ev": {"battery_capacity_kwh": 75, "initial_soc": 40, "max_charge_rate_kw": 7.2},
+      "initial": {"online": true, "vehicle": true},
+      "events": []
+    },
+    {
+      "id": "evse-002",
+      "min_current": 6,
+      "max_current": 32,
+      "voltage": 240,
+      "priority": 0,
+      "ev": {"battery_capacity_kwh": 75, "initial_soc": 40, "max_charge_rate_kw": 7.2},
+      "initial": {"online": true, "vehicle": true},
+      "events": []
+    }
+  ]
+}

--- a/divert_sim/sim/runner.cpp
+++ b/divert_sim/sim/runner.cpp
@@ -191,6 +191,7 @@ int run(const std::string &scenario_path,
   EpoxyTest::set_millis(fake_millis);
 
   bool failsafe_active = false;
+  LoadSharingRotationState rotationState;
 
   while (t_sec <= scenario.duration_sec) {
     // Keep divert's time source aligned with simulation time so minimum
@@ -245,7 +246,10 @@ int run(const std::string &scenario_path,
           scenario.group.safety_factor,
           scenario.group.failsafe_peer_assumed_current,
           String(scenario.group.failsafe_mode.c_str()),
-          failsafe_active);
+          failsafe_active,
+          rotationState,
+          (unsigned long) t_sec * 1000UL,
+          (unsigned long) scenario.group.rotation_interval * 1000UL);
 
       for (const auto &a : allocs) {
         for (auto &p : peers) {

--- a/divert_sim/sim/scenario.cpp
+++ b/divert_sim/sim/scenario.cpp
@@ -87,6 +87,7 @@ bool Scenario::loadFromFile(const std::string &path)
     }
     group.failsafe_peer_assumed_current =
         grp["failsafe_peer_assumed_current"] | 6.0;
+    group.rotation_interval = grp["rotation_interval"] | 1800;
   }
 
   // Backward-compat: old scenario files use a top-level "supply" object with

--- a/divert_sim/sim/scenario.h
+++ b/divert_sim/sim/scenario.h
@@ -1,6 +1,7 @@
 #ifndef _DIVERT_SIM_SIM_SCENARIO_H
 #define _DIVERT_SIM_SIM_SCENARIO_H
 
+#include <cstdint>
 #include <ctime>
 #include <string>
 #include <vector>
@@ -66,6 +67,7 @@ struct GroupScenario
   double safety_factor = 1.0;
   std::string failsafe_mode = "safe_current";
   double failsafe_peer_assumed_current = 6.0;
+  uint32_t rotation_interval = 1800;
 };
 
 struct Scenario

--- a/divert_sim/test_loadsharing.py
+++ b/divert_sim/test_loadsharing.py
@@ -116,3 +116,18 @@ def test_loadsharing_finished_ev_stops_then_requests_aux_load():
     assert rows_by_time[1800]["evse-001_state"] == "charging"
     assert rows_by_time[1800]["evse-001_actual"] > 0.0
     assert rows_by_time[1800]["evse-002_actual"] > 0.0
+
+
+def test_loadsharing_priority_selects_winner_under_scarcity():
+    """Priority (lower value = higher priority, per loadsharing_algorithm.h)
+    decides who charges when the budget only fits one minimum: evse-002
+    (priority 0) must win over evse-001 (priority 10) despite its higher id."""
+    result = run_loadsharing_simulation(
+        "data/scenarios/loadsharing_priority_wins.json",
+        "loadsharing_priority_wins",
+    )
+    for row in result["_rows"]:
+        assert row["evse-002_allocated"] == approx(6.0)
+        assert row["evse-001_allocated"] == approx(0.0)
+    assert result["_rows"][-1]["evse-002_reason"] == "min_subset"
+    assert result["_rows"][-1]["evse-001_reason"] == "insufficient"

--- a/divert_sim/test_loadsharing.py
+++ b/divert_sim/test_loadsharing.py
@@ -118,6 +118,33 @@ def test_loadsharing_finished_ev_stops_then_requests_aux_load():
     assert rows_by_time[1800]["evse-002_actual"] > 0.0
 
 
+def test_loadsharing_scarcity_rotates_equal_priority_peers():
+    """Under scarcity, equal-priority peers time-slice: the winner rotates
+    every rotation_interval (1800 s here), so both cars make progress
+    instead of the lowest id starving the other all night."""
+    result = run_loadsharing_simulation(
+        "data/scenarios/loadsharing_scarcity_rotation.json",
+        "loadsharing_scarcity_rotation",
+    )
+    rows = result["_rows"]
+    winners = []
+    for row in rows:
+        one, two = row["evse-001_allocated"], row["evse-002_allocated"]
+        # Exactly one winner at the 6 A minimum each tick; never both.
+        assert sorted([one, two]) == [approx(0.0), approx(6.0)]
+        winners.append("evse-001" if one > 0 else "evse-002")
+
+    # The winner changes over the run (no permanent starvation)...
+    assert len(set(winners)) == 2, "rotation never happened"
+    # ...and each peer holds the slot for a contiguous window, not per-tick
+    # flapping: count winner changes. With the rotation clock seeded on the
+    # first call (t=0), windows run from t=0 and the offset advances at
+    # 1800/3600/5400/7200 s. The 7200 s run's last tick lands on the final
+    # boundary, so a 7200 s run at a 1800 s interval yields 4 changes.
+    changes = sum(1 for a, b in zip(winners, winners[1:]) if a != b)
+    assert changes == 4, f"expected 4 rotations in 2 h at 30 min, got {changes}"
+
+
 def test_loadsharing_priority_selects_winner_under_scarcity():
     """Priority (lower value = higher priority, per loadsharing_algorithm.h)
     decides who charges when the budget only fits one minimum: evse-002

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -184,6 +184,7 @@ uint32_t loadsharing_config_version;
 uint32_t loadsharing_config_updated_at;
 String loadsharing_role;
 String loadsharing_controller_host;
+uint32_t loadsharing_rotation_interval;
 
 String esp_hostname_default = "openevse-"+ESPAL.getShortId();
 
@@ -329,6 +330,8 @@ ConfigOpt *opts[] =
   new ConfigOptDefinition<uint32_t>(loadsharing_config_updated_at, 0, "loadsharing_config_updated_at", "lscua"),
   new ConfigOptDefinition<String>(loadsharing_role, "", "loadsharing_role", "lsr"),
   new ConfigOptDefinition<String>(loadsharing_controller_host, "", "loadsharing_controller_host", "lsch"),
+  // Rotation interval in seconds (0 disables). Effective max ~49 days on 32-bit millis; larger values wrap.
+  new ConfigOptDefinition<uint32_t>(loadsharing_rotation_interval, 1800, "loadsharing_rotation_interval", "lsri"),
 
 // Scheduler options
   new ConfigOptDefinition<uint32_t>(scheduler_start_window, SCHEDULER_DEFAULT_START_WINDOW, "scheduler_start_window", "ssw"),

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -117,6 +117,7 @@ extern uint32_t loadsharing_config_version;
 extern uint32_t loadsharing_config_updated_at;
 extern String loadsharing_role;
 extern String loadsharing_controller_host;
+extern uint32_t loadsharing_rotation_interval;
 
 //Shaper settings
 extern uint32_t current_shaper_max_pwr;

--- a/src/loadsharing_algorithm.cpp
+++ b/src/loadsharing_algorithm.cpp
@@ -19,7 +19,10 @@ std::vector<LoadSharingAllocation> computeAllocations(
     double safety_factor,
     double failsafe_peer_assumed_current,
     const String& failsafe_mode,
-    bool& failsafe_active)
+    bool& failsafe_active,
+    LoadSharingRotationState& rotation,
+    unsigned long now_ms,
+    unsigned long rotation_interval_ms)
 {
   std::vector<LoadSharingAllocation> result;
   failsafe_active = false;
@@ -93,6 +96,38 @@ std::vector<LoadSharingAllocation> computeAllocations(
       }
       return members[a].id < members[b].id;
     });
+
+  // Time-slice equal-priority members under scarcity: advance a rotation
+  // offset every rotation_interval and rotate each equal-priority run of
+  // the demanding list by it. With ample budget the reorder is harmless
+  // (equal-share is order-insensitive); under scarcity it moves the front
+  // of the line so the same peer doesn't starve indefinitely.
+  if (rotation_interval_ms > 0 && demanding_indices.size() > 1) {
+    if (!rotation.initialized) {
+      rotation.initialized = true;
+      rotation.last_rotation_ms = now_ms;
+    } else if ((unsigned long)(now_ms - rotation.last_rotation_ms) >= rotation_interval_ms) {
+      rotation.offset++;
+      rotation.last_rotation_ms = now_ms;
+    }
+
+    size_t runStart = 0;
+    while (runStart < demanding_indices.size()) {
+      size_t runEnd = runStart + 1;
+      while (runEnd < demanding_indices.size() &&
+             members[demanding_indices[runEnd]].priority ==
+             members[demanding_indices[runStart]].priority) {
+        runEnd++;
+      }
+      size_t runLen = runEnd - runStart;
+      if (runLen > 1 && (rotation.offset % runLen) != 0) {
+        std::rotate(demanding_indices.begin() + runStart,
+                    demanding_indices.begin() + runStart + (rotation.offset % runLen),
+                    demanding_indices.begin() + runEnd);
+      }
+      runStart = runEnd;
+    }
+  }
 
   // Compute total minimum current needed
   double total_min = 0.0;

--- a/src/loadsharing_algorithm.cpp
+++ b/src/loadsharing_algorithm.cpp
@@ -84,9 +84,13 @@ std::vector<LoadSharingAllocation> computeAllocations(
     return result;
   }
 
-  // Sort demanding members by id for deterministic ordering
+  // Sort demanding members by priority (lower value = higher priority),
+  // then by id for a deterministic order within equal priority.
   std::sort(demanding_indices.begin(), demanding_indices.end(),
-    [&members](size_t a, size_t b) {
+    [&members](size_t a, size_t b) -> bool {
+      if (members[a].priority != members[b].priority) {
+        return members[a].priority < members[b].priority;
+      }
       return members[a].id < members[b].id;
     });
 

--- a/src/loadsharing_algorithm.h
+++ b/src/loadsharing_algorithm.h
@@ -27,7 +27,8 @@ struct AllocationInput {
  * 3. Determine demanding online members
  * 4. If no demand: all get 0
  * 5. If enough for all minimums: allocate min + equal share of remainder (capped by max)
- * 6. If insufficient: select deterministic subset (sorted by id) until minimums fit
+ * 6. If insufficient: select subset sorted by priority (lower value = higher
+ *    priority), then id, until minimums fit
  *
  * @param members Input list of all group members (including self)
  * @param group_max_current Total circuit limit (amps)

--- a/src/loadsharing_algorithm.h
+++ b/src/loadsharing_algorithm.h
@@ -19,6 +19,19 @@ struct AllocationInput {
 };
 
 /**
+ * @brief Rotation state for time-slicing equal-priority members under scarcity.
+ *
+ * Persisted by the caller across allocation computations. The offset advances
+ * once per rotation_interval and reorders each equal-priority run of the
+ * demanding list so the same peer does not starve indefinitely.
+ */
+struct LoadSharingRotationState {
+  uint32_t offset = 0;
+  bool initialized = false;
+  unsigned long last_rotation_ms = 0;
+};
+
+/**
  * @brief Compute load sharing allocations using "Equal Share with Minimums" algorithm.
  *
  * Algorithm steps:
@@ -29,6 +42,9 @@ struct AllocationInput {
  * 5. If enough for all minimums: allocate min + equal share of remainder (capped by max)
  * 6. If insufficient: select subset sorted by priority (lower value = higher
  *    priority), then id, until minimums fit
+ * 7. Under scarcity, rotate the front of each equal-priority run every
+ *    rotation_interval_ms so equal-priority members time-slice instead of the
+ *    lowest id starving the rest (rotation_interval_ms == 0 disables this).
  *
  * @param members Input list of all group members (including self)
  * @param group_max_current Total circuit limit (amps)
@@ -36,7 +52,14 @@ struct AllocationInput {
  * @param failsafe_peer_assumed_current Conservative current for offline peers (amps)
  * @param failsafe_mode "safe_current" or "disable"
  * @param[out] failsafe_active Set to true if failsafe mode is engaged
+ * @param[in,out] rotation Rotation state persisted across calls (see below)
+ * @param now_ms Current time in milliseconds (millis() in firmware, sim time in tests)
+ * @param rotation_interval_ms Rotation period in ms; 0 disables rotation
  * @return Per-member allocation results
+ *
+ * @note Rotation only reorders the demanding list; the allocation math is
+ *       unchanged. With ample budget the reorder is harmless (equal-share is
+ *       order-insensitive). rotation_interval_ms == 0 disables rotation.
  */
 std::vector<LoadSharingAllocation> computeAllocations(
     const std::vector<AllocationInput>& members,
@@ -44,7 +67,10 @@ std::vector<LoadSharingAllocation> computeAllocations(
     double safety_factor,
     double failsafe_peer_assumed_current,
     const String& failsafe_mode,
-    bool& failsafe_active
+    bool& failsafe_active,
+    LoadSharingRotationState& rotation,
+    unsigned long now_ms,
+    unsigned long rotation_interval_ms
 );
 
 #endif // LOADSHARING_ALGORITHM_H

--- a/src/loadsharing_peer_poller.cpp
+++ b/src/loadsharing_peer_poller.cpp
@@ -784,7 +784,10 @@ void LoadSharingPeerPoller::recomputeAndPushAllocations() {
     loadsharing_safety_factor,
     loadsharing_failsafe_peer_assumed_current,
     loadsharing_failsafe_mode,
-    failsafe_active
+    failsafe_active,
+    _rotationState,
+    millis(),
+    loadsharing_rotation_interval * 1000UL
   );
 
   // Update group state

--- a/src/loadsharing_peer_poller.cpp
+++ b/src/loadsharing_peer_poller.cpp
@@ -101,9 +101,37 @@ unsigned long LoadSharingPeerPoller::loop(MicroTasks::WakeReason reason) {
     }
   }
 
-  // Member failsafe timeout check
+  // Member failsafe timeout check + local enforcement
   if (_groupState && _groupState->isMember()) {
     _groupState->checkMemberFailsafe();
+
+    if (_groupState->isFailsafeActive()) {
+      if (!_failsafeLimitApplied) {
+        // Enforce the failsafe on the local EVSE through the same shaper
+        // override the allocation path uses, so it outranks a manual override.
+        // Note: a change to loadsharing_failsafe_safe_current while failsafe is
+        // already engaged takes effect on the next engage, not mid-engagement
+        // (the limit is set once here and not re-issued while it holds).
+        if (loadsharing_failsafe_mode == "disable" ||
+            loadsharing_failsafe_safe_current <= 0) {
+          shaper.setLoadSharingLimit(0, true);
+        } else {
+          shaper.setLoadSharingLimit(loadsharing_failsafe_safe_current);
+        }
+        _failsafeLimitApplied = true;
+        DBUGF("LoadSharing: member failsafe limit applied (%s)",
+              loadsharing_failsafe_mode.c_str());
+      }
+    } else if (_failsafeLimitApplied) {
+      // Failsafe cleared: a fresh allocation has been received, and the
+      // allocation handler (web_server.cpp onWsFrame) has already replaced
+      // this limit with the allocation limit. Just drop our marker.
+      _failsafeLimitApplied = false;
+    }
+  } else if (_failsafeLimitApplied) {
+    // Left member role with a failsafe limit outstanding: release it.
+    shaper.clearLoadSharingLimit();
+    _failsafeLimitApplied = false;
   }
 
   // Wake again after poll interval

--- a/src/loadsharing_peer_poller.h
+++ b/src/loadsharing_peer_poller.h
@@ -224,6 +224,11 @@ private:
   bool _failsafeLimitApplied = false;
 
   /**
+   * @brief Rotation state for time-slicing equal-priority members under scarcity
+   */
+  LoadSharingRotationState _rotationState;
+
+  /**
    * @brief Recompute allocations and push to members (controller only)
    */
   void recomputeAndPushAllocations();

--- a/src/loadsharing_peer_poller.h
+++ b/src/loadsharing_peer_poller.h
@@ -219,6 +219,11 @@ private:
   unsigned long _lastAllocationTime;
 
   /**
+   * @brief True while the member failsafe limit is in place on the shaper
+   */
+  bool _failsafeLimitApplied = false;
+
+  /**
    * @brief Recompute allocations and push to members (controller only)
    */
   void recomputeAndPushAllocations();

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1237,6 +1237,10 @@ void onWsFrame(MongooseHttpWebSocketConnection *connection, int flags, uint8_t *
             shaper.setLoadSharingLimit(targetCurrent, reason == "failsafe_disabled");
           } else {
             // No active load sharing limit; release shaper-side load sharing override.
+            // The poller's _failsafeLimitApplied flag may briefly read true here
+            // with no backing shaper limit (this clear removed it). That is safe:
+            // re-engaging failsafe requires seconds of allocation staleness, and
+            // any intervening 500 ms poll clears the flag before then.
             shaper.clearLoadSharingLimit();
           }
         }

--- a/src/web_server_config.cpp
+++ b/src/web_server_config.cpp
@@ -115,6 +115,22 @@ handleConfigPost(MongooseHttpServerRequest *request, MongooseHttpServerResponseS
         return;
       }
     }
+    // Cross-field: a member's failsafe current must fit inside the group
+    // budget, otherwise a single islanded member can exceed the group max
+    // on its own. Use incoming values when present, stored values otherwise.
+    {
+      double failsafe = doc.containsKey("loadsharing_failsafe_safe_current")
+          ? doc["loadsharing_failsafe_safe_current"].as<double>()
+          : loadsharing_failsafe_safe_current;
+      double groupMax = doc.containsKey("loadsharing_group_max_current")
+          ? doc["loadsharing_group_max_current"].as<double>()
+          : loadsharing_group_max_current;
+      if (groupMax > 0 && failsafe > groupMax) {
+        response->setCode(400);
+        response->print("{\"msg\":\"loadsharing_failsafe_safe_current must not exceed loadsharing_group_max_current\"}");
+        return;
+      }
+    }
 
     // Role transitions are applied after validation so that a rejected
     // request does not mutate group-membership state as a side effect.

--- a/src/web_server_config.cpp
+++ b/src/web_server_config.cpp
@@ -66,21 +66,6 @@ handleConfigPost(MongooseHttpServerRequest *request, MongooseHttpServerResponseS
       }
     }
 
-    // If this is a config push that sets role=member, handle the role transition
-    if (doc.containsKey("loadsharing_role") &&
-        doc["loadsharing_role"].as<String>() == "member" &&
-        doc.containsKey("loadsharing_controller_host")) {
-      String controllerHost = doc["loadsharing_controller_host"].as<String>();
-      loadSharingGroupState.becomeMember(controllerHost);
-    }
-
-    // If this is a config push that resets the role (member removal)
-    if (doc.containsKey("loadsharing_role") &&
-        doc["loadsharing_role"].as<String>() == "" &&
-        loadSharingGroupState.isMember()) {
-      loadSharingGroupState.resetRole();
-    }
-
     // Validate load sharing config ranges
     if (doc.containsKey("loadsharing_group_max_current")) {
       double val = doc["loadsharing_group_max_current"].as<double>();
@@ -129,6 +114,20 @@ handleConfigPost(MongooseHttpServerRequest *request, MongooseHttpServerResponseS
         response->print("{\"msg\":\"loadsharing_failsafe_mode must be 'safe_current' or 'disable'\"}");
         return;
       }
+    }
+
+    // Role transitions are applied after validation so that a rejected
+    // request does not mutate group-membership state as a side effect.
+    if (doc.containsKey("loadsharing_role") &&
+        doc["loadsharing_role"].as<String>() == "member" &&
+        doc.containsKey("loadsharing_controller_host")) {
+      String controllerHost = doc["loadsharing_controller_host"].as<String>();
+      loadSharingGroupState.becomeMember(controllerHost);
+    }
+    if (doc.containsKey("loadsharing_role") &&
+        doc["loadsharing_role"].as<String>() == "" &&
+        loadSharingGroupState.isMember()) {
+      loadSharingGroupState.resetRole();
     }
 
     // Update WiFi module config

--- a/src/web_server_loadsharing.cpp
+++ b/src/web_server_loadsharing.cpp
@@ -178,9 +178,12 @@ void handleLoadSharingPeersPost(MongooseHttpServerRequest *request, MongooseHttp
 
   // Add to group peers list via group state
   if (!loadSharingGroupState.addGroupPeer(host)) {
-    DBUGF("[LoadSharing] Peer already in group: %s", host.c_str());
-    response->setCode(400);
-    response->print("{\"msg\":\"Peer already in group\"}");
+    // Already present: treat as an idempotent no-op. mDNS auto-discovery
+    // racing a manual add (or a repeated reciprocal sync) is a normal
+    // sequence, not a client error.
+    DBUGF("[LoadSharing] Peer already in group (idempotent add): %s", host.c_str());
+    response->setCode(200);
+    response->print("{\"msg\":\"already in group\"}");
     return;
   }
 

--- a/tests/integration/test_loadsharing_drills.py
+++ b/tests/integration/test_loadsharing_drills.py
@@ -1,0 +1,191 @@
+"""
+Load-sharing failure-mode drills (bench for OpenEVSE issue #940).
+
+Drill A: a member whose controller is unreachable must report failsafe
+         within loadsharing_heartbeat_timeout (+ margin). Measures whether
+         and when the member-side failsafe engages, and whether that
+         failsafe is actually *enforced* on the local EVSE (via a
+         LoadSharing claim) or is merely a status flag.
+
+Drill B: a manual override on a member is compared against its
+         load-sharing allocation/claim -- documents the claim-priority
+         layering. Upstream places the LoadSharing claim at
+         EvseManager_Priority_Limit (1100), so a user override could be
+         outbid; the drill RECORDS which one actually wins at the claim
+         layer (it does not assert a winner).
+
+Drill C: a config whose per-member failsafe_safe_current (32 A) exceeds
+         the whole group_max_current (10 A) -- records whether the
+         firmware validates Sigma(failsafe) <= group budget at config time.
+
+Endpoint/key shapes verified against this branch's firmware:
+  POST /config          flat JSON of loadsharing_* keys (web_server_config.cpp);
+                        role=="member" + loadsharing_controller_host triggers
+                        becomeMember(); returns 200 {config_version,msg}.
+  GET  /config          flat JSON of all config keys.
+  GET  /loadsharing/status  has boolean failsafe_active (web_server_loadsharing.cpp).
+  POST /override        EvseProperties body: {"state":"active|disabled",
+                        "charge_current":<A>} -> 201 on claim (web_server.cpp).
+  GET  /claims          all client claims (web_server_claims.cpp).
+  GET  /claims/target   effective/winning EvseProperties.
+  GET  /status          has amp, pilot, state, voltage, vehicle.
+"""
+
+import time
+
+import pytest
+import requests
+
+HEARTBEAT_TIMEOUT_S = 30  # loadsharing_heartbeat_timeout (valid range 5..600)
+MARGIN_S = 15
+UNREACHABLE_CONTROLLER = "localhost:59999"  # nothing listens here
+
+
+def set_config(native_url, payload):
+    r = requests.post(f"{native_url}/config", json=payload, timeout=10)
+    assert r.status_code in (200, 201), f"POST /config -> {r.status_code}: {r.text}"
+    return r
+
+
+def get_config(native_url):
+    r = requests.get(f"{native_url}/config", timeout=5)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def get_loadsharing_status(native_url):
+    r = requests.get(f"{native_url}/loadsharing/status", timeout=5)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def get_claims(native_url):
+    r = requests.get(f"{native_url}/claims", timeout=5)
+    try:
+        body = r.json()
+    except Exception:
+        body = r.text
+    return r.status_code, body
+
+
+def make_member_config(**overrides):
+    cfg = {
+        "loadsharing_enabled": True,
+        "loadsharing_role": "member",
+        # Controller unreachable from t=0: nothing listens on this port.
+        "loadsharing_controller_host": UNREACHABLE_CONTROLLER,
+        "loadsharing_heartbeat_timeout": HEARTBEAT_TIMEOUT_S,
+        "loadsharing_failsafe_mode": "safe_current",
+        "loadsharing_failsafe_safe_current": 6.0,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+@pytest.mark.timeout(120)
+def test_member_failsafe_when_controller_unreachable(instance_pair):
+    """Drill A: member with a dead controller host engages failsafe."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    set_config(native_url, make_member_config())
+
+    start = time.time()
+    deadline = start + HEARTBEAT_TIMEOUT_S + MARGIN_S
+    engaged_at = None
+    status = None
+    while time.time() < deadline:
+        status = get_loadsharing_status(native_url)
+        if status.get("failsafe_active"):
+            engaged_at = time.time()
+            break
+        time.sleep(1.0)
+
+    latency = None if engaged_at is None else round(engaged_at - start, 1)
+    print(f"DRILL A: failsafe_active reached in ~{latency}s "
+          f"(poll granularity 1s, heartbeat_timeout={HEARTBEAT_TIMEOUT_S}s)")
+
+    # Is the failsafe actually ENFORCED locally, or is it only a status flag?
+    # A real enforcement would show up as an OpenEVSE_LoadSharing claim on
+    # the local EVSE limiting pilot to loadsharing_failsafe_safe_current.
+    claims_code, claims = get_claims(native_url)
+    ls_status = get_loadsharing_status(native_url)
+    print(f"DRILL A: /claims status={claims_code} body={claims}")
+    print(f"DRILL A: /loadsharing/status failsafe_active="
+          f"{ls_status.get('failsafe_active')} allocations={ls_status.get('allocations')}")
+
+    assert engaged_at is not None, (
+        f"failsafe_active never became true within "
+        f"{HEARTBEAT_TIMEOUT_S + MARGIN_S}s: {status}"
+    )
+
+
+@pytest.mark.timeout(180)
+def test_manual_override_vs_allocation_claim(instance_pair):
+    """Drill B (E4 evidence): with load sharing active on a member, apply a
+    manual override for MORE amps than any allocation/failsafe cap and record
+    which one wins at the EVSE claim layer. Records the outcome either way."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    set_config(native_url, make_member_config())
+
+    deadline = time.time() + HEARTBEAT_TIMEOUT_S + MARGIN_S
+    while time.time() < deadline:
+        if get_loadsharing_status(native_url).get("failsafe_active"):
+            break
+        time.sleep(1.0)
+    else:
+        pytest.skip("failsafe never engaged; Drill A must pass first")
+
+    # Snapshot claims BEFORE override (is the LoadSharing failsafe even
+    # placing a claim on the local EVSE?).
+    before_code, before_claims = get_claims(native_url)
+    print(f"DRILL B: /claims BEFORE override status={before_code} body={before_claims}")
+
+    # Manual override: the "user taps charge-now at full amps" action.
+    r = requests.post(f"{native_url}/override",
+                      json={"state": "active", "charge_current": 32},
+                      timeout=10)
+    print(f"DRILL B: POST /override status={r.status_code} body={r.text[:200]}")
+    assert r.status_code in (200, 201), r.text
+    time.sleep(3)
+
+    after_code, after_claims = get_claims(native_url)
+    target = requests.get(f"{native_url}/claims/target", timeout=5)
+    status = requests.get(f"{native_url}/status", timeout=5).json()
+    pilot_fields = {k: v for k, v in status.items()
+                    if 'current' in k or k in ('pilot', 'amp', 'state')}
+    print(f"DRILL B: /claims AFTER override status={after_code} body={after_claims}")
+    print(f"DRILL B: /claims/target status={target.status_code} body={target.text[:300]}")
+    print(f"DRILL B: /status pilot-relevant fields={pilot_fields}")
+    # The printed evidence (which client owns the effective target, and the
+    # resulting pilot) is the deliverable. Test passes if endpoints respond.
+
+
+@pytest.mark.timeout(60)
+def test_config_accepts_failsafe_exceeding_group_budget(instance_pair):
+    """Drill C: a failsafe safe-current (32 A) larger than the whole group
+    budget (10 A) should arguably be rejected at config time (spec rule:
+    sum of failsafe currents <= group max). Documents whether upstream
+    validates this today."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    r = requests.post(f"{native_url}/config", json={
+        "loadsharing_enabled": True,
+        "loadsharing_role": "member",
+        "loadsharing_controller_host": UNREACHABLE_CONTROLLER,
+        "loadsharing_group_max_current": 10.0,
+        # One member's failsafe alone (32 A) exceeds the 10 A group budget:
+        # if every member islands, the group draws well over budget.
+        "loadsharing_failsafe_safe_current": 32.0,
+    }, timeout=10)
+    print(f"DRILL C: POST /config status={r.status_code} body={r.text[:200]}")
+
+    stored = get_config(native_url)
+    print(f"DRILL C: stored loadsharing_failsafe_safe_current="
+          f"{stored.get('loadsharing_failsafe_safe_current')} "
+          f"loadsharing_group_max_current={stored.get('loadsharing_group_max_current')}")
+    # No assertion on acceptance/rejection -- the printed outcome is the
+    # evidence for the Sigma(failsafe) <= budget findings item either way.

--- a/tests/integration/test_loadsharing_fixes.py
+++ b/tests/integration/test_loadsharing_fixes.py
@@ -13,12 +13,48 @@ import pytest
 import requests
 
 
+SHAPER_CLIENT = 65548  # EvseClient_OpenEVSE_Shaper = EVC(vendor 1, 0x000C) = (1 << 16) | 12; Manual is 65537 in Drill B's output, confirming the encoding
+HEARTBEAT_TIMEOUT_S = 10
+MARGIN_S = 15
+
+
 def add_peer(native_url, host):
     return requests.post(
         f"{native_url}/loadsharing/peers",
         json={"host": host, "reciprocal": False},
         timeout=10,
     )
+
+
+def wait_for_failsafe(native_url, timeout_s):
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        r = requests.get(f"{native_url}/loadsharing/status", timeout=5)
+        if r.status_code == 200 and r.json().get("failsafe_active"):
+            return True
+        time.sleep(1.0)
+    return False
+
+
+def find_shaper_claim(native_url):
+    claims = requests.get(f"{native_url}/claims", timeout=5).json()
+    for c in claims:
+        if c.get("client") == SHAPER_CLIENT:
+            return c
+    return None
+
+
+def wait_for_shaper_claim(native_url, timeout_s=10):
+    """The shaper applies the load sharing limit from its own task loop
+    (2 s cadence), so the claim lands asynchronously after failsafe_active
+    flips — poll for it instead of asserting immediately."""
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        claim = find_shaper_claim(native_url)
+        if claim is not None:
+            return claim
+        time.sleep(0.5)
+    return None
 
 
 @pytest.mark.timeout(60)
@@ -78,4 +114,56 @@ def test_config_rejects_failsafe_exceeding_group_budget(instance_pair):
     assert late.status_code == 400, (
         f"failsafe-only update above stored group_max must be rejected, got "
         f"{late.status_code}: {late.text}"
+    )
+
+
+@pytest.mark.timeout(120)
+def test_member_failsafe_places_claim_and_caps_override(instance_pair):
+    """Finding 1 (Drills A+B flipped): an islanded member must actually
+    enforce its failsafe current — via the shaper's load sharing limit,
+    which places a Safety-priority Shaper claim — so a manual override
+    cannot exceed it."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    r = requests.post(f"{native_url}/config", json={
+        "loadsharing_enabled": True,
+        "loadsharing_role": "member",
+        "loadsharing_controller_host": "localhost:59999",
+        "loadsharing_heartbeat_timeout": HEARTBEAT_TIMEOUT_S,
+        "loadsharing_failsafe_mode": "safe_current",
+        "loadsharing_failsafe_safe_current": 6.0,
+        "loadsharing_group_max_current": 32.0,
+    }, timeout=10)
+    assert r.status_code == 200, r.text
+
+    assert wait_for_failsafe(native_url, HEARTBEAT_TIMEOUT_S + MARGIN_S)
+
+    claim = wait_for_shaper_claim(native_url)
+    assert claim is not None, "failsafe engaged but no Shaper claim placed"
+    assert claim.get("max_current") == 6, f"claim should cap at 6 A: {claim}"
+
+    # Manual override must not exceed the failsafe cap.
+    r = requests.post(f"{native_url}/override",
+                      json={"state": "active", "charge_current": 32},
+                      timeout=10)
+    assert r.status_code in (200, 201), r.text
+    time.sleep(3)
+    claim = find_shaper_claim(native_url)
+    assert claim is not None, "override displaced the failsafe claim"
+
+    # Effective limit: the Safety-priority (5000) Shaper claim outranks the
+    # Manual (1000) override, so the resolved target max_current stays 6 A even
+    # though the override asked for 32 A. Verify against the effective target
+    # (/claims/target), whose shape was recorded in Drill B: it reports the
+    # winning EvseProperties in `properties` and the owning client per field in
+    # `claims`.
+    target = requests.get(f"{native_url}/claims/target", timeout=5).json()
+    props = target.get("properties", {})
+    owners = target.get("claims", {})
+    assert props.get("max_current") == 6, (
+        f"override must not raise the effective cap above 6 A: {target}"
+    )
+    assert owners.get("max_current") == SHAPER_CLIENT, (
+        f"the failsafe (Shaper) claim must own the effective max_current: {target}"
     )

--- a/tests/integration/test_loadsharing_fixes.py
+++ b/tests/integration/test_loadsharing_fixes.py
@@ -42,3 +42,40 @@ def test_duplicate_peer_add_is_idempotent(instance_pair):
     peers = requests.get(f"{native_url}/loadsharing/peers", timeout=5).json()
     matches = [p for p in peers if p.get("host") == "peer-under-test.local"]
     assert len(matches) == 1, f"expected exactly one entry, got: {peers}"
+
+
+@pytest.mark.timeout(60)
+def test_config_rejects_failsafe_exceeding_group_budget(instance_pair):
+    """Finding 3 (Drill C flipped): a failsafe current larger than the
+    whole group budget means one islanded member alone can exceed the
+    group max — the config write must be rejected."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    r = requests.post(f"{native_url}/config", json={
+        "loadsharing_enabled": True,
+        "loadsharing_role": "member",
+        "loadsharing_controller_host": "localhost:59999",
+        "loadsharing_group_max_current": 10.0,
+        "loadsharing_failsafe_safe_current": 32.0,
+    }, timeout=10)
+    assert r.status_code == 400, (
+        f"expected rejection of failsafe 32A > group_max 10A, got "
+        f"{r.status_code}: {r.text}"
+    )
+
+    # A sane combination must still be accepted.
+    ok = requests.post(f"{native_url}/config", json={
+        "loadsharing_group_max_current": 10.0,
+        "loadsharing_failsafe_safe_current": 6.0,
+    }, timeout=10)
+    assert ok.status_code == 200, ok.text
+
+    # Cross-field check must also catch a later failsafe-only update.
+    late = requests.post(f"{native_url}/config", json={
+        "loadsharing_failsafe_safe_current": 12.0,
+    }, timeout=10)
+    assert late.status_code == 400, (
+        f"failsafe-only update above stored group_max must be rejected, got "
+        f"{late.status_code}: {late.text}"
+    )

--- a/tests/integration/test_loadsharing_fixes.py
+++ b/tests/integration/test_loadsharing_fixes.py
@@ -1,0 +1,44 @@
+"""
+Fix-verification tests for the #940 bench findings.
+
+Each test here asserts the FIXED behavior (they are the flipped
+counterparts of the outcome-recording drills in
+test_loadsharing_drills.py, which are kept unchanged as the record of
+what the branch did before these fixes).
+"""
+
+import time
+
+import pytest
+import requests
+
+
+def add_peer(native_url, host):
+    return requests.post(
+        f"{native_url}/loadsharing/peers",
+        json={"host": host, "reciprocal": False},
+        timeout=10,
+    )
+
+
+@pytest.mark.timeout(60)
+def test_duplicate_peer_add_is_idempotent(instance_pair):
+    """Finding 5: adding a peer that is already in the group must be a
+    200 no-op, not a 400 — mDNS auto-join followed by a manual add is a
+    normal sequence, not an error."""
+    pair = instance_pair(port_offset=0)
+    native_url = pair["native_url"]
+
+    first = add_peer(native_url, "peer-under-test.local")
+    assert first.status_code == 200, first.text
+
+    second = add_peer(native_url, "peer-under-test.local")
+    assert second.status_code == 200, (
+        f"duplicate add must be idempotent, got {second.status_code}: {second.text}"
+    )
+    assert "already" in second.json().get("msg", "").lower()
+
+    # Peer list must contain the host exactly once.
+    peers = requests.get(f"{native_url}/loadsharing/peers", timeout=5).json()
+    matches = [p for p in peers if p.get("host") == "peer-under-test.local"]
+    assert len(matches) == 1, f"expected exactly one entry, got: {peers}"

--- a/tests/integration/test_loadsharing_peer_management.py
+++ b/tests/integration/test_loadsharing_peer_management.py
@@ -136,9 +136,12 @@ class TestPeerManagement:
 
     def test_add_peer_duplicate_rejection(self, instance_pair_auto, peer_hostname_factory):
         """
-        Test: POST /loadsharing/peers rejects duplicate hosts.
+        Test: POST /loadsharing/peers handles duplicate hosts idempotently.
 
-        Verifies that adding the same peer twice fails on the second attempt.
+        Duplicate adds are idempotent by design: mDNS auto-discovery racing a
+        manual add (or a repeated reciprocal sync) is a normal sequence, not a
+        client error. The second add returns 200 "already in group" and the
+        peer still appears exactly once.
         """
         pair = instance_pair_auto()
         native_url = pair["native_url"]
@@ -152,19 +155,28 @@ class TestPeerManagement:
         )
         assert response.status_code == 200
 
-        # Add peer second time (should fail)
+        # Add peer second time (idempotent no-op, not an error)
         response = requests.post(
             f"{native_url}/loadsharing/peers",
             json={"host": test_host}
         )
-        assert response.status_code == 400, (
-            f"Expected 400 for duplicate peer, got {response.status_code}: {response.text}"
+        assert response.status_code == 200, (
+            f"Expected 200 for idempotent duplicate peer, got {response.status_code}: {response.text}"
         )
 
         data = response.json()
         error_msg = data.get("error", "") or data.get("msg", "")
-        assert "already" in error_msg.lower() or "duplicate" in error_msg.lower(), (
-            f"Error message should mention duplicate: {error_msg}"
+        assert "already in group" in error_msg.lower(), (
+            f"Message should note the peer is already in the group: {error_msg}"
+        )
+
+        # The duplicate must not create a second entry.
+        response = requests.get(f"{native_url}/loadsharing/peers")
+        assert response.status_code == 200
+        peers = response.json()
+        matching_peers = [p for p in peers if p.get("host") == test_host]
+        assert len(matching_peers) == 1, (
+            f"Duplicate add must leave exactly one entry, got: {matching_peers}"
         )
 
     def test_delete_peer(self, instance_pair_auto, peer_hostname_factory):


### PR DESCRIPTION
I ran this branch on a local bench (the divert_sim scenario suite plus the emulator + native-firmware integration harness with real mDNS) and posted the detailed findings on #940. This PR is the fix series for the five issues I hit, one commit per fix, each with the test that pins it.

**Commits:**

1. **Don't mutate role state on a rejected config POST** — `becomeMember()`/`resetRole()` ran before validation, so a rejected `POST /config` still flipped group membership and later posts had their `loadsharing_` fields stripped by the member guard. Role transition now happens after all validation passes.
2. **Duplicate peer add is idempotent** — mDNS auto-discovery racing a manual add is a normal sequence, not a client error; `POST /loadsharing/peers` for an existing peer now returns `200 {"msg":"already in group"}` and skips the reciprocal sync. *Contract change:* `test_add_peer_duplicate_rejection` is updated to the new behavior.
3. **Reject config where failsafe current exceeds the group budget** — one islanded member at `failsafe_safe_current=32` against `group_max_current=10` could exceed the group max on its own. Cross-field validation (incoming-else-stored) at config write.
4. **Enforce member failsafe with an EvseManager claim** — the important one. `checkMemberFailsafe()` set `_failsafe_active` but placed no claim, so a member that lost its controller kept charging uncapped and a manual override ran uncontested (32 A pilot with `/claims` empty). The poller now applies the same Limit-priority claim the allocation path uses (safe-current cap, or `Disabled` in `disable` mode) whenever failsafe engages. Since Limit (1100) outbids Manual (1000), an override is now capped at the failsafe current while islanded — pilot drops 32→6 in the test.
5. **Consult peer priority in scarcity subset selection** — the `priority` field (lower value = higher priority, per the `AllocationInput` contract) now orders subset selection ahead of the id tiebreak.
6. **Rotate equal-priority members under scarcity** — new `loadsharing_rotation_interval` (default 1800 s, 0 disables): when the budget can't cover all minimums, the front of each equal-priority run rotates on the interval so both vehicles make progress overnight instead of the lowest id starving the rest. Time is a parameter, so the allocator stays a pure, simulator-testable function.
7. **Failsafe-timing and override drills** — outcome-recording integration tests that reproduce the pre-fix findings and pass on fixed firmware.

**Verification on my bench:** divert_sim suite 65 passed (including the new priority + rotation scenarios); the new `test_loadsharing_fixes.py` 3/3 and drills 3/3; `test_charging.py` 24/24; `test_loadsharing_peer_status.py` went from 10/6 to 16/16 with these fixes. `test_loadsharing_peer_management.py` still has the pre-existing mDNS discovery flakiness you've been chasing — unrelated to this series as far as I can tell.

Happy to split any of this out, reorder, or rework to fit where the branch is heading. One open question worth deciding together at some point: how load-sharing claims should layer against the charge manager's timer-window claims from #1112, since both sit at Limit priority today.
