### PR TITLE
feat(mqtt): make the $SYS/broker/version probe optional

### DIFF
--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -327,6 +327,7 @@ ConfigOpt *opts[] =
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_MQTT, CONFIG_SERVICE_MQTT, "mqtt_enabled", "me"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_MQTT_ALLOW_ANY_CERT, 0, "mqtt_reject_unauthorized", "mru"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_MQTT_RETAINED, CONFIG_MQTT_RETAINED, "mqtt_retained", "mrt"),
+  new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_MQTT_NO_SYS_QUERY, 0, "mqtt_sys_query", "msq"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_SNTP, CONFIG_SERVICE_SNTP, "sntp_enabled", "se"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_TESLA, CONFIG_SERVICE_TESLA, "tesla_enabled", "te"),
   new ConfigOptVirtualMaskedBool(flagsOpt, flagsChanged, CONFIG_SERVICE_DIVERT, CONFIG_SERVICE_DIVERT, "divert_enabled", "de"),

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -165,7 +165,10 @@ extern uint32_t flags;
 #define CONFIG_WIZARD               (1 << 25)
 #define CONFIG_DEFAULT_STATE        (1 << 26)
 #define CONFIG_TEMP_THROTTLE        (1 << 27)
-#define CONFIG_LCD_NETWORK_INFO     (1 << 28) // next free bit after CONFIG_LCD_NETWORK_INFO
+#define CONFIG_LCD_NETWORK_INFO     (1 << 28)
+// Inverted sense: bit SET disables the $SYS/broker/version probe. Existing
+// installs have this bit clear, so they keep probing exactly as before.
+#define CONFIG_MQTT_NO_SYS_QUERY    (1 << 29) // next free bit after CONFIG_MQTT_NO_SYS_QUERY
 
 #define INITIAL_CONFIG_VERSION  1
 
@@ -187,6 +190,13 @@ inline uint8_t config_mqtt_protocol() {
 
 inline bool config_mqtt_retained() {
   return CONFIG_MQTT_RETAINED == (flags & CONFIG_MQTT_RETAINED);
+}
+
+// Query broker metadata via $SYS/broker/version. Must be off for managed
+// brokers (AWS IoT Core): they have no $SYS tree and answer an unauthorised
+// subscribe by closing the connection rather than failing the SUBACK.
+inline bool config_mqtt_sys_query() {
+  return 0 == (flags & CONFIG_MQTT_NO_SYS_QUERY);
 }
 
 inline bool config_mqtt_reject_unauthorized() {

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -342,8 +342,16 @@ void Mqtt::subscribeTopics() {
   _mqttclient.subscribe(mqtt_topic + "/config/set"); yield();
   _mqttclient.subscribe(mqtt_topic + "/restart"); yield();
 
-  // Broker metadata — most brokers publish this as a retained message
-  _mqttclient.subscribe("$SYS/broker/version"); yield();
+  // Broker metadata — most brokers publish this as a retained message.
+  //
+  // Off for managed brokers (AWS IoT Core): they have no $SYS tree and answer a
+  // subscribe to an unauthorised topic by closing the connection, not by failing
+  // the SUBACK. So this cannot be "try it and tolerate the failure" — probing
+  // kills the session and the client reconnects straight back into the same
+  // probe. _brokerVersion stays "", which is exactly what it means: unknown.
+  if (config_mqtt_sys_query()) {
+    _mqttclient.subscribe("$SYS/broker/version"); yield();
+  }
 
   DBUGLN("MQTT Subscriptions complete");
 }


### PR DESCRIPTION
## Problem

`Mqtt::onConnect()` subscribes to `$SYS/broker/version` unconditionally to
populate `mqtt_broker_version`. That works on Mosquitto and most self-hosted
brokers, but managed brokers have no `$SYS` tree.

AWS IoT Core treats a subscribe to an unauthorised topic as a policy violation
and answers by **closing the connection**, not by returning a failed SUBACK. The
client then reconnects, subscribes again, and is dropped again — so a device
configured against IoT Core never establishes a working session.

This is why it can't be handled as "subscribe and tolerate the failure": there
is no failure to tolerate, only a dropped connection, and nothing in the reply
distinguishes it from an ordinary disconnect.

## Change

Adds a `mqtt_sys_query` option (short name `msq`) gating the probe. One new
flag bit, one accessor, one `if`.

**Stored with inverted sense** — bit set = disabled — matching the existing
`mqtt_reject_unauthorized` / `CONFIG_MQTT_ALLOW_ANY_CERT` pattern. This is
load-bearing rather than stylistic: `flags` is read from NVS wholesale and
`flags_changed` only records options a user has explicitly set, so a newly
added bit reads 0 on every existing install. With normal sense, every current
user would silently stop seeing their broker version after upgrading. Inverted,
existing installs keep probing exactly as they do today and only a deliberate
opt-out changes behaviour.

## Testing

Hardware, against Mosquitto 2.1.2:

| | `mqtt_sys_query` | `mqtt_broker_version` |
|---|---|---|
| default | `true` | `"mosquitto version 2.1.2"` |
| after `POST {"mqtt_sys_query": false}` | `false` | unset |

The reconnect after toggling is clean and `mqtt_connected` stays 1, so no
`$SYS` subscribe goes out and the field correctly reads unknown rather than
going stale.

Builds green on `openevse_wifi_v1` (4 MB, the tightest env): flash 94.8%,
RAM 23.7%.

## Note for the GUI

The option is exposed on `/config` but has no UI yet — a checkbox alongside
the other MQTT settings would finish it. Defaulting on means nothing changes
for existing users until they turn it off.
