### PR TITLE
perf(web): sample LittleFS usage on a timer instead of per /status

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -541,6 +541,43 @@ static String html_escape(const String &input) {
 // stops adding members.
 #define STATUS_JSON_CAPACITY (JSON_OBJECT_SIZE(128) + 2048)
 
+// LittleFS.totalBytes() and LittleFS.usedBytes() each run lfs_fs_size(), a
+// full traversal of every metadata pair and data block in the filesystem,
+// reading flash with the FS lock held. Arduino's wrapper discards whichever
+// half of esp_littlefs_info() you did not ask for, so reporting both numbers
+// cost three traversals per request.
+//
+// That made /status the most expensive poll on the device, and expensive in
+// proportion to how full the filesystem is: measured on hardware, a trivial
+// JSON endpoint answers in 11ms while /status took 94ms on a box with 57KB
+// used and 143ms on one with 237KB used. The TSDB store grows, so the cost
+// grows with it. With evcc and the Home Assistant integration polling, the
+// main loop was stalled on flash reads several percent of the time -- and
+// nothing drains the network stack while it is.
+//
+// These two numbers only move when something writes, so sample them on a
+// timer rather than per request.
+#define LFS_STATUS_SAMPLE_MS 30000
+
+static void status_littlefs_usage(uint32_t &free_bytes, uint32_t &used_bytes)
+{
+  static uint32_t sampled_at = 0;
+  static uint32_t cached_free = 0;
+  static uint32_t cached_used = 0;
+
+  uint32_t now = millis();
+  if(0 == sampled_at || (now - sampled_at) >= LFS_STATUS_SAMPLE_MS)
+  {
+    size_t total = LittleFS.totalBytes();
+    cached_used = (uint32_t)LittleFS.usedBytes();
+    cached_free = (uint32_t)(total - cached_used);
+    sampled_at = now;
+  }
+
+  free_bytes = cached_free;
+  used_bytes = cached_used;
+}
+
 void buildStatus(DynamicJsonDocument &doc) {
 
   // Get the current time
@@ -600,8 +637,12 @@ void buildStatus(DynamicJsonDocument &doc) {
 
   doc["free_heap"] = ESPAL.getFreeHeap();
   diagnostics_status(doc);
-  doc["littlefs_free"] = (uint32_t)(LittleFS.totalBytes() - LittleFS.usedBytes());
-  doc["littlefs_used"] = (uint32_t)LittleFS.usedBytes();
+  {
+    uint32_t lfs_free, lfs_used;
+    status_littlefs_usage(lfs_free, lfs_used);
+    doc["littlefs_free"] = lfs_free;
+    doc["littlefs_used"] = lfs_used;
+  }
 
   doc["comm_sent"] = rapiSender.getSent();
   doc["comm_success"] = rapiSender.getSuccess();


### PR DESCRIPTION
`/status` is the most expensive endpoint on the device, and it is expensive in proportion to how full the filesystem is.

`buildStatus()` reports two filesystem numbers:

```c
doc["littlefs_free"] = (uint32_t)(LittleFS.totalBytes() - LittleFS.usedBytes());
doc["littlefs_used"] = (uint32_t)LittleFS.usedBytes();
```

That is three calls. Each one goes `LittleFSFS::totalBytes()`/`usedBytes()` -> `esp_littlefs_info()` -> `lfs_fs_size()`, which walks every metadata pair and data block in the filesystem, reading flash with the FS lock held. The Arduino wrapper discards whichever half of `esp_littlefs_info()` it was not asked for, so asking for total and used separately costs two traversals, and the third is the duplicated `usedBytes()`.

### Measurements

Two `openevse_wifi_tft_v1` units on the same build, timed with `curl`:

| endpoint | 57 KB used | 237 KB used |
|---|---|---|
| `/override`, `/claims`, `/schedule`, `/limit` | 11-12 ms | 10-13 ms |
| `/status` | 94 ms | 143 ms |

Comparable small-JSON endpoints answer in ~11 ms on both. `/status` costs 8-12x that, and the gap between the two units tracks filesystem usage — the signature of an O(filesystem) operation.

The existing `diagnostics_probe_*` counters (max free-heap drop around each half of the handler) tell the same story. On the busier unit, before and after this change:

```
             probe0_max  probe1_max
before          35328       24576
after               0        4096
```

`/status` latency there went from ~137 ms to ~31 ms. The second row matches what the lightly-loaded unit already showed.

### Why it matters beyond latency

Those milliseconds are spent inside the Mongoose event callback, so `loop()` is stalled and nothing drains the network stack while it runs. A unit polled by an external consumer every couple of seconds spends a noticeable fraction of wall clock blocked on flash reads. The cost also grows over time — with `ENABLE_TSDB` the energy store is what fills the filesystem, so `/status` gets slower the longer the unit runs.

### The change

Sample the two values on a 30 s timer instead of per request. They only move when something writes, so the reported numbers stay accurate; the traversal drops from 3 per request to 2 per 30 s.

### Testing

Built for `openevse_wifi_tft_v1` and run on two units for several hours. `littlefs_used`/`littlefs_free` continue to track real writes (observed rising as the TSDB store grew). No change to the response schema.

Not tested on a build without `ENABLE_TSDB`, where the filesystem stays small and the win is correspondingly smaller — the change is a no-op there rather than a risk.
