### PR TITLE
ci: auto-mark and close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Close stale issues and PRs
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 180
+          days-before-issue-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
+          stale-issue-label: stale
+          stale-pr-label: stale
+          exempt-issue-labels: 'pinned,security,bug confirmed'
+          exempt-pr-labels: 'pinned,security'
+          exempt-all-milestones: true
+          stale-issue-message: >
+            This issue has had no activity for 6 months. It will be closed in 30
+            days unless there is further activity. Comment or add more detail to
+            keep it open.
+          stale-pr-message: >
+            This pull request has had no activity for 3 months. It will be closed
+            in 30 days unless there is further activity. Comment or rebase to
+            keep it open.
+          close-issue-message: >
+            Closing due to inactivity. Feel free to reopen or file a new issue if
+            this is still a problem on the latest firmware.
+          close-pr-message: >
+            Closing due to inactivity. Feel free to reopen once the branch is
+            ready to move forward.


### PR DESCRIPTION
Adds [actions/stale](https://github.com/actions/stale) to auto-triage inactive issues and PRs: daily run (04:30 UTC) plus manual dispatch.

## Policy as proposed

| | Marked stale after | Closed after a further |
|---|---|---|
| Issues | 180 days of inactivity | 30 days |
| PRs | 90 days of inactivity | 30 days |

- Exempt: `pinned` and `security` labels (issues additionally `bug confirmed`), and anything assigned to a milestone.
- Any comment or activity removes the `stale` label and resets the clock; the close messages invite reopening or refiling against current firmware.

The numbers are a starting point — happy to tune the windows or exemption labels to whatever suits the project's triage style.

Note: scheduled workflows only run on the default branch, so this is inert until merged. `workflow_dispatch` is included for a controlled first run — the default `operations-per-run: 30` means the initial backlog gets worked through gradually over daily runs rather than mass-labelled at once.
