### PR TITLE
Enable tsdb energy history on openevse_wifi_tft_v1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -496,9 +496,11 @@ upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update
 
 [env:openevse_wifi_tft_v1]
 board = denky32
+platform = ${common.platform_core3}
 build_flags =
   ${common.build_flags_openevse_tft}
   ${common.lvgl_tft_renderer_flags}
+  -D ENABLE_TSDB
   -D DEBUG_PORT=Serial2
   -D RAPI_PORT=Serial
 lib_deps =
@@ -508,6 +510,7 @@ lib_deps =
   ${common.ws2812fx_lib}
   lvgl/lvgl@^8.3.9
   adafruit/Adafruit MCP9808 Library @ 2.0.2
+  ${core3_tsdb_common.esp_tsdb_lib}
 board_build.partitions = ${common.build_partitions_16mb}
 board_upload.flash_size = 16MB
 board_build.flash_mode = qio


### PR DESCRIPTION
`openevse_wifi_tft_v1` is a 16 MB board but was still building on the core-2.x platform, which left it as the only 16 MB target without the tsdb-backed energy history. This moves the env to the pinned core-3 platform (the same one `openevse_wifi_v1_16mb` uses) and turns on `ENABLE_TSDB` with the shared esp_tsdb lib dep — three lines in `platformio.ini`, no source changes.

Hardware-tested on a TFT v1 unit (D9.0.0.SAMD controller):

- OTA'd over a running core-2 image; config and LittleFS carried over cleanly
- `tsdb_ready: 1` / `tsdb_err: 0` on first boot, minute samples accumulating and served through `/energy/raw` (SoC/voltage/power/pilot fields included)
- Display, RAPI comms, and the web UI all behave the same as the core-2 build; image grows from ~2.25 MB to ~2.47 MB (37.6 % of the 16 MB app slot)
- Stable across the periodic tsdb LittleFS writes, with no visible display glitches from the flash-cache stalls (SPI panel, framebuffer in internal RAM)

One behavior note for anyone updating an existing unit: the tsdb store starts fresh, so the daily/monthly/annual summaries build from the day of the update rather than importing the old EnergyLogger rollups.
