### PR TITLE
add missing   ${common.debug_flags} to [env:openevse_wifi_v1_16mb]

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -548,7 +548,7 @@ lib_deps =
   ${core3_tsdb_common.esp_tsdb_lib}
 build_flags =
   ${common.build_flags}
-  -Os
+  ${common.debug_flags}
   -D ENABLE_TSDB
   -D NEO_PIXEL_PIN=17
   -D NEO_PIXEL_LENGTH=14


### PR DESCRIPTION
env:openevse_wifi_v1_16mb is missing the ${common.debug_flags} giving empty debug consnole in gui. 