### PR TITLE
Fix WS2812 status LEDs staying dark on Arduino core 3

### DIFF
--- a/src/LedManagerTask.cpp
+++ b/src/LedManagerTask.cpp
@@ -37,6 +37,15 @@ Adafruit_NeoPixel strip = Adafruit_NeoPixel(NEO_PIXEL_LENGTH, NEO_PIXEL_PIN, NEO
 #include <WS2812FX.h>
 WS2812FX ws2812fx = WS2812FX(NEO_PIXEL_LENGTH, NEO_PIXEL_PIN, NEO_GRB + NEO_KHZ800);
 
+// True once ws2812fx.init() has run. WS2812FX::setBrightness() calls show(),
+// and a show() before init() breaks the strip on core 3: NeoPixel's espShow()
+// caches the pin it has RMT-initialised, then init()'s pinMode(OUTPUT) makes
+// the Peripheral Manager destroy that RMT channel, and every later show()
+// trusts the stale cache, skips re-init and dies silently in rmtWrite().
+// config_load_settings() calls setBrightness() before setup() runs, so the
+// pre-init forward has to be suppressed (the value is applied in setup()).
+static bool neopixels_ready = false;
+
 class LedAnimatorTask : public MicroTasks::Task
 {
   public:
@@ -190,7 +199,10 @@ void LedManagerTask::setup()
 #elif defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
   DEBUG.printf("Initialising NeoPixels WS2812FX MODE...\n");
   ws2812fx.init();
-  ws2812fx.setBrightness(brightness);
+  neopixels_ready = true;
+  // apply the brightness stored by any pre-init setBrightness() call, with
+  // the same 0 = max mapping it uses
+  ws2812fx.setBrightness(0 == brightness ? 255 : brightness - 1);
   ws2812fx.setSpeed(DEFAULT_FX_SPEED);
   ws2812fx.setColor(BLACK);
   ws2812fx.setMode(FX_MODE_STATIC);
@@ -766,13 +778,15 @@ void LedManagerTask::setBrightness(uint8_t brightness)
 #if defined(NEO_PIXEL_PIN) && defined(NEO_PIXEL_LENGTH) && defined(ENABLE_WS2812FX)
 // This controls changes on the limits of the web interface slidebar.
 // Otherwise it gets out of sync
-  if (this->brightness == 0){
-    ws2812fx.setBrightness(255);
+  if(neopixels_ready)
+  {
+    if (this->brightness == 0){
+      ws2812fx.setBrightness(255);
+    }
+    else {
+      ws2812fx.setBrightness(this->brightness-1);
+    }
   }
-  else {
-    ws2812fx.setBrightness(this->brightness-1);
-  }
-
 #endif
 
   DBUGVAR(this->brightness);


### PR DESCRIPTION
On the core 3 builds (`openevse_wifi_tft_v1`) the WS2812 status LEDs never light. There are no errors anywhere - the strip just stays dark.

## Root cause

It's an init-ordering bug of the same class as #1151 (pinMode reclaiming a pin detaches the live peripheral on core 3):

1. `config_load_settings()` runs before `LedManagerTask::setup()` and calls `ledManager.setBrightness()`, which `WS2812FX::setBrightness()` forwards straight into `show()`. That early show makes Adafruit NeoPixel's IDF5 `espShow()` set up an RMT channel on the LED pin and cache the pin as initialised (`static int rmtPin`).
2. `setup()` then runs `ws2812fx.init()`, whose `Adafruit_NeoPixel::begin()` calls `pinMode(pin, OUTPUT)`. On core 3 the Peripheral Manager destroys the live RMT channel as part of the GPIO claim.
3. Every `show()` after that trusts the stale pin cache, skips re-initialisation and dies inside `rmtWrite()`. All the error paths are `log_e`/`log_w`, compiled out at the default log level, so the failure is completely silent.

## Fix

Gate the `setBrightness()` forward on the strip actually having been initialised; the stored brightness is applied in `setup()` right after `init()`, with the same 0 = max mapping. Once no show() happens before init(), espShow's own RMT setup runs (and stays) on a cleanly claimed pin.

## Verification

Verified on `openevse_wifi_tft_v1` hardware with an instrumented build printing `perimanGetPinBusType()` for the LED pin into the /debug ring:

- Before the fix: the pin is already `RMT_TX` when `setup()` starts (the config-load show), and drops back to `GPIO` after `init()` - the channel is gone and the LEDs stay dark.
- After the fix: untouched at `setup()`, `RMT_TX` after the first show, and it stays there. LEDs work, including live brightness changes from the web UI slider.

For reference, two related issues in the vendored Adafruit NeoPixel 1.15.2 IDF5 path that made this so hard to see (worth an upstream report, not addressed here): `espShow()` trusts its static pin cache instead of checking the pin's actual peripheral state, and its `rmtInit()`-failure path returns without releasing `show_mutex`, wedging every subsequent `show()`.