### PR TITLE
Legacy LCD Text

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ the web UI, with screenshots.
   source: [api.yml](../api.yml))
 - [MQTT API](mqtt.md) and the [MQTT developer guide](Developers_Guide_MQTT.md)
 - [RAPI protocol](rapi.md)
+- [Character LCD display](lcd.md) — what the 2×16 LCD shows in each state
 
 ## AI / coding-agent context — [docs/ai/](ai/)
 

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -88,20 +88,20 @@ Every entry shows for 4 s, then advances. Entries that need live data
 **Not connected / Connected:**
 `Energy 1,018Wh` → `Lifetime 2313kWh` → `EVSE Temp 30.5C` →
 `Time 3:14:00 PM` → `Date 2020-08-25` →
-[`openevse-55ad` → `IP 192.168.1.42`] →
+[`openevse-55ad` → `192.168.1.42`] →
 [`Start 10:00 PM`] → [`Stop 6:00 AM`]
 
 **Charging:**
 `Energy` → `Lifetime` → `EVSE Temp` →
 [if divert active: `Solar 3.41kW` → `Divert 16A`] →
-[`openevse-55ad` → `IP 192.168.1.42`] →
+[`openevse-55ad` → `192.168.1.42`] →
 [`Stop 6:00 AM`] → [`Left 6:23:00`] →
 [if vehicle data: `Charge level 79%` → `Range 259 miles` → `ETA h:mm:ss`]
 
 **Sleeping / Disabled:**
 [if paused by divert: `Solar 3.41kW` → `Avail 4.2A`] →
 `Time` → `Date` →
-[`openevse-55ad` → `IP 192.168.1.42`] →
+[`openevse-55ad` → `192.168.1.42`] →
 [`Start 10:00 PM`] → [`Stop 6:00 AM`]
 
 The hostname and IP address entries appear in every non-fault state and are

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -87,17 +87,28 @@ Every entry shows for 4 s, then advances. Entries that need live data
 
 **Not connected / Connected:**
 `Energy 1,018Wh` → `Lifetime 2313kWh` → `EVSE Temp 30.5C` →
-`Time 3:14:00 PM` → `Date 2020-08-25` → [`Start 10:00 PM`] → [`Stop 6:00 AM`]
+`Time 3:14:00 PM` → `Date 2020-08-25` →
+[`openevse-55ad` → `IP 192.168.1.42`] →
+[`Start 10:00 PM`] → [`Stop 6:00 AM`]
 
 **Charging:**
 `Energy` → `Lifetime` → `EVSE Temp` →
 [if divert active: `Solar 3.41kW` → `Divert 16A`] →
+[`openevse-55ad` → `IP 192.168.1.42`] →
 [`Stop 6:00 AM`] → [`Left 6:23:00`] →
 [if vehicle data: `Charge level 79%` → `Range 259 miles` → `ETA h:mm:ss`]
 
 **Sleeping / Disabled:**
 [if paused by divert: `Solar 3.41kW` → `Avail 4.2A`] →
-`Time` → `Date` → [`Start 10:00 PM`] → [`Stop 6:00 AM`]
+`Time` → `Date` →
+[`openevse-55ad` → `IP 192.168.1.42`] →
+[`Start 10:00 PM`] → [`Stop 6:00 AM`]
+
+The hostname and IP address entries appear in every non-fault state and are
+controlled by the `lcd_network_info` config setting (boolean, default
+enabled; persisted in the config store). Disable via the config API/MQTT
+(`{"lcd_network_info": false}`) to remove them from the rotation. Fault
+states show fixed two-line error text and never rotate.
 
 Divert-related entries:
 

--- a/docs/lcd.md
+++ b/docs/lcd.md
@@ -1,0 +1,123 @@
+# Character LCD (2×16) Display
+
+This document describes how the ESP32 gateway drives the 2-line × 16-character
+text LCD on the OpenEVSE controller, and what is shown in each state.
+
+It applies to the character-LCD builds only. The TFT touchscreen
+(`ENABLE_SCREEN_LCD_TFT`) and LVGL (`ENABLE_SCREEN_LVGL_TFT`) variants have
+their own UI and are not covered here.
+
+## Ownership model
+
+The character LCD is physically attached to the OpenEVSE ATmega/SAMD
+controller, not the ESP32. All display output goes over the RAPI serial link:
+
+| RAPI command | Purpose |
+|---|---|
+| `$F0 0` | Disable the controller's own display updates (sent once at startup) |
+| `$FP <x> <y> <text>` | Write text at column `x`, row `y` (0 = top, 1 = bottom) |
+| `$FB <colour>` | Set the backlight colour |
+
+On the first state transition out of `STARTING`, `LcdTask` (`src/lcd.cpp`)
+sends `$F0 0` and takes over the front button, so the controller's built-in
+messages ("Sleeping", "Connected", …) are only ever visible for a moment at
+power-up. From then on the ESP32 paints every character.
+
+Constraints:
+
+- Text is hard-truncated to 16 characters (`LCD_MAX_LEN`); there is no
+  scrolling.
+- When clearing the remainder of a line, spaces are sent in blocks of at most
+  6 per `$FP` command — older controller firmware crashes on longer runs.
+- Custom glyphs are available at character codes 1–5: stop, play, lightning,
+  lock, clock (`LCD_CHAR_*` in `src/lcd.h`).
+
+## Message API
+
+Modules display transient text through the queue API:
+
+```cpp
+lcd.display(msg, x, y, time_ms, flags);
+```
+
+- `time_ms` — how long the message holds before the queue advances.
+- `LCD_CLEAR_LINE` — blank the rest of the line after the text.
+- `LCD_DISPLAY_NOW` — drop any queued messages and show immediately.
+
+When the queue empties, the automatic status screen (below) reasserts itself.
+Transient messages come from boot (`OpenEVSE WiFI` + version), network events
+(AP SSID/password, hostname, IP address, factory reset), OTA updates
+(`Updating WiFi`, percentage, `Complete`/`Error`), and RFID
+(tag prompts and results).
+
+## Status screen
+
+The status screen has two independently managed lines:
+
+- **Top line (row 0)** — the state line: the most important fact about the
+  current state plus its key number.
+- **Bottom line (row 1)** — the info line: rotates through contextual data
+  every 4 s (`LCD_DISPLAY_CHANGE_TIME`).
+
+### Top line by state
+
+| State | Display | Notes |
+|---|---|---|
+| Not connected | `Ready          48A` | Configured charge current |
+| Vehicle connected | `Connected      48A` | Configured charge current |
+| Charging | `Charging    47.80A` | Live measured amps, 1 s refresh |
+| Charging under divert (Eco mode active) | `Eco         16.00A` | Live amps; divert is modulating the rate |
+| Sleeping — divert waiting for excess | `Divert      1.23kW` | Live incoming power, 1 s refresh: solar generation (`solar` feed), or grid export (`-grid_ie`) for grid-type divert |
+| Sleeping — schedule/timer | `Paused Timer` | Bottom line rotation includes the next `Start` time |
+| Sleeping — manual override | `Paused Manual` | Front button or web/API manual stop |
+| Sleeping — session limit reached | `Limit Reached` | Energy/time/SOC/range limit |
+| Sleeping — remote pause | `Paused Remote` | OCPP, MQTT or Ohm Connect claim |
+| Sleeping — other/unknown cause | `zzZ Sleeping Zzz` | E.g. paused directly on the controller |
+| Fault | Two fixed lines | e.g. `SAFETY ERROR` / `GROUND FAULT`, `VEHICLE ERROR` / `VENT REQUIRED` |
+
+The pause cause is derived from `EvseManager::getStateClient()` — the
+highest-priority claim currently forcing the state (see the client/priority
+table in `src/evse_man.h`). The display repaints when the controlling client
+changes even if the hardware state does not.
+
+### Bottom line rotation by state
+
+Every entry shows for 4 s, then advances. Entries that need live data
+(time, divert power) refresh at 1 s while displayed.
+
+**Not connected / Connected:**
+`Energy 1,018Wh` → `Lifetime 2313kWh` → `EVSE Temp 30.5C` →
+`Time 3:14:00 PM` → `Date 2020-08-25` → [`Start 10:00 PM`] → [`Stop 6:00 AM`]
+
+**Charging:**
+`Energy` → `Lifetime` → `EVSE Temp` →
+[if divert active: `Solar 3.41kW` → `Divert 16A`] →
+[`Stop 6:00 AM`] → [`Left 6:23:00`] →
+[if vehicle data: `Charge level 79%` → `Range 259 miles` → `ETA h:mm:ss`]
+
+**Sleeping / Disabled:**
+[if paused by divert: `Solar 3.41kW` → `Avail 4.2A`] →
+`Time` → `Date` → [`Start 10:00 PM`] → [`Stop 6:00 AM`]
+
+Divert-related entries:
+
+| Entry | Meaning |
+|---|---|
+| `Solar 3.41kW` | Solar generation feed (solar-type divert) |
+| `Grid IE -500W` | Grid import/export feed, negative = exporting (grid-type divert) |
+| `Divert 16A` | Charge rate divert has set (while charging) |
+| `Avail 4.2A` | Smoothed current available for divert — charging starts when it exceeds the minimum charge current (typically 6 A) |
+
+A manual override forces the bottom line to `Manual Override` until released.
+
+### Backlight colour
+
+Set from `EvseManager::getStateColour()` on every state/flag change:
+
+| State | Colour |
+|---|---|
+| Not connected | Green |
+| Connected | Yellow |
+| Charging | Teal |
+| Sleeping/Disabled | Teal if vehicle connected, else violet |
+| Any fault | Red |

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -186,7 +186,8 @@ void config_changed(String name);
                               CONFIG_OCPP_AUTO_AUTH | \
                               CONFIG_OCPP_OFFLINE_AUTH | \
                               CONFIG_TEMP_THROTTLE_DEFAULT | \
-                              CONFIG_DEFAULT_STATE_DEFAULT)
+                              CONFIG_DEFAULT_STATE_DEFAULT | \
+                              CONFIG_LCD_NETWORK_INFO)
 
 ConfigOptDefinition<uint32_t> flagsOpt = ConfigOptDefinition<uint32_t>(flags, CONFIG_DEFAULT_FLAGS, "flags", "f");
 ConfigOptDefinition<uint32_t> flagsChanged = ConfigOptDefinition<uint32_t>(flags_changed, 0, "flags_changed", "c");
@@ -335,6 +336,7 @@ ConfigOpt *opts[] =
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_WIZARD, CONFIG_WIZARD, "wizard_passed", "wzp"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_DEFAULT_STATE, CONFIG_DEFAULT_STATE, "default_state", "dfs"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_TEMP_THROTTLE, CONFIG_TEMP_THROTTLE, "temp_throttle_enabled", "tte"),
+  new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_LCD_NETWORK_INFO, CONFIG_LCD_NETWORK_INFO, "lcd_network_info", "lni"),
   new ConfigOptVirtualMqttProtocol(flagsOpt, flagsChanged, "mqtt_protocol", "mprt"),
   new ConfigOptVirtualChargeMode(flagsOpt, flagsChanged, "charge_mode", "chmd")
 };

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -158,7 +158,8 @@ extern uint32_t flags;
 #define CONFIG_THREEPHASE           (1 << 24)
 #define CONFIG_WIZARD               (1 << 25)
 #define CONFIG_DEFAULT_STATE        (1 << 26)
-#define CONFIG_TEMP_THROTTLE        (1 << 27) // next free bit after CONFIG_DEFAULT_STATE
+#define CONFIG_TEMP_THROTTLE        (1 << 27)
+#define CONFIG_LCD_NETWORK_INFO     (1 << 28) // next free bit after CONFIG_LCD_NETWORK_INFO
 
 #define INITIAL_CONFIG_VERSION  1
 
@@ -255,6 +256,11 @@ inline EvseState config_default_state()
 inline bool config_temp_throttle_enabled()
 {
   return CONFIG_TEMP_THROTTLE == (flags & CONFIG_TEMP_THROTTLE);
+}
+
+inline bool config_lcd_network_info_enabled()
+{
+  return CONFIG_LCD_NETWORK_INFO == (flags & CONFIG_LCD_NETWORK_INFO);
 }
 
 // Ohm Connect Settings

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -278,6 +278,15 @@ class EvseManager : public MicroTasks::Task
     uint32_t getChargeCurrent(EvseClient client = EvseClient_NULL);
     uint32_t getMaxCurrent(EvseClient client = EvseClient_NULL);
 
+    // Get the client whose claim is currently setting the state/charge current,
+    // EvseClient_NULL if no active claim sets the property
+    EvseClient getStateClient() {
+      return _state_client;
+    }
+    EvseClient getChargeCurrentClient() {
+      return _charge_current_client;
+    }
+
     bool serializeClaims(DynamicJsonDocument &doc);
     bool serializeClaim(DynamicJsonDocument &doc, EvseClient client);
     bool serializeTarget(DynamicJsonDocument &doc);

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -11,6 +11,7 @@
 #include "input.h"
 #include "app_config.h"
 #include "divert.h"
+#include "net_manager.h"
 #include <sys/time.h>
 
 static void IGNORE(int ret) {
@@ -162,6 +163,8 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
          LcdInfoLine::TimerRemaining == _infoLine ? "LcdInfoLine::TimerRemaining" :
          LcdInfoLine::SolarPower == _infoLine ? "LcdInfoLine::SolarPower" :
          LcdInfoLine::DivertRate == _infoLine ? "LcdInfoLine::DivertRate" :
+         LcdInfoLine::Hostname == _infoLine ? "LcdInfoLine::Hostname" :
+         LcdInfoLine::IPAddress == _infoLine ? "LcdInfoLine::IPAddress" :
          LcdInfoLine::ManualOverride == _infoLine ? "LcdInfoLine::ManualOverride" :
          "UNKNOWN");
 
@@ -342,6 +345,14 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::Time:
           return LcdInfoLine::Date;
         case LcdInfoLine::Date:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::Hostname;
+          }
+        case LcdInfoLine::Hostname:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::IPAddress;
+          }
+        case LcdInfoLine::IPAddress:
           if(_scheduler->getNextEvent(EvseState::Active).isValid()) {
             return LcdInfoLine::TimerStart;
           }
@@ -379,6 +390,14 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
             return LcdInfoLine::DivertRate;
           }
         case LcdInfoLine::DivertRate:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::Hostname;
+          }
+        case LcdInfoLine::Hostname:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::IPAddress;
+          }
+        case LcdInfoLine::IPAddress:
           if(_scheduler->getNextEvent(EvseState::Disabled).isValid()) {
             return LcdInfoLine::TimerStop;
           }
@@ -422,6 +441,14 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::Time:
           return LcdInfoLine::Date;
         case LcdInfoLine::Date:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::Hostname;
+          }
+        case LcdInfoLine::Hostname:
+          if(config_lcd_network_info_enabled()) {
+            return LcdInfoLine::IPAddress;
+          }
+        case LcdInfoLine::IPAddress:
           if(_scheduler->getNextEvent(EvseState::Active).isValid()) {
             return LcdInfoLine::TimerStart;
           }
@@ -706,6 +733,21 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
       }
       nextUpdate = 1000;
       break;
+
+    case LcdInfoLine::Hostname:
+      // openevse-55ad
+      snprintf(temp, sizeof(temp), "%.*s", LCD_MAX_LEN, esp_hostname.c_str());
+      showText(0, 1, temp, true);
+      _updateInfoLine = false;
+      break;
+
+    case LcdInfoLine::IPAddress:
+    {
+      // IP 192.168.1.42
+      String ip = net.getIp();
+      displayNameValue(1, "IP", ip.length() > 0 ? ip.c_str() : "none");
+      _updateInfoLine = false;
+    } break;
 
     case LcdInfoLine::ManualOverride:
       showText(0, 1, "Manual Override", true);

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -743,9 +743,10 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
 
     case LcdInfoLine::IPAddress:
     {
-      // IP 192.168.1.42
+      // 192.168.100.100 (bare, a full IPv4 is 15 chars so no room for a prefix)
       String ip = net.getIp();
-      displayNameValue(1, "IP", ip.length() > 0 ? ip.c_str() : "none");
+      snprintf(temp, sizeof(temp), "%.*s", LCD_MAX_LEN, ip.length() > 0 ? ip.c_str() : "No IP address");
+      showText(0, 1, temp, true);
       _updateInfoLine = false;
     } break;
 

--- a/src/lcd.cpp
+++ b/src/lcd.cpp
@@ -10,6 +10,7 @@
 #include "openevse.h"
 #include "input.h"
 #include "app_config.h"
+#include "divert.h"
 #include <sys/time.h>
 
 static void IGNORE(int ret) {
@@ -52,6 +53,7 @@ LcdTask::LcdTask() :
   _evseState(OPENEVSE_STATE_STARTING),
   _evse(NULL),
   _scheduler(NULL),
+  _lastStateClient(EvseClient_NULL),
   _nextMessageTime(0),
   _evseStateEvent(this),
   _evseSettingsEvent(this)
@@ -158,6 +160,8 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
          LcdInfoLine::TimerStart == _infoLine ? "LcdInfoLine::TimerStart" :
          LcdInfoLine::TimerStop == _infoLine ? "LcdInfoLine::TimerStop" :
          LcdInfoLine::TimerRemaining == _infoLine ? "LcdInfoLine::TimerRemaining" :
+         LcdInfoLine::SolarPower == _infoLine ? "LcdInfoLine::SolarPower" :
+         LcdInfoLine::DivertRate == _infoLine ? "LcdInfoLine::DivertRate" :
          LcdInfoLine::ManualOverride == _infoLine ? "LcdInfoLine::ManualOverride" :
          "UNKNOWN");
 
@@ -222,6 +226,18 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
   // If the OpenEVSE has not started don't do anything
   if(OPENEVSE_STATE_STARTING == _evseState) {
     return MicroTask.Infinate;
+  }
+
+  // Repaint if the client controlling the EVSE state has changed, the cause
+  // shown while sleeping (divert/timer/manual/...) can change without a
+  // hardware state change, e.g. manual override released while a timer still
+  // holds the EVSE off
+  EvseClient newStateClient = _evse->getStateClient();
+  if(newStateClient != _lastStateClient)
+  {
+    _lastStateClient = newStateClient;
+    _updateStateDisplay = true;
+    _updateInfoLine = true;
   }
 
   if(evseStateChanged || flagsChanged)
@@ -355,6 +371,14 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
         case LcdInfoLine::EnergyTotal:
           return LcdInfoLine::Temperature;
         case LcdInfoLine::Temperature:
+          if(DivertMode::Eco == divert.getMode() && divert.isActive()) {
+            return LcdInfoLine::SolarPower;
+          }
+        case LcdInfoLine::SolarPower:
+          if(DivertMode::Eco == divert.getMode() && divert.isActive()) {
+            return LcdInfoLine::DivertRate;
+          }
+        case LcdInfoLine::DivertRate:
           if(_scheduler->getNextEvent(EvseState::Disabled).isValid()) {
             return LcdInfoLine::TimerStop;
           }
@@ -380,13 +404,21 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
 
     case OPENEVSE_STATE_SLEEPING:
     case OPENEVSE_STATE_DISABLED:
-      // Line 1 "Time 03:14PM"
+      // Line 1 if divert "Solar 3.41kW"
+      //                  "Avail 4.2A"
+      //        "Time 03:14PM"
       //        "Date 08/25/2020"
       //        if timer "Start 10:00PM"
       //                 "Stop 06:00AM"
 
       switch(info)
       {
+        case LcdInfoLine::SolarPower:
+          if(EvseClient_OpenEVSE_Divert == _evse->getStateClient()) {
+            return LcdInfoLine::DivertRate;
+          }
+        case LcdInfoLine::DivertRate:
+          return LcdInfoLine::Time;
         case LcdInfoLine::Time:
           return LcdInfoLine::Date;
         case LcdInfoLine::Date:
@@ -398,7 +430,9 @@ LcdTask::LcdInfoLine LcdTask::getNextInfoLine(LcdInfoLine info)
             return LcdInfoLine::TimerStop;
           }
         default:
-          return LcdInfoLine::Time;
+          return EvseClient_OpenEVSE_Divert == _evse->getStateClient() ?
+                   LcdInfoLine::SolarPower :
+                   LcdInfoLine::Time;
       }
   }
 
@@ -422,8 +456,10 @@ void LcdTask::displayStateLine(uint8_t evseState, unsigned long &nextUpdate)
       break;
 
     case OPENEVSE_STATE_CHARGING:
-      // Line 0 "Charging 47.8A"
-      displayNumberValue(0, "Charging", _evse->getAmps(), 2, "A");
+      // Line 0 "Charging 47.8A", or "Eco 16.00A" when divert is modulating the rate
+      displayNumberValue(0,
+        (DivertMode::Eco == divert.getMode() && divert.isActive()) ? "Eco" : "Charging",
+        _evse->getAmps(), 2, "A");
       nextUpdate = 1000;
       break;
 
@@ -493,10 +529,48 @@ void LcdTask::displayStateLine(uint8_t evseState, unsigned long &nextUpdate)
 
     case OPENEVSE_STATE_SLEEPING:
     case OPENEVSE_STATE_DISABLED:
-      // Line 0 "zzZ Sleeping Zzz"
-      showText(0, 0, "zzZ Sleeping Zzz", true);
-      _updateStateDisplay = false;
-      break;
+    {
+      // Line 0 shows why the EVSE is paused and, when waiting on divert, the
+      // live incoming power (solar generation, or grid export for grid divert)
+      EvseClient stateClient = _evse->getStateClient();
+      if(EvseClient_OpenEVSE_Divert == stateClient)
+      {
+        // Line 0 "Divert 1.23kW"
+        double watts = DIVERT_TYPE_GRID == divert_type ?
+                         -divert.getGridIe() :
+                         divert.getSolar();
+        displayPowerValue(0, "Divert", watts);
+        nextUpdate = 1000;
+      }
+      else if(EvseClient_OpenEVSE_Schedule == stateClient)
+      {
+        showText(0, 0, "Paused Timer", true);
+        _updateStateDisplay = false;
+      }
+      else if(EvseClient_OpenEVSE_Manual == stateClient)
+      {
+        showText(0, 0, "Paused Manual", true);
+        _updateStateDisplay = false;
+      }
+      else if(EvseClient_OpenEVSE_Limit == stateClient)
+      {
+        showText(0, 0, "Limit Reached", true);
+        _updateStateDisplay = false;
+      }
+      else if(EvseClient_OpenEVSE_OCPP == stateClient ||
+              EvseClient_OpenEVSE_MQTT == stateClient ||
+              EvseClient_OpenEVSE_Ohm == stateClient)
+      {
+        showText(0, 0, "Paused Remote", true);
+        _updateStateDisplay = false;
+      }
+      else
+      {
+        // Line 0 "zzZ Sleeping Zzz"
+        showText(0, 0, "zzZ Sleeping Zzz", true);
+        _updateStateDisplay = false;
+      }
+    } break;
 
     default:
       break;
@@ -612,6 +686,27 @@ void LcdTask::displayInfoLine(LcdInfoLine line, unsigned long &nextUpdate)
       }
     } break;
 
+    case LcdInfoLine::SolarPower:
+      // Solar 3.41kW, or Grid IE -500W for grid divert (negative = exporting)
+      if(DIVERT_TYPE_GRID == divert_type) {
+        displayPowerValue(1, "Grid IE", divert.getGridIe());
+      } else {
+        displayPowerValue(1, "Solar", divert.getSolar());
+      }
+      nextUpdate = 1000;
+      break;
+
+    case LcdInfoLine::DivertRate:
+      if(divert.isActive()) {
+        // Divert 16A, the charge rate divert has set
+        displayNumberValue(1, "Divert", divert.getChargeRate(), 0, "A");
+      } else {
+        // Avail 4.2A, how close the excess is to the minimum needed to charge
+        displayNumberValue(1, "Avail", divert.smoothedAvailableCurrent(), 1, "A");
+      }
+      nextUpdate = 1000;
+      break;
+
     case LcdInfoLine::ManualOverride:
       showText(0, 1, "Manual Override", true);
       break;
@@ -651,6 +746,20 @@ void LcdTask::displayNumberValue(int line, const char *name, double value, int p
   snprintf(number, sizeof(number), "%.*f%s", precision, value, unit);
 
   displayNameValue(line, name, number);
+}
+
+void LcdTask::displayPowerValue(int line, const char *name, double watts)
+{
+  char value[20];
+  if(watts >= 10000 || watts <= -10000) {
+    snprintf(value, sizeof(value), "%.1fkW", watts / 1000.0);
+  } else if(watts >= 1000 || watts <= -1000) {
+    snprintf(value, sizeof(value), "%.2fkW", watts / 1000.0);
+  } else {
+    snprintf(value, sizeof(value), "%.0fW", watts);
+  }
+
+  displayNameValue(line, name, value);
 }
 
 void LcdTask::displayInfoEventTime(const char *name, Scheduler::EventInstance &event)

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -100,7 +100,7 @@ class LcdTask : public MicroTasks::Task
       SolarPower,     // Solar 3.41kW / Grid IE -500W
       DivertRate,     // Divert 16A / Avail 4.2A
       Hostname,       // openevse-55ad
-      IPAddress,      // IP 192.168.1.42
+      IPAddress,      // 192.168.100.100
       ManualOverride
     };
 

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -97,6 +97,8 @@ class LcdTask : public MicroTasks::Task
       TimerStart,     // Start 10:00PM
       TimerStop,      // Stop 06:00AM
       TimerRemaining, // Remaining 6:23
+      SolarPower,     // Solar 3.41kW / Grid IE -500W
+      DivertRate,     // Divert 16A / Avail 4.2A
       ManualOverride
     };
 
@@ -112,6 +114,8 @@ class LcdTask : public MicroTasks::Task
     EvseManager *_evse;
     Scheduler *_scheduler;
     ManualOverride *_manual;
+
+    EvseClient _lastStateClient;
 
     uint32_t _nextMessageTime;
     uint32_t _infoLineChageTime;
@@ -143,6 +147,7 @@ class LcdTask : public MicroTasks::Task
     void displayInfoLine(LcdInfoLine info, unsigned long &nextUpdate);
     void displayNumberValue(int line, const char *name, double value, int precision, const char *unit);
     void displayScaledNumberValue(int line, const char *name, double value, int precision, const char *unit);
+    void displayPowerValue(int line, const char *name, double watts);
     void displayInfoEventTime(const char *name, Scheduler::EventInstance &event);
     void displayNameValue(int line, const char *name, const char *value);
     void displayStopWatchTime(const char *name, uint32_t time);

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -99,6 +99,8 @@ class LcdTask : public MicroTasks::Task
       TimerRemaining, // Remaining 6:23
       SolarPower,     // Solar 3.41kW / Grid IE -500W
       DivertRate,     // Divert 16A / Avail 4.2A
+      Hostname,       // openevse-55ad
+      IPAddress,      // IP 192.168.1.42
       ManualOverride
     };
 


### PR DESCRIPTION
Resolves

https://github.com/OpenEVSE/openevse_esp32_firmware/issues/145

and provides more information particularly while Sleeping.

# Character LCD (2×16) Display

This document describes how the ESP32 gateway drives the 2-line × 16-character
text LCD on the OpenEVSE controller, and what is shown in each state.

It applies to the character-LCD builds only. The TFT touchscreen
(`ENABLE_SCREEN_LCD_TFT`) and LVGL (`ENABLE_SCREEN_LVGL_TFT`) variants have
their own UI and are not covered here.

## Ownership model

The character LCD is physically attached to the OpenEVSE ATmega/SAMD
controller, not the ESP32. All display output goes over the RAPI serial link:

| RAPI command | Purpose |
|---|---|
| `$F0 0` | Disable the controller's own display updates (sent once at startup) |
| `$FP <x> <y> <text>` | Write text at column `x`, row `y` (0 = top, 1 = bottom) |
| `$FB <colour>` | Set the backlight colour |

On the first state transition out of `STARTING`, `LcdTask` (`src/lcd.cpp`)
sends `$F0 0` and takes over the front button, so the controller's built-in
messages ("Sleeping", "Connected", …) are only ever visible for a moment at
power-up. From then on the ESP32 paints every character.

Constraints:

- Text is hard-truncated to 16 characters (`LCD_MAX_LEN`); there is no
  scrolling.
- When clearing the remainder of a line, spaces are sent in blocks of at most
  6 per `$FP` command — older controller firmware crashes on longer runs.
- Custom glyphs are available at character codes 1–5: stop, play, lightning,
  lock, clock (`LCD_CHAR_*` in `src/lcd.h`).

## Message API

Modules display transient text through the queue API:

```cpp
lcd.display(msg, x, y, time_ms, flags);
```

- `time_ms` — how long the message holds before the queue advances.
- `LCD_CLEAR_LINE` — blank the rest of the line after the text.
- `LCD_DISPLAY_NOW` — drop any queued messages and show immediately.

When the queue empties, the automatic status screen (below) reasserts itself.
Transient messages come from boot (`OpenEVSE WiFI` + version), network events
(AP SSID/password, hostname, IP address, factory reset), OTA updates
(`Updating WiFi`, percentage, `Complete`/`Error`), and RFID
(tag prompts and results).

## Status screen

The status screen has two independently managed lines:

- **Top line (row 0)** — the state line: the most important fact about the
  current state plus its key number.
- **Bottom line (row 1)** — the info line: rotates through contextual data
  every 4 s (`LCD_DISPLAY_CHANGE_TIME`).

### Top line by state

| State | Display | Notes |
|---|---|---|
| Not connected | `Ready          48A` | Configured charge current |
| Vehicle connected | `Connected      48A` | Configured charge current |
| Charging | `Charging    47.80A` | Live measured amps, 1 s refresh |
| Charging under divert (Eco mode active) | `Eco         16.00A` | Live amps; divert is modulating the rate |
| Sleeping — divert waiting for excess | `Divert      1.23kW` | Live incoming power, 1 s refresh: solar generation (`solar` feed), or grid export (`-grid_ie`) for grid-type divert |
| Sleeping — schedule/timer | `Paused Timer` | Bottom line rotation includes the next `Start` time |
| Sleeping — manual override | `Paused Manual` | Front button or web/API manual stop |
| Sleeping — session limit reached | `Limit Reached` | Energy/time/SOC/range limit |
| Sleeping — remote pause | `Paused Remote` | OCPP, MQTT or Ohm Connect claim |
| Sleeping — other/unknown cause | `zzZ Sleeping Zzz` | E.g. paused directly on the controller |
| Fault | Two fixed lines | e.g. `SAFETY ERROR` / `GROUND FAULT`, `VEHICLE ERROR` / `VENT REQUIRED` |

The pause cause is derived from `EvseManager::getStateClient()` — the
highest-priority claim currently forcing the state (see the client/priority
table in `src/evse_man.h`). The display repaints when the controlling client
changes even if the hardware state does not.

### Bottom line rotation by state

Every entry shows for 4 s, then advances. Entries that need live data
(time, divert power) refresh at 1 s while displayed.

**Not connected / Connected:**
`Energy 1,018Wh` → `Lifetime 2313kWh` → `EVSE Temp 30.5C` →
`Time 3:14:00 PM` → `Date 2020-08-25` →
[`openevse-55ad` → `IP 192.168.1.42`] →
[`Start 10:00 PM`] → [`Stop 6:00 AM`]

**Charging:**
`Energy` → `Lifetime` → `EVSE Temp` →
[if divert active: `Solar 3.41kW` → `Divert 16A`] →
[`openevse-55ad` → `IP 192.168.1.42`] →
[`Stop 6:00 AM`] → [`Left 6:23:00`] →
[if vehicle data: `Charge level 79%` → `Range 259 miles` → `ETA h:mm:ss`]

**Sleeping / Disabled:**
[if paused by divert: `Solar 3.41kW` → `Avail 4.2A`] →
`Time` → `Date` →
[`openevse-55ad` → `192.168.1.42`] →
[`Start 10:00 PM`] → [`Stop 6:00 AM`]

The hostname and IP address entries appear in every non-fault state and are
controlled by the `lcd_network_info` config setting (boolean, default
enabled; persisted in the config store). Disable via the config API/MQTT
(`{"lcd_network_info": false}`) to remove them from the rotation. Fault
states show fixed two-line error text and never rotate.

Divert-related entries:

| Entry | Meaning |
|---|---|
| `Solar 3.41kW` | Solar generation feed (solar-type divert) |
| `Grid IE -500W` | Grid import/export feed, negative = exporting (grid-type divert) |
| `Divert 16A` | Charge rate divert has set (while charging) |
| `Avail 4.2A` | Smoothed current available for divert — charging starts when it exceeds the minimum charge current (typically 6 A) |

A manual override forces the bottom line to `Manual Override` until released.

### Backlight colour

Set from `EvseManager::getStateColour()` on every state/flag change:

| State | Colour |
|---|---|
| Not connected | Green |
| Connected | Yellow |
| Charging | Teal |
| Sleeping/Disabled | Teal if vehicle connected, else violet |
| Any fault | Red |
