### PR TITLE
fix(lcd): length-adaptive state word on the standby screen

### DIFF
--- a/src/lvgl_tft/charge_screen.cpp
+++ b/src/lvgl_tft/charge_screen.cpp
@@ -20,10 +20,6 @@
 // Ring full-scale (amps). The ring is indicative, not a hard gauge.
 #define RING_FULL_SCALE_A 48.0f
 
-// Max rendered width (px) for the centre state word at the large font before we
-// step down a size. Sized to the ring's usable inner width (200px ring - 14px
-// band each side) so long words ("NOT CONNECTED") never wrap onto the band.
-#define STATE_WORD_FIT_W 172
 
 static lv_obj_t *charge_scr   = nullptr;  // the screen object (for destroy on switch)
 static lv_obj_t *arc          = nullptr;

--- a/src/lvgl_tft/screen_common.h
+++ b/src/lvgl_tft/screen_common.h
@@ -7,6 +7,12 @@
 #include <stdint.h>
 #include <lvgl.h>
 
+// Max rendered width (px) for the centre state word at the large font before we
+// step down a size. Sized to the ring's usable inner width (200px ring - 14px
+// band each side) so long words ("NOT CONNECTED") never wrap onto the band.
+// The charge and standby rings share this geometry.
+#define STATE_WORD_FIT_W 172
+
 // Map an OPENEVSE_STATE_* value to a status word + accent colour (nightshift).
 const char *state_word(uint8_t evse_state, lv_color_t *colour);
 

--- a/src/lvgl_tft/standby_screen.cpp
+++ b/src/lvgl_tft/standby_screen.cpp
@@ -121,6 +121,16 @@ void standby_screen_update(const StandbyScreenData &d)
 
   lv_color_t accent;
   const char *word = state_word(d.evse_state, &accent);
+
+  // Length-adaptive font, mirroring the charge screen: keep the large size for
+  // words that render inside the ring, drop one size for the wide ones so they
+  // stay on a single line.
+  lv_point_t sz;
+  lv_txt_get_size(&sz, word, &lv_font_montserrat_28, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
+  const lv_font_t *font = (sz.x <= STATE_WORD_FIT_W) ? &lv_font_montserrat_28
+                                                     : &lv_font_montserrat_20;
+  lv_obj_set_style_text_font(state_lbl, font, 0);
+
   lv_label_set_text(state_lbl, word);
   lv_obj_set_style_text_color(state_lbl, accent, 0);
   lv_obj_align_to(state_lbl, arc, LV_ALIGN_CENTER, 0, 0);


### PR DESCRIPTION
The charge screen already steps the centre state word down one font size when it is too wide for the ring (#1140), but the standby screen kept a fixed 28pt label — so long words like "NOT CONNECTED" wrap onto two lines there.

This applies the same measure-and-shrink logic in `standby_screen_update()`, and moves the shared `STATE_WORD_FIT_W` constant into `screen_common.h` since the charge and standby rings share the same 200px / 14px-band geometry.

Built for `openevse_wifi_tft_v1` and flashed to a 16MB TFT unit; the standby state word now stays on a single line, matching the charge screen.

<img width="1936" height="692" alt="standby-before-after" src="https://github.com/user-attachments/assets/ac037736-e4d8-4e85-83f8-73761adae2b4" />

