### PR TITLE
build: move OpenEVSE_Lib to v0.0.20 (RAPI queue heap fix)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   jeremypoulter/ArduinoMongoose@0.0.26
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#0.0.19  ; OpenEVSE library with D9 command support (protocol-gated)
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.20  ; OpenEVSE library with D9 command support (protocol-gated)
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -644,7 +644,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#0.0.19
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.20
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4


### PR DESCRIPTION
Moves the `OpenEVSE_Lib` pin from `0.0.19` to the [`v0.0.20`](https://github.com/OpenEVSE/OpenEVSE_Lib/releases/tag/v0.0.20) release, which is on the PlatformIO registry.

## Why

`0.0.19`'s RAPI command queue leaks its slots. `queue.h`'s `pop()` copies the item out but never clears the slot it came from, so the ten-element static `CommandItem` array keeps ten `String`s and ten `std::function`s alive for the life of the process. Every command allocates fresh and frees nothing, and the surviving allocations migrate steadily deeper into the heap.

This is invisible in free-heap terms — total free stays flat. What collapses is the largest contiguous block, which is what lwIP and the TLS stack actually need.

| | largest contiguous block |
|---|---|
| `0.0.19`, live controller, ~1.3 cmd/s, 14 h | ~51 KB → **under 10 KB** |
| `v0.0.20`, same unit, 10 h / 41,898 commands | **36,852 B, flat** |

An identical unit with no controller attached — so no RAPI traffic — held flat on both. That is what points at the queue rather than at the web or MQTT paths.

## Also in v0.0.20

- The async event handler is guarded against short frames.
- Inline handler storage is sized by pointer width (`sizeof(void *) * 10`) rather than a fixed byte count, so 64-bit host and native-test builds no longer trip its capacity `static_assert`.
- Wider state and flag accessors on `OpenEVSEClass`, including the `$G0` path.

## Verification

Both device envs build unchanged on this pin:

- `openevse_wifi_v1` — 94.6% of the 1,966,080-byte slot
- `openevse_wifi_tft_v1` — 38.1%

The two `platformio.ini` occurrences are the `common` block and `native_simulator`; nothing else changes.
