### PR TITLE
fix(web): send a valid ETag so browsers stop re-downloading the whole UI

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -577,7 +577,7 @@ platform = native
 framework =
 test_framework = doctest
 test_build_src = true
-build_src_filter = -<*> +<tsdb_sample.cpp> +<home_battery.cpp> +<lvgl_tft/backlight.cpp> +<crypto/sha256.c> +<crypto/hmac_sha256.cpp> +<web_auth.cpp> +<ota_url_allow.cpp>
+build_src_filter = -<*> +<tsdb_sample.cpp> +<home_battery.cpp> +<lvgl_tft/backlight.cpp> +<crypto/sha256.c> +<crypto/hmac_sha256.cpp> +<web_auth.cpp> +<ota_url_allow.cpp> +<http_etag.cpp>
 build_flags = -std=gnu++17 -I src/lvgl_tft -I src
 lib_deps = bblanchon/ArduinoJson@6.20.1
 extra_scripts =

--- a/src/http_etag.cpp
+++ b/src/http_etag.cpp
@@ -1,0 +1,102 @@
+#include "http_etag.h"
+
+#include <string.h>
+
+// Strip one optional weak marker (`W/`) and one optional pair of quotes,
+// yielding the opaque tag itself. Both are advisory decoration: for a weak
+// comparison neither participates in the match.
+static void unwrap(const char *&p, size_t &len)
+{
+  if(len >= 2 && 'W' == p[0] && '/' == p[1]) {
+    p += 2;
+    len -= 2;
+  }
+  if(len >= 2 && '"' == p[0] && '"' == p[len - 1]) {
+    p += 1;
+    len -= 2;
+  }
+}
+
+bool http_etag_matches(const char *header, size_t header_len, const char *etag)
+{
+  if(NULL == header || 0 == header_len || NULL == etag) {
+    return false;
+  }
+
+  const char *want = etag;
+  size_t want_len = strlen(etag);
+  unwrap(want, want_len);
+  if(0 == want_len) {
+    return false;
+  }
+
+  size_t i = 0;
+  while(i < header_len)
+  {
+    // Skip separators and leading whitespace.
+    while(i < header_len && (',' == header[i] || ' ' == header[i] || '\t' == header[i])) {
+      i++;
+    }
+    size_t start = i;
+
+    // A tag runs to the next comma. Quotes cannot contain one: the opaque part
+    // of an entity-tag excludes both DQUOTE and, in practice, the comma we
+    // split on, so a plain scan is enough here.
+    while(i < header_len && ',' != header[i]) {
+      i++;
+    }
+    size_t end = i;
+
+    // Trim trailing whitespace.
+    while(end > start && (' ' == header[end - 1] || '\t' == header[end - 1])) {
+      end--;
+    }
+    if(end == start) {
+      continue;
+    }
+
+    const char *got = header + start;
+    size_t got_len = end - start;
+
+    if(1 == got_len && '*' == got[0]) {
+      return true;
+    }
+
+    unwrap(got, got_len);
+
+    if(got_len == want_len && 0 == memcmp(got, want, want_len)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool http_etag_quote(const char *etag, char *out, size_t out_len)
+{
+  if(NULL == out || 0 == out_len) {
+    return false;
+  }
+  out[0] = '\0';
+
+  if(NULL == etag) {
+    return false;
+  }
+
+  const char *tag = etag;
+  size_t tag_len = strlen(etag);
+  unwrap(tag, tag_len);
+  if(0 == tag_len) {
+    return false;
+  }
+
+  if(tag_len + 3 > out_len) {
+    return false;
+  }
+
+  out[0] = '"';
+  memcpy(out + 1, tag, tag_len);
+  out[tag_len + 1] = '"';
+  out[tag_len + 2] = '\0';
+  return true;
+}

--- a/src/http_etag.h
+++ b/src/http_etag.h
@@ -1,0 +1,37 @@
+// src/http_etag.h — RFC 7232 conditional-request helpers for the embedded
+// static-file handler.
+//
+// The static files carry a content hash as their entity-tag. Getting the
+// comparison wrong is silent and expensive: the handler simply falls through to
+// the 200 path and re-sends the whole body, so a browser that caches perfectly
+// still re-downloads the entire UI bundle on every page load.
+//
+// Pure (no Arduino, no Mongoose) so it can be host-tested.
+#ifndef HTTP_ETAG_H
+#define HTTP_ETAG_H
+
+#include <stddef.h>
+
+// The stored etags are 64-char hex; +2 quotes +NUL.
+#define HTTP_ETAG_QUOTED_MAX 80
+
+// True if an If-None-Match header value matches `etag`, per RFC 7232 section 3.2.
+//
+// `header` is a raw header value (NOT necessarily NUL-terminated -- pass its
+// length) and may be a comma-separated list, may quote its tags, and may mark
+// them weak with a `W/` prefix. `etag` is the stored tag, with or without
+// quotes. Comparison is weak: a `W/` prefix on either side is ignored, which is
+// what a cache revalidation wants.
+//
+// Returns false when `header` is empty or `etag` is null/empty. A bare `*`
+// matches anything, as the RFC requires.
+bool http_etag_matches(const char *header, size_t header_len, const char *etag);
+
+// Write `etag` to `out` as a quoted entity-tag, adding quotes if it has none.
+// Browsers echo back exactly what we send, and an unquoted tag is not a valid
+// entity-tag, so sending one invites the client to normalise it into a form our
+// own comparison then has to cope with. Returns false (and writes an empty
+// string) if the result would not fit.
+bool http_etag_quote(const char *etag, char *out, size_t out_len);
+
+#endif // HTTP_ETAG_H

--- a/src/web_server_static.cpp
+++ b/src/web_server_static.cpp
@@ -10,6 +10,7 @@
 #include "app_config.h"
 #include "net_manager.h"
 #include "embedded_files.h"
+#include "http_etag.h"
 
 extern bool enableCors; // defined in web_server.cpp
 
@@ -61,10 +62,18 @@ bool web_static_handle(MongooseHttpServerRequest *request)
   {
     MongooseHttpServerResponseBasic *response = request->beginResponse();
 
-    response->addHeader(F("Cache-Control"), F("public, max-age=30, must-revalidate"));
+    // Vite content-hashes everything under /assets/, so those URLs are
+    // immutable by construction: a changed file gets a changed name. Telling
+    // the browser so removes the revalidation round trip entirely. index.html
+    // is NOT hashed -- it is what points at the current asset names -- so it
+    // keeps a short lifetime or a new build would never be picked up.
+    bool immutable = 0 == strncmp(file->filename, "/assets/", 8);
+    response->addHeader(F("Cache-Control"),
+                        immutable ? F("public, max-age=31536000, immutable")
+                                  : F("public, max-age=30, must-revalidate"));
 
     MongooseString ifNoneMatch = request->headers("If-None-Match");
-    if(ifNoneMatch.equals(file->etag)) {
+    if(http_etag_matches(ifNoneMatch.c_str(), ifNoneMatch.length(), file->etag)) {
       request->send(304);
       return true;
     }
@@ -80,7 +89,13 @@ bool web_static_handle(MongooseHttpServerRequest *request)
       response->addHeader(F("Content-Encoding"), F("gzip"));
     }
 
-    response->addHeader("Etag", file->etag);
+    // Quoted, per RFC 7232. Sending a bare tag is what broke this: browsers
+    // store it, hand it back quoted in If-None-Match, and the old exact-match
+    // compare above never fired -- so every page load re-sent the whole bundle.
+    char etag[HTTP_ETAG_QUOTED_MAX];
+    if(http_etag_quote(file->etag, etag, sizeof(etag))) {
+      response->addHeader("Etag", etag);
+    }
     response->setContent((const uint8_t *)file->data, file->length);
 
     request->send(response);

--- a/test/test_http_etag/test_http_etag.cpp
+++ b/test/test_http_etag/test_http_etag.cpp
@@ -1,0 +1,114 @@
+// Host-side tests for the conditional-request helpers (http_etag.cpp).
+//
+// The bug these exist to prevent: the handler emitted a bare, unquoted entity
+// tag and compared If-None-Match with an exact string match. Browsers hand the
+// tag back quoted, the compare never fired, and every page load re-sent the
+// full UI bundle while looking, from the device side, like a working cache.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "http_etag.h"
+
+#include <string.h>
+
+static bool match(const char *header, const char *etag) {
+  return http_etag_matches(header, strlen(header), etag);
+}
+
+static const char *HASH = "21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0";
+
+TEST_CASE("the quoted form a browser sends matches the stored bare tag") {
+  // This is the exact case that was broken on hardware.
+  CHECK(match("\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\"", HASH));
+}
+
+TEST_CASE("bare, weak and weak-quoted forms all match") {
+  CHECK(match(HASH, HASH));
+  CHECK(match("W/\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\"", HASH));
+  CHECK(match("W/21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0", HASH));
+  // ...and a stored tag that already carries quotes still matches both ways.
+  CHECK(match(HASH, "\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\""));
+}
+
+TEST_CASE("a list matches on any member, in any position") {
+  CHECK(match("\"aaa\", \"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\"", HASH));
+  CHECK(match("\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\", \"bbb\"", HASH));
+  CHECK(match("\"aaa\",\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\",\"bbb\"", HASH));
+  // Whitespace around the separators is optional and may be a tab.
+  CHECK(match("\t\"aaa\" ,\t\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\" ", HASH));
+  // Empty members are skipped rather than matching something.
+  CHECK(match(",,\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\",,", HASH));
+}
+
+TEST_CASE("* matches anything") {
+  CHECK(match("*", HASH));
+  CHECK(match(" * ", HASH));
+  CHECK(match("\"aaa\", *", HASH));
+}
+
+TEST_CASE("non-matching tags do not match") {
+  CHECK_FALSE(match("\"aaa\"", HASH));
+  CHECK_FALSE(match("\"\"", HASH));
+  // A prefix of the real tag must not match: length is compared, not just the
+  // leading bytes.
+  CHECK_FALSE(match("\"21293ded\"", HASH));
+  // Nor may a superset.
+  CHECK_FALSE(match("\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0f\"", HASH));
+  // '*' only counts as a wildcard when it is the whole tag.
+  CHECK_FALSE(match("\"*\"", HASH));
+  CHECK_FALSE(match("**", HASH));
+}
+
+TEST_CASE("empty and null inputs are a miss, not a match") {
+  CHECK_FALSE(http_etag_matches(NULL, 0, HASH));
+  CHECK_FALSE(http_etag_matches("", 0, HASH));
+  CHECK_FALSE(http_etag_matches(HASH, strlen(HASH), NULL));
+  CHECK_FALSE(http_etag_matches(HASH, strlen(HASH), ""));
+  CHECK_FALSE(http_etag_matches(HASH, strlen(HASH), "\"\""));
+  // A miss here is safe (a full 200); a false match would serve a stale body.
+  CHECK_FALSE(match("   ", HASH));
+}
+
+TEST_CASE("the header need not be NUL-terminated") {
+  // Mongoose hands us a pointer/length into the request buffer, so the byte
+  // after the value is whatever followed it on the wire.
+  const char *raw = "\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\"\r\nHost: x";
+  CHECK(http_etag_matches(raw, 66, HASH));
+  // Truncating inside the tag must not match.
+  CHECK_FALSE(http_etag_matches(raw, 20, HASH));
+}
+
+TEST_CASE("quoting adds quotes exactly once") {
+  char out[HTTP_ETAG_QUOTED_MAX];
+
+  CHECK(http_etag_quote(HASH, out, sizeof(out)));
+  CHECK(0 == strcmp(out, "\"21293ded49db24e51fd0ab812561afe63b20618aadc7f22343c46173d97aeac0\""));
+
+  CHECK(http_etag_quote("\"abc\"", out, sizeof(out)));
+  CHECK(0 == strcmp(out, "\"abc\""));
+
+  CHECK(http_etag_quote("W/\"abc\"", out, sizeof(out)));
+  CHECK(0 == strcmp(out, "\"abc\""));
+}
+
+TEST_CASE("quoting refuses rather than truncating") {
+  char out[8];
+  CHECK_FALSE(http_etag_quote(HASH, out, sizeof(out)));
+  CHECK(0 == strlen(out));   // and leaves nothing half-written behind
+
+  CHECK_FALSE(http_etag_quote(NULL, out, sizeof(out)));
+  CHECK(0 == strlen(out));
+  CHECK_FALSE(http_etag_quote("", out, sizeof(out)));
+
+  // Exactly-fits is allowed: 3 chars + 2 quotes + NUL.
+  char snug[6];
+  CHECK(http_etag_quote("abc", snug, sizeof(snug)));
+  CHECK(0 == strcmp(snug, "\"abc\""));
+}
+
+TEST_CASE("a tag that round-trips through quoting still matches") {
+  char out[HTTP_ETAG_QUOTED_MAX];
+  REQUIRE(http_etag_quote(HASH, out, sizeof(out)));
+  // What we send is what the browser gives back, so this is the whole contract.
+  CHECK(match(out, HASH));
+}


### PR DESCRIPTION
## The bug

`web_server_static.cpp` emits the entity tag **unquoted** and then compares
`If-None-Match` against the stored tag with an exact string match:

```cpp
response->addHeader("Etag", file->etag);          // Etag: 21293ded...
...
if(ifNoneMatch.equals(file->etag)) {              // exact match
  request->send(304);
```

RFC 7232 defines an entity-tag as a quoted string. Browsers store the tag and
send it back **quoted** — `If-None-Match: "21293ded..."` — which never equals
the bare stored hash, so the handler falls through to the 200 path and re-sends
the whole body.

The result is that no browser receives a 304 from the web UI: every page load
re-downloads the entire bundle. From the device side it looks like a working
cache, which is why this has been easy to miss.

Measured against a running device, same URL, same file:

| `If-None-Match` sent | Response |
|---|---|
| `21293ded…` (bare — what curl sends) | `304`, 0 bytes |
| `"21293ded…"` (quoted — what a browser sends) | `200`, 89,739 bytes |

That is ~200 KB of bundle re-sent per page load on a device with a few tens of
KB of usable heap.

## The fix

New pure helper, `src/http_etag.{h,cpp}`:

- `http_etag_quote()` — emit the tag quoted, adding quotes only if absent.
- `http_etag_matches()` — compare per RFC 7232 §3.2: tolerate quotes on either
  side, a `W/` weak prefix on either side, a comma-separated list, and `*`.
  Takes pointer + length, because Mongoose hands over a slice of the request
  buffer that is not NUL-terminated.

`/assets/` additionally gets `Cache-Control: public, max-age=31536000, immutable`.
Those filenames are content-hashed by the bundler, so a changed file always gets
a changed URL and revalidating them is a pure round trip. `index.html` keeps
`max-age=30, must-revalidate` — it is the unhashed file that *names* the current
assets, so marking it immutable would strand browsers on an old build after an
OTA. The check is a path prefix, so a GUI that does not emit `/assets/` is
unaffected.

## Tests

`test/test_http_etag/` — 10 cases, 42 assertions, host-run under `native_test`.
Covers the exact hardware failure (bare stored tag vs quoted header), weak and
list forms, prefix and superset near-misses so length is compared rather than
just leading bytes, `"*"` quoted *not* counting as a wildcard, empty/null being
a miss rather than a match, and a non-NUL-terminated header.

## Verification

- `native_test`: 8/8 suites pass.
- `openevse_wifi_v1` builds at 94.7% of the 1,966,080-byte slot — the helper is
  small and does not threaten the 4 MB budget.
- `openevse_wifi_tft_v1` builds at 38.2%.
- Flashed to hardware: assets now return `Etag: "a69d2c5a…"` with
  `max-age=31536000, immutable`, a quoted `If-None-Match` returns `304` with 0
  bytes, and `index.html` correctly retains `max-age=30, must-revalidate`.
  Confirmed from iOS Safari, which was the original symptom.

## Notes

Independent of #1155 — that PR does not touch `web_server_static.cpp`, and this
applies cleanly on either side of the Mongoose 7 migration (`MongooseString`
exposes `c_str()`/`length()` on both). The helper itself is pure, with no
Arduino or Mongoose dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
