### PR TITLE
fix(web): HTML-escape reflected RAPI parameter in /r console (XSS)

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -204,6 +204,27 @@ bool isPositive(MongooseHttpServerRequest *request, const char *param) {
   return paramFound >= 0 && (0 == paramFound || isPositive(String(paramValue)));
 }
 
+// -------------------------------------------------------------------
+// Escape a string for safe inclusion in an HTML response body, so that
+// reflected user input cannot be interpreted as markup or script.
+// -------------------------------------------------------------------
+static String html_escape(const String &input) {
+  String out;
+  out.reserve(input.length());
+  for(size_t i = 0; i < input.length(); i++) {
+    char c = input.charAt(i);
+    switch(c) {
+      case '&':  out += F("&amp;");  break;
+      case '<':  out += F("&lt;");   break;
+      case '>':  out += F("&gt;");   break;
+      case '"':  out += F("&quot;"); break;
+      case '\'': out += F("&#39;");  break;
+      default:   out += c;           break;
+    }
+  }
+  return out;
+}
+
 //---------------------------------------------------------------------
 // Build status data
 // --------------------------------------------------------------------
@@ -1111,9 +1132,9 @@ handleRapi(MongooseHttpServerRequest *request) {
       if (json) {
         s = "{\"cmd\":\""+rapi+"\",\"ret\":\""+rapiString+"\"}";
       } else {
-        s += rapi;
+        s += html_escape(rapi);
         s += F("<p>&gt;");
-        s += rapiString;
+        s += html_escape(rapiString);
       }
     }
     else
@@ -1135,7 +1156,7 @@ handleRapi(MongooseHttpServerRequest *request) {
       if (json) {
         s = "{\"cmd\":\""+rapi+"\",\"error\":\""+errorString+"\"}";
       } else {
-        s += rapi;
+        s += html_escape(rapi);
         s += F("<p><strong>Error:</strong>");
         s += errorString;
       }


### PR DESCRIPTION
## Summary

The `/r` RAPI web console reflects the user-supplied `rapi` query parameter (and the controller's response string) into a `text/html` response without output encoding. A crafted link such as `/r?rapi=<script>…</script>` therefore executes attacker-controlled script in the origin of the device. Both the success and error branches reflect the raw value, so it fires regardless of the `isRapiCommandBlocked()` allowlist outcome.

This came in via a coordinated-disclosure report (CWE-79). This PR addresses that reflected-XSS finding only — see "Scope" below.

## Fix

- Add a small file-local `html_escape()` helper (escapes `& < > " '`).
- Escape the reflected `rapi` parameter in both the success and error HTML branches, plus the dynamic controller response string, before concatenation into the response.

The JSON branch (`?json=1`) is unchanged: it returns `application/json`, not HTML, so it is not an XSS sink. (It does build JSON by string concatenation, which is a separate correctness nit worth a follow-up, but not part of this security fix.)

## Verification

Built and run on the `native_openevse` host target:

```
# before: reflects raw <script>…</script>
# after:
$ curl -s 'http://localhost:8000/r?rapi=<script>alert(1)</script>' | grep -c '<script>alert(1)</script>'
0
# the probe now reflects as: &lt;script&gt;alert(1)&lt;/script&gt;
```

`pio run -e native_openevse` → SUCCESS.

## Scope

The disclosure bundled two other items that are intentionally **not** in this PR because they are product decisions rather than clear bugs:

- **Auth-off-when-no-password** (`requestPreProcess`): flipping to fail-closed would lock out existing no-password devices and is at odds with the empty-username semantics kept in the recent WebSocket-auth work. Better handled as a login-page / first-run-setup discussion.
- **Arbitrary-URL OTA** (`/update`): needs a signing/allowlist decision. Its practical severity drops substantially once this XSS is fixed and the endpoint sits behind auth.

Happy to follow up on either separately.
