### PR TITLE
Mqtt solar

### DIFF
--- a/mqtt_solar_changes.md
+++ b/mqtt_solar_changes.md
@@ -1,0 +1,110 @@
+# mqtt_solar branch changes
+
+Fixes for solar divert when driven by a **scheduler timer window** ("divert"
+schedule feature) rather than the config enable flag, plus a cleanup of the
+legacy emonpi/data.openevse.com defaults.
+
+Branched from `master`. Verified against a live station (`openevse-c620`) fed
+by `powerwall/solar` (integer watts, ~10 s interval).
+
+## Background / symptoms
+
+On a setup where eco divert is activated by a schedule (config
+`divert_enabled` off, schedule event with `"feature": "divert"`):
+
+1. **Divert never saw solar data.** The station showed a few watts of solar
+   while the MQTT feed carried ~3–5 kW, and never started an eco charge.
+2. **Manual override was ignored** during a scheduled eco window.
+3. **Cancelling an override (reselecting Auto)** brought the timer window back
+   *without* eco mode — the EVSE charged at full rate for the rest of the
+   window.
+
+## Fixes
+
+### 1. Subscribe to divert/shaper feed topics whenever configured (`effd9878`)
+
+`Mqtt::subscribeTopics()` only subscribed to `mqtt_solar` / `mqtt_grid_ie`
+when `config_divert_enabled()` was true (and `mqtt_live_pwr` only when
+`config_current_shaper_enabled()`). The scheduler's Divert and Shaper timer
+features activate those subsystems at runtime **without touching the config
+flags**, so a schedule-driven divert received no feed data at all.
+
+The subscriptions now depend only on a topic being configured (and, for the
+divert feeds, on `divert_type` matching). `subscribeTopics()` runs on every
+(re)connect, so topic edits still take effect via the MQTT restart on config
+change.
+
+### 2. Manual override now beats schedule-activated divert/shaper (`cc26ce11`)
+
+Timer-window divert and timer-only shaper claimed at
+`EvseManager_Priority_Limit` (1100), unintentionally outranking Manual (1000),
+RFID (1030) and OCPP (1050). The elevation only ever needed to beat the
+scheduler's base Timer claim (100) and API/MQTT (500).
+
+New constant:
+
+```c
+#define EvseManager_Priority_TimerFeature 900
+```
+
+Used by all timer-window divert claims (`divert.cpp`) and timer-only shaper
+claims including the stale-data failsafe (`current_shaper.cpp`). A
+config-enabled (always-on) shaper still claims at Safety (5000) with its
+failsafe at Limit (1100), so supply protection cannot be overridden.
+
+Resulting order: schedule Timer (100) < API/MQTT (500) < **timer
+divert/shaper (900)** < Manual (1000) < RFID (1030) < OCPP (1050) < Limit
+(1100) < Safety (5000).
+
+### 3. Ignore `divertmode=Normal` while a timer window is active (`1f9d47e7`)
+
+When reselecting **Auto** after an override, the GUI releases the override and
+then normalises divert mode via `POST /divertmode divertmode=1`. During a
+timer window that dropped the divert task out of Eco and released its claim,
+leaving the schedule's base claim (Active at hardware max) in charge.
+
+`DivertTask::setMode()` now ignores a request for `Normal` while
+`_timer_divert_active` is set — the same intent as the existing
+`isTimerDivertActive()` guard on the config-change path, extended to the
+`/divertmode` endpoint and MQTT `divertmode/set`. End-of-window cleanup is
+unaffected (`setTimerDivertActive(false)` clears the flag before restoring the
+configured mode). To stop eco charging inside a window, use a manual override,
+which now outranks it.
+
+## Default config changes (`effd9878`)
+
+| Setting | Old default | New default |
+|---|---|---|
+| `mqtt_server` | `emonpi` | *(blank)* |
+| `mqtt_user` | `emonpi` | *(blank)* |
+| `mqtt_pass` | `emonpimqtt2016` | *(blank)* |
+| `mqtt_vrms` (voltage topic) | `emon/emonpi/vrms` | *(blank)* |
+| `mqtt_grid_ie` | `emon/emonpi/power1` | *(blank)* |
+| `emoncms_server` | `https://data.openevse.com/emoncms` | `https://emoncms.org` |
+
+`mqtt_topic` (base topic) already defaults to the device hostname
+(`openevse-XXXX`) — unchanged.
+
+Blanking `mqtt_grid_ie` also means `initDivertType()` now guesses
+`DIVERT_TYPE_SOLAR` (not GRID) for fresh installs, since the guess keys off a
+non-empty grid topic.
+
+Note: devices that silently relied on the old emonpi defaults (never
+explicitly saved those values) will come up unconfigured after this change and
+need their MQTT settings entered once.
+
+## Related, not in this branch
+
+- The GUI submodules still contain two `data.openevse.com` references
+  (gui-v2 EmonCMS settings example link, gui-nightshift dev fixture). Edited
+  locally; publishing goes through the GUI submodule flow.
+- Anything POSTing `/status` with `"solar"` in **kilowatts** will fight the
+  MQTT feed — `setSolar()` stores integer watts, so `3.048` truncates to 3 W.
+  Feed watts to both inputs.
+
+## Testing
+
+- `pio run -e openevse_wifi_v1_16mb` clean after each commit.
+- On-device: scheduled eco window picks up the solar feed and eco-charges;
+  manual override On takes over at the requested rate; reselecting Auto
+  returns to eco divert within the window.

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -241,21 +241,21 @@ ConfigOpt *opts[] =
   new ConfigOptDefinition<uint32_t>(limit_default_value, LIMIT_DEFAULT_VALUE_DEFAULT, "limit_default_value", "ldv"),
 
 // EMONCMS SERVER strings
-  new ConfigOptDefinition<String>(emoncms_server, "https://data.openevse.com/emoncms", "emoncms_server", "es"),
+  new ConfigOptDefinition<String>(emoncms_server, "https://emoncms.org", "emoncms_server", "es"),
   new ConfigOptDefinition<String>(emoncms_node, esp_hostname, "emoncms_node", "en"),
   new ConfigOptSecret(emoncms_apikey, "", "emoncms_apikey", "ea"),
   new ConfigOptDefinition<String>(emoncms_fingerprint, "", "emoncms_fingerprint", "ef"),
 
 // MQTT Settings
-  new ConfigOptDefinition<String>(mqtt_server, "emonpi", "mqtt_server", "ms"),
+  new ConfigOptDefinition<String>(mqtt_server, "", "mqtt_server", "ms"),
   new ConfigOptDefinition<uint32_t>(mqtt_port, 1883, "mqtt_port", "mpt"),
   new ConfigOptDefinition<String>(mqtt_topic, esp_hostname, "mqtt_topic", "mt"),
-  new ConfigOptDefinition<String>(mqtt_user, "emonpi", "mqtt_user", "mu"),
-  new ConfigOptSecret(mqtt_pass, "emonpimqtt2016", "mqtt_pass", "mp"),
+  new ConfigOptDefinition<String>(mqtt_user, "", "mqtt_user", "mu"),
+  new ConfigOptSecret(mqtt_pass, "", "mqtt_pass", "mp"),
   new ConfigOptDefinition<String>(mqtt_certificate_id, "", "mqtt_certificate_id", "mct"),
   new ConfigOptDefinition<String>(mqtt_solar, "", "mqtt_solar", "mo"),
-  new ConfigOptDefinition<String>(mqtt_grid_ie, "emon/emonpi/power1", "mqtt_grid_ie", "mg"),
-  new ConfigOptDefinition<String>(mqtt_vrms, "emon/emonpi/vrms", "mqtt_vrms", "mv"),
+  new ConfigOptDefinition<String>(mqtt_grid_ie, "", "mqtt_grid_ie", "mg"),
+  new ConfigOptDefinition<String>(mqtt_vrms, "", "mqtt_vrms", "mv"),
   new ConfigOptDefinition<String>(mqtt_live_pwr, "", "mqtt_live_pwr", "map"),
   new ConfigOptDefinition<String>(mqtt_vehicle_soc, "", "mqtt_vehicle_soc", "mc"),
   new ConfigOptDefinition<String>(mqtt_vehicle_range, "", "mqtt_vehicle_range", "mr"),

--- a/src/current_shaper.cpp
+++ b/src/current_shaper.cpp
@@ -55,10 +55,11 @@ unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
 				if (_evse->getState() != props.getState() || _evse->getChargeCurrent() != props.getChargeCurrent())
 				{
 					// Always-on shaper claims at Safety (5000); a shaper running *only*
-					// because of a timer window claims at Limit (1100).  A window must
-					// never demote a config-enabled (always-on) shaper below Safety.
+					// because of a timer window claims at TimerFeature (900) so a
+					// manual override can still beat it.  A window must never demote a
+					// config-enabled (always-on) shaper below Safety.
 					int priority = (_timer_controlled && !config_current_shaper_enabled())
-					               ? EvseManager_Priority_Limit : EvseManager_Priority_Safety;
+					               ? EvseManager_Priority_TimerFeature : EvseManager_Priority_Safety;
 					_evse->claim(EvseClient_OpenEVSE_Shaper, priority, props);
 					StaticJsonDocument<128> event;
 					event["shaper"] = 1;
@@ -85,7 +86,11 @@ unsigned long CurrentShaperTask::loop(MicroTasks::WakeReason reason) {
 				if (_evse->getState(EvseClient_OpenEVSE_Shaper) != EvseState::Disabled)
 				{
 					props.setState(EvseState::Disabled);
-					_evse->claim(EvseClient_OpenEVSE_Shaper, EvseManager_Priority_Limit, props);
+					// Stale-data failsafe: overridable by Manual only when the shaper
+					// runs purely from a timer window, as above.
+					int failsafe_priority = (_timer_controlled && !config_current_shaper_enabled())
+					               ? EvseManager_Priority_TimerFeature : EvseManager_Priority_Limit;
+					_evse->claim(EvseClient_OpenEVSE_Shaper, failsafe_priority, props);
 					StaticJsonDocument<128> event;
 					event["shaper"] = 1;
 					event["shaper_live_pwr"] = _live_pwr;
@@ -159,7 +164,7 @@ void CurrentShaperTask::setState(bool state) {
 	event_send(event);
 }
 
-// Enable shaper from a scheduler timer window (priority 1100 instead of 5000)
+// Enable shaper from a scheduler timer window (priority 900 instead of 5000)
 void CurrentShaperTask::setTimerEnabled(bool active) {
 	_timer_controlled = active;
 	_enabled = active ? true : config_current_shaper_enabled();

--- a/src/current_shaper.h
+++ b/src/current_shaper.h
@@ -62,7 +62,7 @@ class CurrentShaperTask: public MicroTasks::Task
     bool isUpdated();
 
     void notifyConfigChanged(bool enabled, uint32_t max_pwr);
-    // Enable shaper from a scheduler timer window (uses Limit priority 1100 instead of Safety 5000)
+    // Enable shaper from a scheduler timer window (uses TimerFeature priority 900 instead of Safety 5000)
     void setTimerEnabled(bool active);
 };
 

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -105,6 +105,19 @@ unsigned long DivertTask::loop(MicroTasks::WakeReason reason)
 void DivertTask::setMode(DivertMode mode)
 {
   DBUGF("Set _mode: %d", mode);
+
+  // A timer window owns Eco: ignore requests to drop back to Normal while the
+  // scheduler's divert feature is active (the GUI normalises divertmode to 1
+  // when the user reselects Auto after a manual override; MQTT clients can
+  // send the same). End-of-window cleanup is unaffected — setTimerDivertActive
+  // clears _timer_divert_active before restoring the configured mode. To stop
+  // eco charging inside a window, use a manual override (which outranks it).
+  if(_timer_divert_active && DivertMode::Normal == mode)
+  {
+    DBUGLN("Ignoring divertmode Normal while timer divert active");
+    return;
+  }
+
   if(_mode != mode)
   {
     _mode = mode;

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -130,10 +130,11 @@ void DivertTask::setMode(DivertMode mode)
 
         // Timer-driven divert must outrank the schedule's base Timer claim
         // (100) so "solar only" wins (idle = EVSE off when there's no excess
-        // solar). Always-on (config) divert keeps its normal low priority.
+        // solar), but stays below Manual so an override still works.
+        // Always-on (config) divert keeps its normal low priority.
         EvseProperties props(EvseState::Disabled);
         _evse->claim(EvseClient_OpenEVSE_Divert,
-          _timer_divert_active ? EvseManager_Priority_Limit : EvseManager_Priority_Default, props);
+          _timer_divert_active ? EvseManager_Priority_TimerFeature : EvseManager_Priority_Default, props);
       } break;
 
       default:
@@ -238,7 +239,7 @@ void DivertTask::update_state()
       EvseProperties props(EvseState::Active);
       props.setChargeCurrent(_charge_rate);
       _evse->claim(EvseClient_OpenEVSE_Divert,
-        _timer_divert_active ? EvseManager_Priority_Limit : EvseManager_Priority_Divert, props);
+        _timer_divert_active ? EvseManager_Priority_TimerFeature : EvseManager_Priority_Divert, props);
     }
     else if (_smoothed_available_current <= trigger_current)
     {
@@ -246,7 +247,7 @@ void DivertTask::update_state()
       {
         EvseProperties props(EvseState::Disabled);
         _evse->claim(EvseClient_OpenEVSE_Divert,
-          _timer_divert_active ? EvseManager_Priority_Limit : EvseManager_Priority_Default, props);
+          _timer_divert_active ? EvseManager_Priority_TimerFeature : EvseManager_Priority_Default, props);
       }
     }
 
@@ -298,17 +299,18 @@ void DivertTask::setTimerDivertActive(bool active)
   if(active) {
     if(_mode == DivertMode::Eco) {
       // Already in Eco — setMode() would no-op.  Re-issue the current claim
-      // immediately at Priority_Limit so the schedule's Timer(100) claim can't
-      // override us while we wait for the next MQTT update_state() call.
+      // immediately at Priority_TimerFeature so the schedule's Timer(100)
+      // claim can't override us while we wait for the next MQTT
+      // update_state() call.
       // If already charging, re-issue Active with the last known charge_rate;
       // update_state() will correct it on the next solar/grid MQTT message.
       if(_evse->getState(EvseClient_OpenEVSE_Divert) == EvseState::Active) {
         EvseProperties props(EvseState::Active);
         props.setChargeCurrent(_charge_rate);
-        _evse->claim(EvseClient_OpenEVSE_Divert, EvseManager_Priority_Limit, props);
+        _evse->claim(EvseClient_OpenEVSE_Divert, EvseManager_Priority_TimerFeature, props);
       } else {
         EvseProperties props(EvseState::Disabled);
-        _evse->claim(EvseClient_OpenEVSE_Divert, EvseManager_Priority_Limit, props);
+        _evse->claim(EvseClient_OpenEVSE_Divert, EvseManager_Priority_TimerFeature, props);
       }
     } else {
       setMode(DivertMode::Eco);

--- a/src/divert.h
+++ b/src/divert.h
@@ -82,7 +82,7 @@ class DivertTask : public MicroTasks::Task
       return _mode;
     }
 
-    // Enable/disable timer-controlled divert (elevates claim priority to 1100)
+    // Enable/disable timer-controlled divert (elevates claim priority to 900)
     void setTimerDivertActive(bool active);
     bool isTimerDivertActive() { return _timer_divert_active; }
 

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -49,6 +49,10 @@ typedef uint32_t EvseClient;
 #define EvseManager_Priority_API       500
 #define EvseManager_Priority_MQTT      500
 #define EvseManager_Priority_Ohm       500
+// Schedule-activated divert/shaper: must outrank the scheduler's base Timer
+// claim (100) and API pokes (500), but stay below Manual/RFID/OCPP so an
+// explicit human action can always override a timer window.
+#define EvseManager_Priority_TimerFeature 900
 #define EvseManager_Priority_Manual   1000
 #define EvseManager_Priority_RFID     1030
 #define EvseManager_Priority_OCPP     1050

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -307,21 +307,19 @@ void Mqtt::subscribeTopics() {
   _mqttclient.subscribe(mqtt_sub_topic);
   yield();
 
-  // Divert mode related
-  if (config_divert_enabled()) {
-    if (divert_type == DIVERT_TYPE_SOLAR && mqtt_solar != "") {
-      _mqttclient.subscribe(mqtt_solar); yield();
-    }
-    if (divert_type == DIVERT_TYPE_GRID && mqtt_grid_ie != "") {
-      _mqttclient.subscribe(mqtt_grid_ie); yield();
-    }
+  // Divert / shaper feeds: subscribe whenever a topic is configured, not only
+  // when the config enable flag is set — the scheduler's Divert and Shaper
+  // timer features activate these at runtime without touching the config
+  // flags, and they need the feed data to already be flowing.
+  if (divert_type == DIVERT_TYPE_SOLAR && mqtt_solar != "") {
+    _mqttclient.subscribe(mqtt_solar); yield();
+  }
+  if (divert_type == DIVERT_TYPE_GRID && mqtt_grid_ie != "") {
+    _mqttclient.subscribe(mqtt_grid_ie); yield();
   }
 
-  // Current shaper related
-  if (config_current_shaper_enabled()) {
-    if (mqtt_live_pwr != "" && mqtt_live_pwr != mqtt_grid_ie) {
-      _mqttclient.subscribe(mqtt_live_pwr); yield();
-    }
+  if (mqtt_live_pwr != "" && mqtt_live_pwr != mqtt_grid_ie) {
+    _mqttclient.subscribe(mqtt_live_pwr); yield();
   }
 
   // Vehicle data

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -1057,7 +1057,8 @@ void Scheduler::applyFeature(Event *event)
   switch(event->getFeature())
   {
     case SchedulerFeature::Divert:
-      // Enter eco mode at elevated priority (1100) so it overrides OCPP/RFID/Manual
+      // Enter eco mode at elevated priority (TimerFeature, 900) — above the
+      // base Timer claim but below Manual/RFID/OCPP so those still override
       divert.setTimerDivertActive(true);
       break;
     case SchedulerFeature::Shaper:

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -9,7 +9,7 @@
 // Feature activated/deactivated by the timer window.
 enum class SchedulerFeature : uint8_t {
   None    = 0,
-  Divert,   // Solar eco-divert at elevated priority (1100)
+  Divert,   // Solar eco-divert at elevated priority (TimerFeature, 900)
   Shaper,   // Grid current shaper
   OCPP,     // OCPP-managed charging (placeholder)
   RFID,     // Require RFID authentication


### PR DESCRIPTION
# mqtt_solar branch changes

Fixes for solar divert when driven by a **scheduler timer window** ("divert"
schedule feature) rather than the config enable flag, plus a cleanup of the
legacy emonpi/data.openevse.com defaults.

Branched from `master`. Verified against a live station (`openevse-c620`) fed
by `powerwall/solar` (integer watts, ~10 s interval).

## Background / symptoms

On a setup where eco divert is activated by a schedule (config
`divert_enabled` off, schedule event with `"feature": "divert"`):

1. **Divert never saw solar data.** The station showed a few watts of solar
   while the MQTT feed carried ~3–5 kW, and never started an eco charge.
2. **Manual override was ignored** during a scheduled eco window.
3. **Cancelling an override (reselecting Auto)** brought the timer window back
   *without* eco mode — the EVSE charged at full rate for the rest of the
   window.

## Fixes

### 1. Subscribe to divert/shaper feed topics whenever configured (`effd9878`)

`Mqtt::subscribeTopics()` only subscribed to `mqtt_solar` / `mqtt_grid_ie`
when `config_divert_enabled()` was true (and `mqtt_live_pwr` only when
`config_current_shaper_enabled()`). The scheduler's Divert and Shaper timer
features activate those subsystems at runtime **without touching the config
flags**, so a schedule-driven divert received no feed data at all.

The subscriptions now depend only on a topic being configured (and, for the
divert feeds, on `divert_type` matching). `subscribeTopics()` runs on every
(re)connect, so topic edits still take effect via the MQTT restart on config
change.

### 2. Manual override now beats schedule-activated divert/shaper (`cc26ce11`)

Timer-window divert and timer-only shaper claimed at
`EvseManager_Priority_Limit` (1100), unintentionally outranking Manual (1000),
RFID (1030) and OCPP (1050). The elevation only ever needed to beat the
scheduler's base Timer claim (100) and API/MQTT (500).

New constant:

```c
#define EvseManager_Priority_TimerFeature 900
```

Used by all timer-window divert claims (`divert.cpp`) and timer-only shaper
claims including the stale-data failsafe (`current_shaper.cpp`). A
config-enabled (always-on) shaper still claims at Safety (5000) with its
failsafe at Limit (1100), so supply protection cannot be overridden.

Resulting order: schedule Timer (100) < API/MQTT (500) < **timer
divert/shaper (900)** < Manual (1000) < RFID (1030) < OCPP (1050) < Limit
(1100) < Safety (5000).

### 3. Ignore `divertmode=Normal` while a timer window is active (`1f9d47e7`)

When reselecting **Auto** after an override, the GUI releases the override and
then normalises divert mode via `POST /divertmode divertmode=1`. During a
timer window that dropped the divert task out of Eco and released its claim,
leaving the schedule's base claim (Active at hardware max) in charge.

`DivertTask::setMode()` now ignores a request for `Normal` while
`_timer_divert_active` is set — the same intent as the existing
`isTimerDivertActive()` guard on the config-change path, extended to the
`/divertmode` endpoint and MQTT `divertmode/set`. End-of-window cleanup is
unaffected (`setTimerDivertActive(false)` clears the flag before restoring the
configured mode). To stop eco charging inside a window, use a manual override,
which now outranks it.

## Default config changes (`effd9878`)

| Setting | Old default | New default |
|---|---|---|
| `mqtt_server` | `emonpi` | *(blank)* |
| `mqtt_user` | `emonpi` | *(blank)* |
| `mqtt_pass` | `emonpimqtt2016` | *(blank)* |
| `mqtt_vrms` (voltage topic) | `emon/emonpi/vrms` | *(blank)* |
| `mqtt_grid_ie` | `emon/emonpi/power1` | *(blank)* |
| `emoncms_server` | `https://data.openevse.com/emoncms` | `https://emoncms.org` |

`mqtt_topic` (base topic) already defaults to the device hostname
(`openevse-XXXX`) — unchanged.

Blanking `mqtt_grid_ie` also means `initDivertType()` now guesses
`DIVERT_TYPE_SOLAR` (not GRID) for fresh installs, since the guess keys off a
non-empty grid topic.

Note: devices that silently relied on the old emonpi defaults (never
explicitly saved those values) will come up unconfigured after this change and
need their MQTT settings entered once.

## Related, not in this branch

- The GUI submodules still contain two `data.openevse.com` references
  (gui-v2 EmonCMS settings example link, gui-nightshift dev fixture). Edited
  locally; publishing goes through the GUI submodule flow.
- Anything POSTing `/status` with `"solar"` in **kilowatts** will fight the
  MQTT feed — `setSolar()` stores integer watts, so `3.048` truncates to 3 W.
  Feed watts to both inputs.

## Testing

- `pio run -e openevse_wifi_v1_16mb` clean after each commit.
- On-device: scheduled eco window picks up the solar feed and eco-charges;
  manual override On takes over at the requested rate; reselecting Auto
  returns to eco divert within the window.
