### PR TITLE
fix(tsdb): pin esp_tsdb to v2.4.1 to stop a watchdog boot loop

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -586,13 +586,17 @@ build_type = debug
 # the reference target proving the two-core build; feature work (tsdb, HA, P4,
 # the S3 display boards, …) stacks on top in later PRs.
 # Shared esp_tsdb lib_dep for ENABLE_TSDB targets (core-3 only). Pinned to a
-# tag: upstream ships no library.json, so PlatformIO reports the package as
-# 0.0.0+<sha> and cannot resolve versions -- the git ref is what pins it.
-# It has no PlatformIO manifest because it is packaged as an ESP-IDF component
-# (CMakeLists.txt + idf_component.yml); the LDF picks up src/ and include/ by
-# convention, and host_test/ is correctly left out of the build.
+# tag rather than a version constraint: the package is not in the PlatformIO
+# registry, so it is fetched by git URL and the ref is what pins it.
+#
+# v2.4.0 is the first release with the sidecar header write. Before it, the
+# database header was rewritten in place on every sample, and because LittleFS
+# stores a file as a CTZ skip-list a write at offset 0 rewrites the whole file
+# (~20 ms/KB) -- so once energy.tsdb passed ~170 KB the write exceeded
+# CONFIG_ESP_TASK_WDT_TIMEOUT_S=5 and the unit boot-looped. Do not move this pin
+# back below v2.4.0.
 [core3_tsdb_common]
-esp_tsdb_lib = https://github.com/zakery292/esp_tsdb.git#v2.3.0
+esp_tsdb_lib = https://github.com/zakery292/esp_tsdb.git#v2.4.1
 
 [env:openevse_wifi_v1_16mb]
 board = esp32dev


### PR DESCRIPTION
# Pin esp_tsdb to v2.4.1 to stop a watchdog boot loop

esp_tsdb **v2.3.0** — what `master` pins today — rewrites the database header in place on every sample. The header sits at offset 0, and LittleFS stores a file as a CTZ skip-list of block addresses, so a write at offset 0 rewrites the *whole* file. The cost is linear in file size, measured at ~20.4 ms/KB.

On the TFT unit logging energy every 5 minutes, `energy.tsdb` reached ~170 KB after two months and the per-sample header write crossed `CONFIG_ESP_TASK_WDT_TIMEOUT_S=5`, panicking `loopTask` mid-write and leaving the unit in a boot loop. Core dump backtrace:

```
loop() -> MicroTasks -> TsdbEnergyLogger::loop -> tsdb_write -> tsdb_write_header
       -> tsdb_flush_and_sync -> fsync -> lfs_ctz_extend -> esp_flash_read
```

with `ipc0` parked in `spi_flash_op_block_func`. Nothing was wrong with the filesystem (185 KB used of 3.4 MB, header sane) or the flash. The cost grows ~80 ms/day, so it presents as "worked for weeks, then bricked" — which is the part worth flagging: **every unit running `master` with TSDB enabled is on that same curve.** The threshold depends only on logging cadence and time.

## The fix

**v2.4.0** writes the header to alternating sidecar files (`<db>.h0` / `<db>.h1`) instead — a fresh small file each time, so the cost is flat (~56-80 ms) regardless of database size.

Backward compatible in both directions, with no migration step. On open the in-file header stays authoritative; a sidecar is adopted only when it is valid (magic + CRC32), geometrically identical, and strictly ahead — i.e. only to recover the records an unclean shutdown would otherwise have lost. `tsdb_close()` refreshes the in-file header and removes the sidecars, so a cleanly-closed database is an ordinary esp_tsdb file that v2.3.0 still reads. Existing `energy.tsdb` files open unchanged.

**v2.4.1** adds a PlatformIO manifest (`library.json`). Until now the component shipped only `idf_component.yml`, which PlatformIO cannot read, so the package resolved as `esp_tsdb@0.0.0+<sha>` — the old comment block in `platformio.ini` existed to explain that. It now resolves as `esp_tsdb@2.4.1+sha.7809169`. No change to the set of compiled files: `srcDir`/`includeDir` match what the LDF already inferred, and `host_test/` is excluded from the package.

## Verification

- `openevse_wifi_v1_16mb` builds clean against the new pin: flash 30.2%, RAM 19.9%.
- esp_tsdb's host regression suite is green on the tagged commit — `test_sidecar` (clean close / crash-with-sidecar-ahead / corrupt-sidecar-ignored) plus `wrap`, `multi`, `schema`, `resize`, `freecap`.
- Hardware-verified on the unit that was failing: it was dying inside the first minute before the fix, and has been logging on cadence since, through a soak across the same threshold that previously killed it.

Rebased onto current master (`d9229d3c`). Supersedes the earlier draft, which pinned a fork sha because the fix was still an open PR upstream; that PR is merged and released now, so this is a tag on the upstream repo.
