### PR TITLE
feat(lcd): device-wide temperature unit (°C/°F) for the display

### DIFF
--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -67,6 +67,9 @@ uint32_t www_https_port;
 String esp_hostname;
 String sntp_hostname;
 
+// Device-wide temperature display unit ("c" | "f").
+String temp_unit;
+
 // On-device LVGL TFT display theme ("dark" | "light").
 String tft_theme;
 uint32_t tft_brightness;
@@ -214,6 +217,10 @@ ConfigOpt *opts[] =
 // Advanced settings
   new ConfigOptDefinition<String>(esp_hostname, esp_hostname_default, "hostname", "hn"),
   new ConfigOptDefinition<String>(sntp_hostname, SNTP_DEFAULT_HOST, "sntp_hostname", "sh"),
+
+// Temperature display unit ("c" | "f") — device-wide, read by the display and
+// the web UI so both agree. Default Celsius (the device always reports °C).
+  new ConfigOptDefinition<String>(temp_unit, "c", "temp_unit", "tu"),
 
 #ifdef ENABLE_SCREEN_LVGL_TFT
 // On-device display theme (only present on LVGL-TFT builds; its presence in

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -43,6 +43,10 @@ extern String esp_hostname;
 extern String esp_hostname_default;
 extern String sntp_hostname;
 
+// Device-wide temperature display unit: "c" (Celsius) or "f" (Fahrenheit).
+// Source of truth for both the on-device display and the web UI.
+extern String temp_unit;
+
 // On-device LVGL TFT display theme: "dark" (nightshift) or "light".
 extern String tft_theme;
 extern uint32_t tft_brightness;

--- a/src/lcd_lvgl.cpp
+++ b/src/lcd_lvgl.cpp
@@ -342,6 +342,7 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
     sd.evse_state        = state;
     sd.temp_valid        = _evse->isTemperatureValid(EVSE_MONITOR_TEMP_MONITOR);
     sd.temp_c            = sd.temp_valid ? _evse->getTemperature(EVSE_MONITOR_TEMP_MONITOR) : 0.0f;
+    sd.temp_fahrenheit   = temp_unit.equals("f");
     sd.wifi_client       = _wifi_client;
     sd.wifi_connected    = _wifi_connected;
     sd.rssi              = WiFi.RSSI();
@@ -380,6 +381,7 @@ unsigned long LcdTask::loop(MicroTasks::WakeReason reason)
   d.session_wh        = _evse->getSessionEnergy();
   d.temp_valid        = _evse->isTemperatureValid(EVSE_MONITOR_TEMP_MONITOR);
   d.temp_c            = d.temp_valid ? _evse->getTemperature(EVSE_MONITOR_TEMP_MONITOR) : 0.0f;
+  d.temp_fahrenheit   = temp_unit.equals("f");
   d.wifi_client       = _wifi_client;
   d.wifi_connected    = _wifi_connected;
   d.rssi              = WiFi.RSSI();

--- a/src/lvgl_tft/charge_screen.cpp
+++ b/src/lvgl_tft/charge_screen.cpp
@@ -226,7 +226,7 @@ void charge_screen_update(const ChargeScreenData &d)
   // Top-right: temp + wifi% + car.
   char tr[48]; tr[0] = '\0';
   size_t n = 0;
-  if (d.temp_valid) n += snprintf(tr + n, sizeof(tr) - n, "%.1fC  ", d.temp_c);
+  if (d.temp_valid) n += fmt_temp(tr + n, sizeof(tr) - n, d.temp_c, d.temp_fahrenheit);
   if (d.wifi_client) {
     if (d.wifi_connected) n += snprintf(tr + n, sizeof(tr) - n, LV_SYMBOL_WIFI " %d%%", wifi_percent(d.rssi));
     else                  n += snprintf(tr + n, sizeof(tr) - n, LV_SYMBOL_WIFI " --");

--- a/src/lvgl_tft/charge_screen.h
+++ b/src/lvgl_tft/charge_screen.h
@@ -22,6 +22,7 @@ struct ChargeScreenData {
   double   session_wh;        // session energy delivered
   bool     temp_valid;
   float    temp_c;
+  bool     temp_fahrenheit;   // render temp_c in °F
   bool     wifi_client;       // true = STA, false = AP
   bool     wifi_connected;
   int      rssi;              // STA dBm (valid when wifi_client && connected)

--- a/src/lvgl_tft/screen_common.cpp
+++ b/src/lvgl_tft/screen_common.cpp
@@ -3,6 +3,7 @@
 
 #ifdef ENABLE_SCREEN_LVGL_TFT
 
+#include <stdio.h>        // snprintf
 #include "openevse.h"     // OPENEVSE_STATE_*
 #include "nightshift.h"   // NS_* palette macros
 
@@ -32,6 +33,12 @@ int wifi_percent(int rssi)
   if (rssi <= -100) return 0;
   if (rssi >= -50)  return 100;
   return 2 * (rssi + 100);
+}
+
+int fmt_temp(char *buf, size_t n, float temp_c, bool fahrenheit)
+{
+  float t = fahrenheit ? (temp_c * 9.0f / 5.0f + 32.0f) : temp_c;
+  return snprintf(buf, n, "%.1f%c  ", t, fahrenheit ? 'F' : 'C');
 }
 
 #endif // ENABLE_SCREEN_LVGL_TFT

--- a/src/lvgl_tft/screen_common.h
+++ b/src/lvgl_tft/screen_common.h
@@ -13,5 +13,10 @@ const char *state_word(uint8_t evse_state, lv_color_t *colour);
 // RSSI (dBm) -> signal %, the usual piecewise mapping.
 int wifi_percent(int rssi);
 
+// Format a temperature (input always °C) into buf as e.g. "22.3C  " or, when
+// fahrenheit is set, "72.1F  " (converting first). Trailing two spaces match
+// the top-strip layout. Returns the number of characters written (like snprintf).
+int fmt_temp(char *buf, size_t n, float temp_c, bool fahrenheit);
+
 #endif // ENABLE_SCREEN_LVGL_TFT
 #endif // __SCREEN_COMMON_H

--- a/src/lvgl_tft/standby_screen.cpp
+++ b/src/lvgl_tft/standby_screen.cpp
@@ -130,7 +130,7 @@ void standby_screen_update(const StandbyScreenData &d)
 
   char tr[48]; tr[0] = '\0';
   size_t n = 0;
-  if (d.temp_valid) n += snprintf(tr + n, sizeof(tr) - n, "%.1fC  ", d.temp_c);
+  if (d.temp_valid) n += fmt_temp(tr + n, sizeof(tr) - n, d.temp_c, d.temp_fahrenheit);
   if (d.wifi_client) {
     if (d.wifi_connected) n += snprintf(tr + n, sizeof(tr) - n, LV_SYMBOL_WIFI " %d%%", wifi_percent(d.rssi));
     else                  n += snprintf(tr + n, sizeof(tr) - n, LV_SYMBOL_WIFI " --");

--- a/src/lvgl_tft/standby_screen.h
+++ b/src/lvgl_tft/standby_screen.h
@@ -12,6 +12,7 @@ struct StandbyScreenData {
   uint8_t  evse_state;        // OPENEVSE_STATE_* (drives the ring word + colour)
   bool     temp_valid;
   float    temp_c;
+  bool     temp_fahrenheit;   // render temp_c in °F
   bool     wifi_client;       // true = STA, false = AP
   bool     wifi_connected;
   int      rssi;              // STA dBm


### PR DESCRIPTION
The LVGL TFT screens hardcode Celsius. This adds a device config key **`temp_unit`** (`"c"` | `"f"`, default `"c"`) that the charge and standby screens read to render the top-strip temperature in the chosen unit, via a shared `fmt_temp()` helper in `screen_common` so both rings stay in step.

The key is **device-wide** (not gated to the display build) on purpose: it is meant to be the single source of truth for temperature units, so the web UI can drive both the panel and the browser from one control (its presence in `/config` is the capability signal). The device still always reports °C in `/status`; `temp_unit` is a display preference only.

- `temp_unit` config key (short `tu`), default `c`
- `fmt_temp()` in `screen_common` (converts °C→°F, shared by charge + standby)
- read live each screen update (settable via `POST /config {"temp_unit":"f"}`, no reboot)

Built and flashed on a 16MB `openevse_wifi_tft_v1` unit; the panel switches between °C and °F live. A companion gui-nightshift PR wires the existing Settings temperature toggle to this key.

Independent of #1162 (standby state-word font); the two touch adjacent code but do not conflict.