### PR TITLE
deps: move core-3 boards to pioarduino 55.03.311 (Arduino 3.3.11 / IDF 5.5.5)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ default_envs = openevse_wifi_v1
 # core-3.x platform for 16MB+ boards (pioarduino / Arduino-ESP32 3.x on ESP-IDF 5.x).
 # 4MB boards stay on the core-2.x default ([env] platform = espressif32@6.12.0).
 # Envs that want core-3 set: platform = ${common.platform_core3}
-platform_core3 = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38-1/platform-espressif32.zip
+platform_core3 = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/ArduinoMongoose@0.0.26


### PR DESCRIPTION
Moves the core-3 platform pin forward:

```
before:  55.03.38-1   Arduino 3.3.8  / ESP-IDF 5.5.4   (2026-04-13)
after:   55.03.311    Arduino 3.3.11 / ESP-IDF 5.5.5   (2026-07-24)
```

Only the two envs that opt into `${common.platform_core3}` are affected — `openevse_wifi_tft_v1` and `openevse_wifi_v1_16mb`. The 4 MB boards stay on the core-2.x default and are untouched by this.

There is one intermediate release, `55.03.39` (Arduino 3.3.9, still IDF 5.5.4). This goes straight to the newest, so it is one Arduino minor and one IDF patch release forward.

### The pin stays a pin

Worth stating explicitly since "why not just track latest" comes up: the pin is a release-ZIP URL rather than a floating ref on purpose. ESP-IDF is where LittleFS, mbedTLS, lwIP and the heap allocator all come from, so an unpinned platform would give different builds on different machines and CI runs, and would make any heap or latency measurement non-reproducible. Bumping deliberately, one tested step at a time, keeps that property.

### Size

`openevse_wifi_tft_v1`:

```
flash   2673216 -> 2560920   (-112296 bytes)
RAM        31.9% -> 31.9%
```

`openevse_wifi_v1_16mb` builds clean at 30.7% flash / 22.1% RAM.

### Testing

Both core-3 envs build with no source changes. `openevse_wifi_tft_v1` was flashed to a 16 MB unit and came up clean:

- boots, WiFi associates, MQTT connects
- `tsdb_ready` 1, `tsdb_err` 0 — the existing energy store opens unchanged
- `/`, `/config`, `/status`, `/claims`, `/override`, `/schedule`, `/limit`, `/energy/daily`, `/energy/monthly` all return 200

This is a fresh bump and has not had a long soak yet, which is why it is a draft. Holding it here until it has meaningful runtime behind it; the risk with a platform move is not the build, it is what shows up after hours of uptime.

Not covered: the unit used has no EVSE controller attached, so the RAPI path is exercised only as far as "the port opens and the sender runs". Anyone with a controller-attached core-3 board confirming normal operation would close that gap.
