### PR TITLE
fix(lcd): brightness settings ignored on core-3 builds (pinMode detaches backlight PWM)

### DIFF
--- a/src/lcd_lvgl.cpp
+++ b/src/lcd_lvgl.cpp
@@ -223,12 +223,9 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
 #ifdef EPOXY_DUINO
       g_lvgl_last_tick = _bootStart;
 #endif
-      pinMode(LCD_BACKLIGHT_PIN, OUTPUT);
-#ifdef TFT_BACKLIGHT_TIMEOUT_MS
+      // lvgl_panel_begin() already owns the backlight pin via LEDC; a raw
+      // pinMode here would detach the PWM binding on core 3.x (perimanager).
       wakeBacklight();
-#else
-      digitalWrite(LCD_BACKLIGHT_PIN, HIGH);
-#endif
     }
     _initialise = false;
   }


### PR DESCRIPTION
The LVGL renderer's brightness settings (`tft_brightness`, `tft_standby_brightness`) have no effect on core-3 builds: the screen stays at full brightness no matter what the config says. Theme switching works, so the config path looks fine — the failure is at the pin.

`LcdTask`'s init block calls `pinMode(LCD_BACKLIGHT_PIN, OUTPUT)` (and `digitalWrite(HIGH)` when `TFT_BACKLIGHT_TIMEOUT_MS` isn't defined) immediately after `lvgl_panel_begin()` has attached LEDC PWM to that same pin. On core 2.x the pinMode is harmless, which is why this never showed up before. Core 3.x's peripheral manager treats it as a new claim on the pin and silently detaches the LEDC binding — the backlight is left driven full-on as a plain GPIO and every subsequent `ledcWrite()` fails.

I caught it by logging the `ledcWrite()` return value on a TFT v1 unit running a core-3 build: the duty writes during panel init succeed, then everything after `LcdTask` init returns false:

```
[panel] BL ledcAttach(pin 27, 5000 Hz, 8 bit) -> OK
[panel] BL duty 255 (100%) write=ok
[panel] BL duty 179 (70%) write=ok      <- applyDisplayConfig() during init
[panel] BL duty 26 (10%) write=FAIL     <- after pinMode ran
[panel] BL duty 255 (100%) write=FAIL
```

The fix drops the raw pin manipulation and calls `wakeBacklight()` instead, which applies the configured active brightness through the panel's PWM path on both cores.

Hardware-tested on the TFT v1 (D9.0.0.SAMD): with the fix, live brightness changes from the web UI apply within a second, standby dimming works, and the same duty-write log shows `ok` across the board. Also build-checked on this branch's core-2 env, where `wakeBacklight()` was already the effective path.

Master is only latently affected today (the TFT env here still builds on core 2.x), but this bites as soon as any LVGL TFT env moves to core 3 — #1149 being the immediate case — and it's live in core-3 builds of the `charge_manager` branch.
