### PR TITLE
Fix silently dropped RAPI commands: LCD text, controller RTC sync, Ohm Connect

### DIFF
--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -579,9 +579,11 @@ class EvseManager : public MicroTasks::Task
       return _sender;
     }
 
-    // Get the OpenEVSE API
+    // Get the OpenEVSE API. Must be the instance the monitor initialised with
+    // the RAPI sender; the global OpenEVSE object is never begin()-ed so its
+    // commands are silently dropped.
     OpenEVSEClass &getOpenEVSE() {
-      return OpenEVSE;
+      return _openevse;
     }
 
     // Register for events

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -169,7 +169,7 @@ handleRapiRead()
 {
   Profile_Start(handleRapiRead);
 
-  OpenEVSE.getTime([](int ret, time_t evse_time)
+  evse.getOpenEVSE().getTime([](int ret, time_t evse_time)
   {
     if(RAPI_RESPONSE_OK == ret)
     {
@@ -188,7 +188,7 @@ void input_setup()
 {
   MicroTask.startTask(input);
 
-  OpenEVSE.onWiFi([](uint8_t wifiMode)
+  evse.getOpenEVSE().onWiFi([](uint8_t wifiMode)
   {
     DBUGVAR(wifiMode);
     switch(wifiMode)

--- a/src/legacy_support.cpp
+++ b/src/legacy_support.cpp
@@ -1,12 +1,13 @@
 #include "debug.h"
 #include "legacy_support.h"
+#include "input.h"
 
 #define IMPORT_DAYS (SCHEDULER_DAY_SUNDAY | SCHEDULER_DAY_MONDAY | SCHEDULER_DAY_TUESDAY | SCHEDULER_DAY_WEDNESDAY | SCHEDULER_DAY_THURSDAY | SCHEDULER_DAY_FRIDAY | SCHEDULER_DAY_SATURDAY | SCHEDULER_REPEAT)
 
 void import_timers(Scheduler *scheduler)
 {
   DBUGLN("Checking for existing timers");
-  OpenEVSE.getTimer([scheduler](int ret, int start_hour, int start_minute, int end_hour, int end_minute)
+  evse.getOpenEVSE().getTimer([scheduler](int ret, int start_hour, int start_minute, int end_hour, int end_minute)
   {
     DBUGVAR(start_hour);
     DBUGVAR(start_minute);
@@ -18,7 +19,7 @@ void import_timers(Scheduler *scheduler)
       DBUGF("Found existing timer: %d, %d, %d, %d", start_hour, start_minute, end_hour, end_minute);
       scheduler->addEvent(1, start_hour, start_minute, 0, IMPORT_DAYS, EvseState(EvseState::Active));
       scheduler->addEvent(2, end_hour, end_minute, 0, IMPORT_DAYS, EvseState(EvseState::Disabled));
-      OpenEVSE.clearTimer([](int ret) {});
+      evse.getOpenEVSE().clearTimer([](int ret) {});
     } else {
       DBUGLN("No timers on EVSE board");
     }

--- a/src/ohm.cpp
+++ b/src/ohm.cpp
@@ -60,7 +60,7 @@ void ohm_loop()
             if (evse_sleep == 0)
             {
               evse_sleep = 1;
-              OpenEVSE.sleep([](int ret)
+              evse.getOpenEVSE().sleep([](int ret)
               {
                 if(RAPI_RESPONSE_OK == ret) {
                   DBUGLN(F("Charge Stopped"));
@@ -74,7 +74,7 @@ void ohm_loop()
             if (evse_sleep == 1)
             {
               evse_sleep = 0;
-              OpenEVSE.enable([](int ret)
+              evse.getOpenEVSE().enable([](int ret)
               {
                 if(RAPI_RESPONSE_OK == ret) {
                   DBUGLN(F("Charging enabled"));

--- a/src/time_man.cpp
+++ b/src/time_man.cpp
@@ -12,6 +12,7 @@
 
 #include "debug.h"
 #include "time_man.h"
+#include "input.h"
 #include "net_manager.h"
 #include "openevse.h"
 #include "app_config.h"
@@ -199,7 +200,7 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
 
       DBUGF("Setting the time on the EVSE, %s",
         time_format_time(utc_time.tv_sec).c_str());
-      OpenEVSE.setTime(utc_time.tv_sec, [this](int ret)
+      evse.getOpenEVSE().setTime(utc_time.tv_sec, [this](int ret)
       {
         DBUGF("EVSE time %sset", RAPI_RESPONSE_OK == ret ? "" : "not ");
       });
@@ -336,7 +337,7 @@ void TimeManager::setTime(struct timeval setTime, const char *source)
   settimeofday(&setTime, &tz_utc);
 
   // Set the time on the OpenEVSE, set from the local time as this could take several ms
-  OpenEVSE.getTime([this](int ret, time_t evse_time)
+  evse.getOpenEVSE().getTime([this](int ret, time_t evse_time)
   {
     if(RAPI_RESPONSE_OK == ret)
     {


### PR DESCRIPTION
## Problem

Since the load-sharing rework (8ffc467a, merged to master 2026-07-09) `EvseManager` owns a private `OpenEVSEClass _openevse` instance (needed so divert_sim can run multiple EVSE peers), and the **global `OpenEVSE` object is never `begin()`-ed**. `OpenEVSEClass` methods silently no-op when `_sender` is null, so everything still using the global object stopped working with no error:

- **Character LCD is completely dead** — `lcd.cpp` sends all `$F0`/`$FB`/`$FP` through `EvseManager::getOpenEVSE()`, which still returned the global. Verified on real hardware (openevse_wifi_v1_16mb, master build `851b3a60`): RAPI polling flows normally, zero `$F*` commands ever sent.
- **Controller RTC never gets set from NTP** (`time_man.cpp` `OpenEVSE.setTime/getTime`)
- **Controller time polling + WiFi state signalling** (`input.cpp`)
- **Ohm Connect sleep/enable** (`ohm.cpp`)
- **Legacy timer import** (`legacy_support.cpp`)

## Fix

- `EvseManager::getOpenEVSE()` returns the monitor-initialised `_openevse` member instead of the global.
- Migrate the five remaining direct users of the global `OpenEVSE` object to `evse.getOpenEVSE()`.

## Testing

- `pio run -e openevse_wifi_v1` builds clean.
- Root cause confirmed on hardware by A/B: master build shows no `$F*` traffic in the RAPI spy (`/evse`) while all monitor polling works; `$F0 1` from the console proves the LCD/controller side is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)