### PR TITLE
Remove Auto service level from the firmware side

### DIFF
--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -694,11 +694,17 @@ bool config_deserialize(DynamicJsonDocument &doc)
 
   if(doc.containsKey("service"))
   {
-    EvseMonitor::ServiceLevel service = static_cast<EvseMonitor::ServiceLevel>(doc["service"].as<uint8_t>());
-    if(service != evse.getServiceLevel()) {
-      evse.setServiceLevel(service);
-      config_modified = true;
-      DBUGLN("service changed");
+    // Only L1/L2 are valid; Auto (0, no longer offered) and anything else are
+    // ignored so a stale stored value can't put $SL A on the wire.
+    uint8_t value = doc["service"].as<uint8_t>();
+    if(1 == value || 2 == value)
+    {
+      EvseMonitor::ServiceLevel service = static_cast<EvseMonitor::ServiceLevel>(value);
+      if(service != evse.getServiceLevel()) {
+        evse.setServiceLevel(service);
+        config_modified = true;
+        DBUGLN("service changed");
+      }
     }
   }
 

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -468,13 +468,10 @@ void EvseMonitor::updateFaultCounters(int ret, long gfci_count, long nognd_count
 
 EvseMonitor::ServiceLevel EvseMonitor::getServiceLevel()
 {
-  if(0 == (getSettingsFlags() & OPENEVSE_ECF_AUTO_SVC_LEVEL_DISABLED)) {
-    return ServiceLevel::Auto;
-  }
-
-  return (OPENEVSE_ECF_L2 == (getSettingsFlags() & OPENEVSE_ECF_L2)) ?
-    ServiceLevel::L2 :
-    ServiceLevel::L1;
+  // Auto service level is only supported by legacy non-WiFi controller builds
+  // ($SL A gets NK'd by the controllers this firmware ships with), so always
+  // report the actual L1/L2 level rather than a state the user cannot select.
+  return getActualServiceLevel();
 }
 
 EvseMonitor::ServiceLevel EvseMonitor::getActualServiceLevel()
@@ -660,6 +657,16 @@ void EvseMonitor::updateEffectiveVoltage()
 
 void EvseMonitor::setServiceLevel(ServiceLevel level, std::function<void(int ret)> callback)
 {
+  // Auto is not supported by the controller builds this firmware ships with
+  // ($SL A answers NK); refuse it here so it never goes on the wire.
+  if(ServiceLevel::Auto == level)
+  {
+    if(callback) {
+      callback(RAPI_RESPONSE_NK);
+    }
+    return;
+  }
+
   if(level == getServiceLevel())
   {
     if(callback) {


### PR DESCRIPTION
Follow-up from the discussion on OpenEVSE/open_evse#54: `AUTOSVCLEVEL` is only compiled into the legacy non-WiFi controller builds, so on the controllers this firmware actually ships with `$SL A` just answers NK (and CGMI hardware force-disables auto detection anyway). Selecting Auto from the UI has never worked - it silently fails and the previous level stays in effect.

This removes it from the firmware side:

- `getServiceLevel()` now reports the actual L1/L2 level instead of inferring an unusable Auto state from the controller flags, so `/config` and the UI always show the real setting
- `setServiceLevel()` refuses `ServiceLevel::Auto` (the callback gets `RAPI_RESPONSE_NK`) so `$SL A` never goes on the wire
- the `service` config key only accepts 1 or 2; a stale stored 0 from an older config is ignored rather than replayed at the controller

The `ServiceLevel` enum keeps its `Auto = 0` member so existing configs still deserialize, it just can't be applied.

The matching gui change (dropping the Auto option from the dropdown) is being done separately.

`openevse_wifi_v1` builds clean.