### PR TITLE
feat(rfid): add RC522 SPI reader support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,6 +103,7 @@ jobs:
           - adafruit_huzzah32
           - adafruit_featheresp32
           - openevse_wifi_v1
+          - openevse_wifi_v1_rc522
           - olimex_esp32-gateway-old
           - olimex_esp32-gateway-e
           - olimex_esp32-gateway-f

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -110,7 +110,7 @@ update those assertions whenever changing defaults in `app_config.cpp`.
 | `current_shaper.h/.cpp` | Grid-level power cap enforcement with smoothing |
 | `temp_throttle.h/.cpp` | Current reduction on over-temperature |
 | `ocpp.h/.cpp` | OCPP 1.6 via the MicroOcpp library |
-| `rfid.h/.cpp` | RFID card auth, PN532 NFC module (optional) |
+| `rfid.h/.cpp` | RFID card auth, PN532 (I2C) or RC522 (SPI) reader (optional) |
 | `net_manager.h/.cpp` | WiFi / wired Ethernet, OTA capability |
 | `lcd.h/.cpp`, `lcd_tft.h/.cpp` | Character LCD and TFT touchscreen display |
 | `time_man.h/.cpp` | SNTP sync, POSIX timezone strings |

--- a/docs/developer/building.md
+++ b/docs/developer/building.md
@@ -39,6 +39,7 @@ pio run -e adafruit_huzzah32
 pio run -e nodemcu-32s
 pio run -e olimex_esp32-gateway-e      # wired Ethernet
 pio run -e openevse_wifi_tft_v1        # TFT touchscreen
+pio run -e openevse_wifi_v1_rc522      # MFRC522/RC522 on SPI (instead of PN532)
 pio run -e wt32-eth01                  # Ethernet (WT32)
 pio run -e olimex_esp32-poe-iso        # Ethernet + PoE
 ```

--- a/docs/user/rfid.md
+++ b/docs/user/rfid.md
@@ -1,8 +1,12 @@
 # RFID
 
-With a PN532 NFC module fitted, the charger can require a card/tag scan before
-it will charge — useful for shared driveways, workplaces, and multi-tenant
-parking.
+With an NFC reader fitted (PN532 on I2C, or MFRC522/RC522 on SPI), the charger
+can require a card/tag scan before it will charge — useful for shared driveways,
+workplaces, and multi-tenant parking.
+
+Stock `openevse_wifi_v1` builds use the PN532. For RC522, build with
+`pio run -e openevse_wifi_v1_rc522` (SPI pins configurable via `RC522_*` build
+flags in `platformio.ini`).
 
 ![RFID settings](screenshots/settings-rfid-dark-desktop.png)
 

--- a/docs/user/rfid.md
+++ b/docs/user/rfid.md
@@ -6,7 +6,8 @@ workplaces, and multi-tenant parking.
 
 Stock `openevse_wifi_v1` builds use the PN532. For RC522, build with
 `pio run -e openevse_wifi_v1_rc522` (SPI pins configurable via `RC522_*` build
-flags in `platformio.ini`).
+flags in `platformio.ini`). The stock env defaults `RC522_RST_PIN` to GPIO4 so
+RC522 reset does not share GPIO22 (I2C SCL / MCP9808).
 
 ![RFID settings](screenshots/settings-rfid-dark-desktop.png)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -311,16 +311,16 @@ build_flags =
 upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update --progress-bar | cat
 
 # RC522 (MFRC522) on SPI — same base features as openevse_wifi_v1 but PN532 disabled.
-# Default wiring: SS=5, RST=22, SCK=18, MOSI=23, MISO=19 (override via -D RC522_*).
-# Note: RC522_RST_PIN defaults to 22, same pin as I2C_SCL on this board; disable
-# MCP9808 or remap pins if both are fitted.
+# Default wiring: SS=5, RST=4, SCK=18, MOSI=23, MISO=19 (override via -D RC522_*).
+# GPIO22 is I2C_SCL on this board (MCP9808); do not use it for RC522_RST unless MCP9808
+# is disabled in the build.
 [env:openevse_wifi_v1_rc522]
 board = esp32dev
 lib_deps =
   ${common.lib_deps}
   ${common.neopixel_lib}
   adafruit/Adafruit MCP9808 Library @ 2.0.2
-  miguelbalboa/MFRC522
+  miguelbalboa/MFRC522 @ 1.4.12
 build_flags =
   ${common.build_flags}
   ${common.debug_flags}
@@ -336,7 +336,7 @@ build_flags =
   -D ENABLE_MCP9808
   -D ENABLE_RC522
   -D RC522_SS_PIN=5
-  -D RC522_RST_PIN=22
+  -D RC522_RST_PIN=4
   -D RC522_SPI_SCK=18
   -D RC522_SPI_MISO=19
   -D RC522_SPI_MOSI=23

--- a/platformio.ini
+++ b/platformio.ini
@@ -292,7 +292,6 @@ lib_deps =
   ${common.lib_deps}
   ${common.neopixel_lib}
   adafruit/Adafruit MCP9808 Library @ 2.0.2
-  miguelbalboa/MFRC522
 build_flags =
   ${common.build_flags}
   ${common.debug_flags}
@@ -307,7 +306,40 @@ build_flags =
   -D I2C_SCL=22
   -D ENABLE_MCP9808
   -D ENABLE_PN532
+  -D TX1=16
+  -D ENABLE_FLASH_MIGRATE
+upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update --progress-bar | cat
+
+# RC522 (MFRC522) on SPI — same base features as openevse_wifi_v1 but PN532 disabled.
+# Default wiring: SS=5, RST=22, SCK=18, MOSI=23, MISO=19 (override via -D RC522_*).
+# Note: RC522_RST_PIN defaults to 22, same pin as I2C_SCL on this board; disable
+# MCP9808 or remap pins if both are fitted.
+[env:openevse_wifi_v1_rc522]
+board = esp32dev
+lib_deps =
+  ${common.lib_deps}
+  ${common.neopixel_lib}
+  adafruit/Adafruit MCP9808 Library @ 2.0.2
+  miguelbalboa/MFRC522
+build_flags =
+  ${common.build_flags}
+  ${common.debug_flags}
+  -D NEO_PIXEL_PIN=17
+  -D NEO_PIXEL_LENGTH=14
+  -D WIFI_PIXEL_NUMBER=1
+  -D WIFI_BUTTON=0
+  -D WIFI_BUTTON_PRESSED_STATE=LOW
+  -D RAPI_PORT=Serial
+  -D DEBUG_PORT=Serial1
+  -D I2C_SDA=21
+  -D I2C_SCL=22
+  -D ENABLE_MCP9808
   -D ENABLE_RC522
+  -D RC522_SS_PIN=5
+  -D RC522_RST_PIN=22
+  -D RC522_SPI_SCK=18
+  -D RC522_SPI_MISO=19
+  -D RC522_SPI_MOSI=23
   -D TX1=16
   -D ENABLE_FLASH_MIGRATE
 upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update --progress-bar | cat

--- a/platformio.ini
+++ b/platformio.ini
@@ -292,6 +292,7 @@ lib_deps =
   ${common.lib_deps}
   ${common.neopixel_lib}
   adafruit/Adafruit MCP9808 Library @ 2.0.2
+  miguelbalboa/MFRC522
 build_flags =
   ${common.build_flags}
   ${common.debug_flags}
@@ -306,6 +307,7 @@ build_flags =
   -D I2C_SCL=22
   -D ENABLE_MCP9808
   -D ENABLE_PN532
+  -D ENABLE_RC522
   -D TX1=16
   -D ENABLE_FLASH_MIGRATE
 upload_command = curl -F firmware=@$SOURCE http://$UPLOAD_PORT/update --progress-bar | cat

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,10 @@
 #include "rc522.h"
 #endif
 
+#if defined(ENABLE_PN532) && defined(ENABLE_RC522)
+#error "ENABLE_PN532 and ENABLE_RC522 are mutually exclusive — use separate PlatformIO envs"
+#endif
+
 #include "LedManagerTask.h"
 #include "event_log.h"
 #include "evse_man.h"
@@ -200,8 +204,8 @@ void setup()
   pn532.begin();
   rfid.begin(evse, pn532);
 #elif defined(ENABLE_RC522)
-  rc522.begin();
   rfid.begin(evse, rc522);
+  rc522.begin();
 #else
   rfid.begin(evse, rfidNullDevice);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,10 @@
 #include "pn532.h"
 #endif
 
+#if defined(ENABLE_RC522)
+#include "rc522.h"
+#endif
+
 #include "LedManagerTask.h"
 #include "event_log.h"
 #include "evse_man.h"
@@ -195,6 +199,9 @@ void setup()
 #if defined(ENABLE_PN532)
   pn532.begin();
   rfid.begin(evse, pn532);
+#elif defined(ENABLE_RC522)
+  rc522.begin();
+  rfid.begin(evse, rc522);
 #else
   rfid.begin(evse, rfidNullDevice);
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,8 +204,8 @@ void setup()
   pn532.begin();
   rfid.begin(evse, pn532);
 #elif defined(ENABLE_RC522)
-  rfid.begin(evse, rc522);
   rc522.begin();
+  rfid.begin(evse, rc522);
 #else
   rfid.begin(evse, rfidNullDevice);
 #endif

--- a/src/rc522.cpp
+++ b/src/rc522.cpp
@@ -22,6 +22,8 @@
 // MFRC522 firmware version bytes (see NXP MFRC522 datasheet, version register).
 #define MFRC522_VERSION_0x91 0x91
 #define MFRC522_VERSION_0x92 0x92
+// FM17522 and other MFRC522-compatible clones often report 0x88.
+#define MFRC522_VERSION_0x88 0x88
 
 RC522Reader::RC522Reader()
     : _mfrc522(RC522_SS_PIN, RC522_RST_PIN),
@@ -64,7 +66,8 @@ bool RC522Reader::probeReader() {
 
     _mfrc522.PCD_Init(_ss_pin, _rst_pin);
     byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
-    _present = (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92);
+    _present = (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92 ||
+                version == MFRC522_VERSION_0x88);
 
     if (_present) {
         DBUGF("[rfid] RC522 probe OK, version=0x%02X", version);
@@ -98,7 +101,8 @@ void RC522Reader::initialize() {
     _mfrc522.PCD_AntennaOn();
 
     byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
-    if (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92) {
+    if (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92 ||
+        version == MFRC522_VERSION_0x88) {
         DBUGLN(F("[rfid] connection to RC522 active"));
         _initialized = true;
         _failure = false;
@@ -134,18 +138,22 @@ void RC522Reader::poll() {
 
     // PICC_IsNewCardPresent() performs a short SPI exchange to detect a tag in
     // the RF field. When the tag leaves, clear contact so the same card can be
-    // presented again later.
+    // presented again later. Any completed PCD exchange shows the reader is alive.
     if (!_mfrc522.PICC_IsNewCardPresent()) {
+        _last_response = millis();
         _has_contact = false;
         _last_uid.clear();
         return;
     }
 
+    _last_response = millis();
+
     if (!_mfrc522.PICC_ReadCardSerial()) {
+        // Leave the RF field in a clean state after a partial select/read failure.
+        _mfrc522.PICC_HaltA();
+        _mfrc522.PCD_StopCrypto1();
         return;
     }
-
-    _last_response = millis();
 
     String uid = uidToString(_mfrc522.uid);
 
@@ -173,16 +181,20 @@ unsigned long RC522Reader::loop(MicroTasks::WakeReason reason) {
     // Allow scanning when a scheduler timer window requires RFID even if the
     // global rfid_enabled setting is off.
     if (!config_rfid_enabled() && !_timer_scanning) {
+        if (_initialized) {
+            _mfrc522.PCD_AntennaOff();
+        }
         _initialized = false;
         _has_contact = false;
         return SCAN_DELAY;
     }
 
-    if (_initialized && millis() - _last_response > MAXIMUM_UNRESPONSIVE_TIME) {
+    if (_initialized && (long)(millis() - _last_response) >= (long)MAXIMUM_UNRESPONSIVE_TIME) {
         DBUGLN(F("[rfid] connection to RC522 lost"));
         lcd.display("RFID chip not found", 0, 1, 5 * 1000, LCD_CLEAR_LINE);
         _failure = true;
         _initialized = false;
+        _present = false;
     }
 
     if (!_initialized || _failure) {

--- a/src/rc522.cpp
+++ b/src/rc522.cpp
@@ -1,0 +1,199 @@
+/*
+ * Author: OpenEVSE contributors
+ */
+
+#if defined(ENABLE_RC522)
+
+#if defined(ENABLE_DEBUG) && !defined(ENABLE_DEBUG_NFCREADER)
+#undef ENABLE_DEBUG
+#endif
+
+#include "rc522.h"
+#include "app_config.h"
+#include "debug.h"
+#include "lcd.h"
+
+#define SCAN_DELAY 1000
+#define POLL_DELAY 50
+
+// After this period without a successful SPI exchange the reader is offline.
+#define MAXIMUM_UNRESPONSIVE_TIME 60000UL
+
+// MFRC522 firmware version bytes (see NXP MFRC522 datasheet, version register).
+#define MFRC522_VERSION_0x91 0x91
+#define MFRC522_VERSION_0x92 0x92
+
+RC522Reader::RC522Reader()
+    : _mfrc522(RC522_SS_PIN, RC522_RST_PIN),
+      _spi(&SPI),
+      _ss_pin(RC522_SS_PIN),
+      _rst_pin(RC522_RST_PIN),
+      MicroTasks::Task() {
+}
+
+RC522Reader::RC522Reader(uint8_t ss_pin, uint8_t rst_pin, SPIClass *spi)
+    : _mfrc522(ss_pin, rst_pin),
+      _spi(spi ? spi : &SPI),
+      _ss_pin(ss_pin),
+      _rst_pin(rst_pin),
+      MicroTasks::Task() {
+}
+
+void RC522Reader::begin() {
+    // SPI presence probe at boot so the UI can report reader connected/disconnected
+    // even when RFID is disabled in config.
+    probeReader();
+    MicroTask.startTask(this);
+}
+
+bool RC522Reader::probeReader() {
+    if (_initialized && !_failure) {
+        // Already communicating — avoid resetting the chip mid-session.
+        return true;
+    }
+
+    // Re-run the version-register read and refresh the cached result. The boot-time
+    // one-shot can false-negative (reader still powering up) and would otherwise
+    // report absent until reboot. readerPresent() returns this cached flag; probeReader()
+    // actively refreshes it over SPI.
+#if defined(RC522_SPI_SCK) && defined(RC522_SPI_MISO) && defined(RC522_SPI_MOSI)
+    _spi->begin(RC522_SPI_SCK, RC522_SPI_MISO, RC522_SPI_MOSI, _ss_pin);
+#else
+    _spi->begin();
+#endif
+
+    _mfrc522.PCD_Init(_ss_pin, _rst_pin);
+    byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
+    _present = (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92);
+
+    if (_present) {
+        DBUGF("[rfid] RC522 probe OK, version=0x%02X", version);
+    } else {
+        DBUGF("[rfid] RC522 probe failed, version=0x%02X", version);
+    }
+
+    return _present;
+}
+
+bool RC522Reader::readerPresent() {
+    // Cached probe result from boot or the last probeReader() call, or currently
+    // initialized and responding while RFID is active.
+    return _present || (_initialized && !_failure);
+}
+
+bool RC522Reader::readerFailure() {
+    return config_rfid_enabled() && _failure;
+}
+
+void RC522Reader::initialize() {
+#if defined(RC522_SPI_SCK) && defined(RC522_SPI_MISO) && defined(RC522_SPI_MOSI)
+    _spi->begin(RC522_SPI_SCK, RC522_SPI_MISO, RC522_SPI_MOSI, _ss_pin);
+#else
+    _spi->begin();
+#endif
+
+    // PCD_Init drives RST, configures SPI chip-select, and verifies the MFRC522
+    // version register over the shared SPI bus.
+    _mfrc522.PCD_Init(_ss_pin, _rst_pin);
+    _mfrc522.PCD_AntennaOn();
+
+    byte version = _mfrc522.PCD_ReadRegister(MFRC522::VersionReg);
+    if (version == MFRC522_VERSION_0x91 || version == MFRC522_VERSION_0x92) {
+        DBUGLN(F("[rfid] connection to RC522 active"));
+        _initialized = true;
+        _failure = false;
+        _present = true;
+        _last_response = millis();
+    } else {
+        DBUGF("[rfid] RC522 init failed, version=0x%02X", version);
+        _initialized = false;
+        _present = false;
+    }
+}
+
+String RC522Reader::uidToString(const MFRC522::Uid &uid) {
+    // Match PN532 UID formatting: lowercase hex pairs with no separator.
+    String out = String('\0');
+    out.reserve(2 * uid.size);
+
+    for (byte i = 0; i < uid.size; i++) {
+        uint8_t b = uid.uidByte[i];
+        uint8_t hi = b / 0x10;
+        uint8_t lo = b % 0x10;
+        out += (char)(hi <= 9 ? hi + '0' : hi % 10 + 'a');
+        out += (char)(lo <= 9 ? lo + '0' : lo % 10 + 'a');
+    }
+
+    return out;
+}
+
+void RC522Reader::poll() {
+    if (!_initialized) {
+        return;
+    }
+
+    // PICC_IsNewCardPresent() performs a short SPI exchange to detect a tag in
+    // the RF field. When the tag leaves, clear contact so the same card can be
+    // presented again later.
+    if (!_mfrc522.PICC_IsNewCardPresent()) {
+        _has_contact = false;
+        _last_uid.clear();
+        return;
+    }
+
+    if (!_mfrc522.PICC_ReadCardSerial()) {
+        return;
+    }
+
+    _last_response = millis();
+
+    String uid = uidToString(_mfrc522.uid);
+
+    if (_has_contact && uid == _last_uid) {
+        // Valid card already reported while still in the field — nothing to do.
+        return;
+    }
+
+    DBUG(F("[rfid] found card! uid = "));
+    DBUG(uid);
+    DBUGLN(F(" end"));
+
+    _has_contact = true;
+    _last_uid = uid;
+    onCardDetected(uid);
+
+    // Halt the PICC so removal/re-tap can be detected on the next poll cycle.
+    _mfrc522.PICC_HaltA();
+    _mfrc522.PCD_StopCrypto1();
+}
+
+unsigned long RC522Reader::loop(MicroTasks::WakeReason reason) {
+    (void)reason;
+
+    // Allow scanning when a scheduler timer window requires RFID even if the
+    // global rfid_enabled setting is off.
+    if (!config_rfid_enabled() && !_timer_scanning) {
+        _initialized = false;
+        _has_contact = false;
+        return SCAN_DELAY;
+    }
+
+    if (_initialized && millis() - _last_response > MAXIMUM_UNRESPONSIVE_TIME) {
+        DBUGLN(F("[rfid] connection to RC522 lost"));
+        lcd.display("RFID chip not found", 0, 1, 5 * 1000, LCD_CLEAR_LINE);
+        _failure = true;
+        _initialized = false;
+    }
+
+    if (!_initialized || _failure) {
+        initialize();
+        return POLL_DELAY;
+    }
+
+    poll();
+    return POLL_DELAY;
+}
+
+RC522Reader rc522;
+
+#endif

--- a/src/rc522.cpp
+++ b/src/rc522.cpp
@@ -49,9 +49,9 @@ void RC522Reader::begin() {
 }
 
 bool RC522Reader::probeReader() {
-    if (_initialized && !_failure) {
+    if (_initialized) {
         // Already communicating — avoid resetting the chip mid-session.
-        return true;
+        return _present;
     }
 
     // Re-run the version-register read and refresh the cached result. The boot-time

--- a/src/rc522.h
+++ b/src/rc522.h
@@ -24,8 +24,9 @@
 
 class RC522Reader : public RfidReader, public MicroTasks::Task {
 private:
-    // MFRC522 talks over the platform default SPI peripheral; bus pin remapping
-    // is done via SPI.begin(...) before PCD_Init(), not via the library constructor.
+    // MFRC522 talks over the platform default SPI peripheral. The optional
+    // SPIClass* constructor argument only selects which bus gets SPI.begin()
+    // pin remapping; MFRC522 library transfers always use the global SPI object.
     MFRC522 _mfrc522;
     SPIClass *_spi;
     uint8_t _ss_pin;
@@ -59,7 +60,12 @@ public:
     bool readerFailure() override;
     bool readerPresent() override;
     bool probeReader() override;
-    void setTimerScanning(bool active) override { _timer_scanning = active; }
+    void setTimerScanning(bool active) override {
+        _timer_scanning = active;
+        if (active) {
+            MicroTask.wakeTask(this);
+        }
+    }
 };
 
 extern RC522Reader rc522;

--- a/src/rc522.h
+++ b/src/rc522.h
@@ -1,0 +1,68 @@
+/*
+ * Author: OpenEVSE contributors
+ */
+
+#if defined(ENABLE_RC522)
+
+#ifndef RC522_H
+#define RC522_H
+
+#include "rfid.h"
+#include <MFRC522.h>
+#include <MicroTasks.h>
+#include <SPI.h>
+
+// Default chip-select (SS/SDA) and reset pins — override via build flags
+// (e.g. -D RC522_SS_PIN=5 -D RC522_RST_PIN=22) for other boards/wiring.
+#ifndef RC522_SS_PIN
+#define RC522_SS_PIN 5
+#endif
+
+#ifndef RC522_RST_PIN
+#define RC522_RST_PIN 22
+#endif
+
+class RC522Reader : public RfidReader, public MicroTasks::Task {
+private:
+    // MFRC522 talks over the platform default SPI peripheral; bus pin remapping
+    // is done via SPI.begin(...) before PCD_Init(), not via the library constructor.
+    MFRC522 _mfrc522;
+    SPIClass *_spi;
+    uint8_t _ss_pin;
+    uint8_t _rst_pin;
+
+    std::function<void(String &uid)> onCardDetected = [] (String &) {};
+
+    bool _initialized = false;
+    bool _present = false;        // last probe result: reader seen on SPI bus
+    bool _failure = false;        // reader was active but stopped responding
+    bool _timer_scanning = false; // scheduler window wants scanning while rfid off
+    bool _has_contact = false;    // card still in field — suppress repeat callbacks
+    String _last_uid;
+
+    ulong _last_response = 0;
+
+    void initialize();
+    void poll();
+    static String uidToString(const MFRC522::Uid &uid);
+
+protected:
+    void setup() { }
+    unsigned long loop(MicroTasks::WakeReason reason);
+
+public:
+    RC522Reader();
+    explicit RC522Reader(uint8_t ss_pin, uint8_t rst_pin, SPIClass *spi = &SPI);
+    void begin();
+
+    void setOnCardDetected(std::function<void(String &)> onCardDet) override { onCardDetected = onCardDet; }
+    bool readerFailure() override;
+    bool readerPresent() override;
+    bool probeReader() override;
+    void setTimerScanning(bool active) override { _timer_scanning = active; }
+};
+
+extern RC522Reader rc522;
+
+#endif
+#endif

--- a/src/rc522.h
+++ b/src/rc522.h
@@ -13,13 +13,13 @@
 #include <SPI.h>
 
 // Default chip-select (SS/SDA) and reset pins — override via build flags
-// (e.g. -D RC522_SS_PIN=5 -D RC522_RST_PIN=22) for other boards/wiring.
+// (e.g. -D RC522_SS_PIN=5 -D RC522_RST_PIN=4) for other boards/wiring.
 #ifndef RC522_SS_PIN
 #define RC522_SS_PIN 5
 #endif
 
 #ifndef RC522_RST_PIN
-#define RC522_RST_PIN 22
+#define RC522_RST_PIN 4
 #endif
 
 class RC522Reader : public RfidReader, public MicroTasks::Task {

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -583,7 +583,7 @@ void buildStatus(DynamicJsonDocument &doc) {
 
   doc["ocpp_connected"] = (int)OcppTask::isConnected();
 
-#if defined(ENABLE_PN532) || defined(ENABLE_RFID)
+#if defined(ENABLE_PN532) || defined(ENABLE_RC522) || defined(ENABLE_RFID)
   doc["rfid_failure"] = (int) rfid.communicationFails();
   doc["rfid_reader"] = (int) rfid.readerPresent();
 #endif


### PR DESCRIPTION
## RC522 RFID Reader Support

This PR adds MFRC522/RC522 SPI RFID reader support as an alternative to the existing PN532 NFC reader.

### Changes
- Added `ENABLE_RC522` RFID backend
- Added `openevse_wifi_v1_rc522` PlatformIO environment
- Added RC522 SPI driver implementation
- Added RC522 build and user documentation
- Added MFRC522 clone version `0x88` support
- Improved reader timeout handling and false failure detection
- Fixed RC522 reset pin conflict with MCP9808 I2C (GPIO22 → GPIO4)

### Validation
- Built successfully:
- python -m platformio run -e openevse_wifi_v1_rc522


Build result:

SUCCESS


### Hardware
Default RC522 wiring:
- SS: GPIO5
- RST: GPIO4
- SCK: GPIO18
- MOSI: GPIO23
- MISO: GPIO19

PN532 support remains unchanged.
