### PR TITLE
Read relay contact-life health from the controller, bump OpenEVSE_Lib…

### DIFF
--- a/docs/relay_health.md
+++ b/docs/relay_health.md
@@ -1,0 +1,200 @@
+# Relay contact-life health estimation
+
+Estimates how much life is left in the main charging contactor and surfaces
+it through the stack: controller firmware → RAPI → client library → this
+gateway firmware → GUI. Diagnostic only — never gates or alters charging
+logic at any layer.
+
+Spans four repos:
+
+| Repo | Branch/tag | What it adds |
+|---|---|---|
+| `open_evse` (ATmega/SAMD controller) | `dev` @ `5b3a755` (built on `442a98f`, `544f277`) | The estimation model: `RelayHealth` module, new RAPI commands, plus stuck-relay auto-recovery ($FK) |
+| `OpenEVSE_Lib` (client library) | `OpenEVSE9` @ `2c7c3f3`, tag `v0.0.22` | `getRelayHealth()` / `resetRelayHealth()` / `runStuckRelayRecovery()` wrappers |
+| `openevse_esp32_firmware` (this repo) | `relay_health` | Polls the new data, caches it, exposes it via `/config` JSON |
+| `openevse-gui-nightshift` | `relay_health` @ `c3f49b8` | Displays it: Monitoring → Health tab's Relay Health section |
+
+## Background / the problem
+
+Relay life splits into two budgets that are easy to conflate: **mechanical**
+life (cycles with no current flowing — springs/bearings, normally
+10⁷–10⁸ cycles) and **electrical** life (cycles under load — contact erosion
+from arcing, 10⁴–10⁵ cycles at rated current). For an EVSE contactor the
+electrical budget is the one that matters, and the single biggest lever is
+whether the contact opens hot (current still flowing) or cold (the car has
+already ramped down). A handful of hot disconnects — fault interrupts,
+e-stops, GFCI trips — can consume more life than years of normal cold
+cycling.
+
+The firmware already measured charging current and knew whether a stop was
+clean or a fault, but nothing accumulated that into a life estimate, and
+nothing gave early warning of the one failure mode a cycle count can't
+predict: a welded contact.
+
+## Model (`open_evse` firmware)
+
+Cumulative-damage (Miner's rule): each relay open consumes a fraction of a
+life budget, summed over the relay's life.
+
+- **Cold open** (current already at/below a zero threshold): `d = 1/N_m`
+- **Hot open** (current still flowing): `d = (1/N_e) · (I/I_r)² · α_load · α_temp`
+
+Where `N_e`/`N_m` are the rated electrical/mechanical life (cycles, from the
+relay's datasheet), `I_r` is rated current, and `α_load`/`α_temp` are
+load-character and temperature penalty multipliers. In a well-behaved
+installation the cold-cycle term rounds to ~0 (mechanical life is normally
+untouchable at any realistic cycle count) and the reported percentage is
+really tracking hot-switch events — exactly what you want surfaced.
+
+Two more independent signals feed into the picture, both self-baselined per
+station since enclosure thermals and hardware vary:
+
+- **Coil drop-out (open) transit-time drift** — a lengthening time between
+  the open command and the contact physically opening (measured via the
+  load-side AC-sense pin, CGMI hardware only) is an early symptom of
+  welding, ahead of the hard `EVSE_STATE_STUCK_RELAY` fault that ultimately
+  catches it.
+- **Thermal index `H = ΔT / I²`** (requires `TEMPERATURE_MONITORING`) —
+  proportional to contact resistance. Heating at the contact is `I²·R`;
+  normalizing by `I²` removes the load dependence, so `H` stays flat while
+  the contact is healthy and climbs as it erodes/oxidizes.
+
+Not implemented: direct contact-resistance measurement via closed-contact
+voltage drop — this hardware has no differential voltage sensor across the
+contacts to measure it.
+
+### New source: `firmware/open_evse/RelayHealth.{h,cpp}`
+
+Gated by `RELAY_HEALTH`, auto-enabled wherever `RELAY_ZC_SWITCH` + `AMMETER`
+are (every current build target). New EEPROM state at offsets 44–55.
+
+### New RAPI commands
+
+| Command | Direction | Purpose |
+|---|---|---|
+| `$SZ ma` | set | Relay-open current-zero threshold (mA) — runtime-tunable per-unit ammeter noise floor |
+| `$GZ` | get | Now returns **two** fields: `freqx100 zerothreshma` (was frequency-only) |
+| `$GW` | get | Relay wear diagnostics: `hotswitchcnt lastopenma closetransitms opentransitms` |
+| `$GL` | get | Relay life/health: `pctremain coldopencnt elecdamagex1e6 transitbaselinems transitdrift thermalx100 thermalbaselinex100 thermalwarn stuckrelayrecoverycnt` (9th field, `stuckrelayrecoverycnt`, added alongside stuck-relay auto-recovery) |
+| `$FH` | set | Reset the health accumulator/baselines/recovery counter (use after a physical relay replacement) |
+| `$FK` | set | Run the stuck-relay recovery cycle manually. NAK'd if an EV is connected; blocking on the controller side for up to ~30s |
+
+Full field-by-field reference: `open_evse/firmware/open_evse/rapi_proc.h`.
+
+## Client library (`OpenEVSE_Lib` 0.0.22)
+
+Added `OpenEVSEClass::getRelayHealth(callback)`, `resetRelayHealth(callback)`,
+and `runStuckRelayRecovery(callback)` in `src/openevse.{h,cpp}`, mirroring
+the existing `getFrequency()` / `getRelayStatus()` / `resetFaultCounters()`
+D9 extensions (same `isD9Supported()` protocol gate, same token-parsing
+style). Added the `OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE` (`0xffff`) sentinel
+for fields that aren't available yet (baseline not established) or at all
+(thermal fields need `TEMPERATURE_MONITORING` on the controller).
+`getRelayHealth()`'s callback took a breaking 9th → 10th argument
+(`stuck_relay_recovery_count`) between 0.0.21 and 0.0.22; older callbacks
+still work against a newer controller (the field defaults to 0 if the
+9-argument form is compiled), but a 10-argument callback against an older
+0.0.21-vintage controller response is a compile-time signature mismatch, not
+a silent bug.
+
+`getFrequency()` itself was **not** changed to expose the new `$GZ`
+zero-threshold field, to avoid a breaking signature change to an existing
+public method — see below for how this gateway firmware gets that value
+instead.
+
+## Gateway firmware (this repo, `relay_health` branch)
+
+`src/evse_monitor.{h,cpp}` — `EvseMonitor` gained:
+
+- **`readRelayHealth()`** — calls `OpenEVSE.getRelayHealth()`, caches all
+  nine fields, exposed via `isRelayHealthKnown()` +
+  `getRelay*()`/`isRelay*()` getters.
+- **`readFrequency()` rewritten** — reads `$GZ` raw via `EvseMonitor`'s own
+  `RapiSender*` instead of the library's single-field `getFrequency()`, so it
+  now also captures the zero-cross threshold from the same response instead
+  of round-tripping `$GZ` twice. Gated on `isD9Supported()` (as
+  `getFrequency()` itself is), so a pre-D9 controller isn't sent a `$GZ` it
+  can only NAK.
+- **`resetRelayHealth()`** — wraps `$FH`; re-reads `$GL` on success rather
+  than guessing what a freshly-reset accumulator looks like locally.
+- **`runStuckRelayRecovery()`** — wraps `$FK`; re-reads `$GL`/`$GR` on
+  success. Sets `_relay_recovery_in_flight` for the duration, which
+  `loop()` checks to skip its own periodic RAPI traffic (heartbeat pulse,
+  state/amp/temp/settings polls) — `$FK` can hold the RAPI queue for up to
+  ~30s, and without this guard everything `loop()` would otherwise enqueue
+  during that window gets `RAPI_RESPONSE_QUEUE_FULL`, heartbeat pulses
+  included, which risks tripping the controller's heartbeat-supervision
+  fallback current if enough consecutive pulses are dropped.
+- **Cache invalidation at `evseBoot()`** — `_relay_health_known` and
+  `_zero_cross_threshold_ma` are reset at the top of `evseBoot()` (which
+  runs on every controller connect, not just ESP32 power-on). Without this,
+  swapping in a controller that doesn't support `RELAY_HEALTH`/D9 — or is
+  simply older — would keep serving the *previous* controller's cached
+  values indefinitely, since nothing else clears them.
+
+**Known gap**: `runStuckRelayRecovery()` and `resetRelayHealth()` are both
+correctly wired C++ API now, but nothing in this repo calls them — the GUI's
+"Relay Replaced - Reset Health Values" button and any future recovery
+trigger go through the generic RAPI passthrough (`/r?json=1&rapi=$FH` /
+`$FK`) instead, bypassing this layer (and, for `$FK`, its queue guard)
+entirely. That's fine functionally — the passthrough works — but it means
+the guard above only takes effect if/when something is pointed at the typed
+method instead.
+
+### Polling cadence
+
+| When | Why |
+|---|---|
+| At boot (`evseBoot()`) | Populate immediately on connect |
+| After every charge session (`updateEvseState()`, the existing relay-open `!isCharging()` branch) | `$GL` is only meaningful once an open has occurred — that's when the controller's accumulator actually updates |
+| Every ~60s (`getSettingsFromEvse()`, existing settings-poll cadence) | Catches changes from other RAPI clients and long-running sessions with no session boundary. Does add `$GZ` + `$GL` to that cycle — small, but not zero. |
+
+### Exposure
+
+`src/app_config.cpp`'s `config_serialize()` (the `/config` JSON), alongside
+the existing `zero_cross`/`relay_dc1` fields:
+
+```json
+{
+  "zero_cross": true,
+  "zero_cross_threshold_ma": 300,
+  "relay_dc1": true,
+  "relay_life_pct": 100,
+  "relay_cold_open_count": 42,
+  "relay_elec_damage_x1e6": 0,
+  "relay_transit_drift_warning": false,
+  "relay_transit_baseline_ms": 18,
+  "relay_thermal_warning_level": 0,
+  "relay_thermal_index_x100": 12,
+  "relay_thermal_baseline_x100": 11,
+  "relay_stuck_recovery_count": 0
+}
+```
+
+Each field/block is **omitted** (not defaulted to 0/false) until the
+controller has actually answered — same pattern already used for
+`relay_dc1`/`relay_dc2`/`relay_ac`, so the GUI can distinguish "not
+supported by this controller" from a real zero.
+
+**Design question, unresolved**: most of these fields are telemetry that
+drifts over the life of the unit (life%, cold-open count, damage, thermal
+index/baseline, recovery count) sitting in an otherwise-static `/config`
+endpoint — `zero_cross_threshold_ma` is the one genuine setting in the
+group. As written, a client has to re-poll `/config` to notice a change
+(e.g. a new thermal warning), and none of it reaches the WebSocket. Moving
+the drifting fields to `/status` (`create_rapi_json()`) would fit the
+existing status/config split better, but is a real API change with GUI
+implications on the other side (`gui-nightshift` currently reads all of
+this from `config_store`) — deliberately not done here.
+
+`/config`'s `DynamicJsonDocument` capacity (`JSON_OBJECT_SIZE(128) + 1024`,
+`web_server_config.cpp`) has headroom for these ~11 new keys on hardware
+(measured: a live TFT unit already serves ~135 members within this budget),
+but it's thinner now — see the comment at the allocation site.
+
+## Verification status
+
+Firmware side (`open_evse`) built clean on `m328p_core`, `m328p_LCD_WIFI`,
+`samd`, `samd_ice` via PlatformIO. Gateway side (`openevse_esp32_firmware`):
+`pio run -e openevse_wifi_v1` builds clean (flash 96.0%, 1887925/1966080
+bytes; RAM 23.8%), including the review-driven fixes above.

--- a/docs/relay_health_review_response.md
+++ b/docs/relay_health_review_response.md
@@ -1,0 +1,138 @@
+# Response to the `relay_health` review
+
+Point-by-point response to the review of `openevse_esp32_firmware`'s
+`relay_health` branch (compiler-verification follow-up to the original PR
+description). Fixes landed in `692afa75` (`relay_health`, merged with
+upstream `master` at `1000bb44`); the typed-endpoint follow-up landed in the
+same commit plus `ad977ae` on `gui-nightshift`'s `http_endpoints` branch.
+
+Thanks for building it and catching these — five real issues in code that
+had only been reviewed by hand, not by a compiler that could actually
+exercise the paths.
+
+## 1. `readFrequency()` silently drops its D9 gate
+
+**Fixed.** Restored the `!isD9Supported()` check the library's
+`getFrequency()` had and the raw-`$GZ` rewrite lost:
+
+```cpp
+if(!_sender || !_openevse.isD9Supported()) {
+  return;
+}
+```
+
+A pre-D9 controller no longer gets sent a `$GZ` it can only NAK, at boot and
+every ~60s settings-poll cycle.
+
+## 2. `runStuckRelayRecovery()` has no caller / `resetRelayHealth()` has no gateway exposure
+
+**Both fixed, and taken further.** Added `EvseMonitor`/`EvseManager::resetRelayHealth()`
+(wraps `$FH`, re-reads `$GL` on success) — the gap you flagged as "the one
+an installer actually needs" is closed.
+
+For `runStuckRelayRecovery()`, we went with your other option and then some:
+rather than leave it uncalled, we built the consumer. New typed HTTP
+endpoints on the gateway:
+
+| Endpoint | Calls |
+|---|---|
+| `GET /relay/reset` | `EvseManager::resetRelayHealth()` ($FH) |
+| `GET /relay/recovery` | `EvseManager::runStuckRelayRecovery()` ($FK) |
+
+Both use the deferred-response pattern already established for `/scan`
+(WiFi scan) — the handler holds the `MongooseHttpServerResponseStream` open
+and returns immediately; the actual HTTP response is sent from the async
+RAPI callback. That matters specifically for `/relay/recovery`: the raw `/r`
+passthrough's `sendCmdSync()` busy-loops the calling task until the RAPI
+reply arrives, which would have frozen the *entire* Mongoose server —
+HTTP, WebSocket, MQTT, everything — for the recovery's ~30s worst case, not
+just the one request. The deferred pattern keeps the rest of the server
+responsive while the recovery runs. Both endpoints carry the same
+`actuatorMethodAllowed()` CSRF guard as `/restart`/`/apoff`/etc.
+
+`gui-nightshift`'s Health tab now points both buttons at these instead of
+raw RAPI passthrough — "Relay Replaced - Reset Health Values" (existing,
+repointed) and a new "Run Stuck Relay Recovery" button. See point 3: this is
+what makes the queue guard there actually take effect.
+
+## 3. The 35s `$FK` will stall the RAPI queue past the heartbeat interval
+
+**Fixed.** Added `_relay_recovery_in_flight`, checked at the top of
+`EvseMonitor::loop()`:
+
+```cpp
+if(_relay_recovery_in_flight) {
+  _count++;
+  return EVSE_MONITOR_POLL_TIME;
+}
+```
+
+Set around the `$FK` call in `runStuckRelayRecovery()`, cleared in its
+callback. While a recovery is outstanding, `loop()` skips its own periodic
+RAPI traffic entirely for that tick — heartbeat pulse, state/amp/temp/
+settings polls — rather than letting them pile into the queue and get
+`RAPI_RESPONSE_QUEUE_FULL`'d once it fills, heartbeat pulses included, which
+is what risked tripping the controller's heartbeat-supervision fallback
+current.
+
+Set unconditionally rather than only on the "will actually run" path: an
+EV-connected refusal NAKs almost immediately (the controller checks before
+doing anything), so the pause costs nothing on that path and only matters
+when the recovery genuinely runs.
+
+This guard is only exercised when `EvseMonitor::runStuckRelayRecovery()` is
+actually called — which, per point 2, is now the case: `/relay/recovery` is
+what the GUI calls, so the fix isn't inert.
+
+## 4. Cached health is never invalidated
+
+**Fixed.** `evseBoot()` (runs on every controller connect, not just ESP32
+power-on) now resets both at the top, before any RAPI round-trips:
+
+```cpp
+_relay_health_known = false;
+_zero_cross_threshold_ma = OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE;
+```
+
+A controller swap to one without `RELAY_HEALTH`/D9 no longer keeps serving
+the previous unit's cached life percentage (or zero-cross threshold)
+indefinitely.
+
+## 5. Most of this is telemetry in a config endpoint
+
+**Not resolved — still your call, as offered.** We didn't move the drifting
+fields (`relay_life_pct` and siblings) to `/status`. It's a real design
+question, but also a real API change with `gui-nightshift` implications on
+the other side (`HealthTab.svelte` currently reads all of it from
+`config_store`) — moving it means updating both repos in lockstep, and we'd
+rather you make that call than have us commit to a direction unprompted.
+
+Did the concrete, low-risk part: added a comment at the `/config`
+`DynamicJsonDocument` allocation site (`web_server_config.cpp`) noting the
+headroom is thinner now — measured against a live TFT unit's ~135 members,
+the ~11 new keys fit, but it's worth rechecking before the next addition
+rather than assuming.
+
+## Minor
+
+- **"without adding RAPI traffic"** — this was in `docs/relay_health.md`
+  (the closest thing we have to a PR description), not a code comment.
+  Corrected: the settings-poll cadence does add `$GZ` + `$GL` to that
+  60s cycle, small but not zero.
+- **Stale commit/version references** — `docs/relay_health.md` described
+  head `6856978` pinning `OpenEVSE_Lib` 0.0.21; the actual head at review
+  time was `de6fe6a1` at 0.0.22. Doc rewritten to match, and again since for
+  everything in this response.
+- **`/config` JSON example missing `relay_stuck_recovery_count`** — fixed
+  in the same doc rewrite.
+
+## Verification
+
+`pio run -e openevse_wifi_v1` builds clean at every stage of this response:
+after the five fixes (flash 96.0%, 1887925/1966080 bytes), after adding the
+typed endpoints (96.1%, 1889937/1966080), and after merging upstream
+`master`'s intervening changes into `relay_health` (96.3%, 1892813/1966080).
+RAM steady at 23.8% throughout. `gui-nightshift`'s `http_endpoints` branch:
+full test suite (958/958), production build, and a Playwright screenshot
+against the mock dev server confirming both buttons render and fire the new
+endpoints.

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   https://github.com/jeremypoulter/ArduinoMongoose.git#ca0a817de014cf4ab1833b32383532366fca10d7  ; master: mbedTLS-3 port + unique SUBSCRIBE ids + TLS teardown UAF fix (97ff3b4)
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.22  ; OpenEVSE library with D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
+  openevse/OpenEVSE@0.0.22  ; PlatformIO registry package (was a git+tag pin) - D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -726,7 +726,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.22
+  openevse/OpenEVSE@0.0.22
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   https://github.com/jeremypoulter/ArduinoMongoose.git#ca0a817de014cf4ab1833b32383532366fca10d7  ; master: mbedTLS-3 port + unique SUBSCRIBE ids + TLS teardown UAF fix (97ff3b4)
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.21  ; OpenEVSE library with D9 command support (protocol-gated) + relay-health $GL/$FH
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.22  ; OpenEVSE library with D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -705,7 +705,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.21
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.22
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   https://github.com/jeremypoulter/ArduinoMongoose.git#ca0a817de014cf4ab1833b32383532366fca10d7  ; master: mbedTLS-3 port + unique SUBSCRIBE ids + TLS teardown UAF fix (97ff3b4)
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.20  ; OpenEVSE library with D9 command support (protocol-gated)
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.21  ; OpenEVSE library with D9 command support (protocol-gated) + relay-health $GL/$FH
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -705,7 +705,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.20
+  https://github.com/OpenEVSE/OpenEVSE_Lib.git#v0.0.21
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -847,6 +847,12 @@ bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutp
     if(evse.isD9Supported()) {
       doc["pp_auto"] = evse.isPPAutoAmpacityEnabled();
       doc["zero_cross"] = evse.isZeroCrossSwitchEnabled();
+      // Relay-open current-zero threshold (mA), configurable on the
+      // controller via $SZ. Omitted (rather than a sentinel) when the
+      // controller hasn't reported one yet.
+      if(evse.getZeroCrossThresholdMa() != OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE) {
+        doc["zero_cross_threshold_ma"] = evse.getZeroCrossThresholdMa();
+      }
     }
     // Per-relay state is only emitted once $GR has actually been answered, so
     // an unknown state is omitted rather than defaulting to "enabled"
@@ -854,6 +860,26 @@ bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutp
       doc["relay_dc1"] = evse.isDC1RelayEnabled();
       doc["relay_dc2"] = evse.isDC2RelayEnabled();
       doc["relay_ac"]  = evse.isACRelayEnabled();
+    }
+    // Relay contact-life health estimate (requires the controller's
+    // RELAY_HEALTH feature). Read only; the whole block is omitted rather
+    // than defaulting to 0% until $GL has actually been answered, same
+    // pattern as the per-relay state above.
+    if(evse.isRelayHealthKnown()) {
+      doc["relay_life_pct"] = evse.getRelayLifeRemainingPct();
+      doc["relay_cold_open_count"] = evse.getRelayColdOpenCount();
+      doc["relay_elec_damage_x1e6"] = evse.getRelayElecDamageX1e6();
+      doc["relay_transit_drift_warning"] = evse.isRelayTransitDriftWarning();
+      if(evse.getRelayTransitBaselineMs() != OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE) {
+        doc["relay_transit_baseline_ms"] = evse.getRelayTransitBaselineMs();
+      }
+      doc["relay_thermal_warning_level"] = evse.getRelayThermalWarningLevel();
+      if(evse.getRelayThermalIndexX100() != OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE) {
+        doc["relay_thermal_index_x100"] = evse.getRelayThermalIndexX100();
+      }
+      if(evse.getRelayThermalBaselineX100() != OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE) {
+        doc["relay_thermal_baseline_x100"] = evse.getRelayThermalBaselineX100();
+      }
     }
     doc["chip_id"] = evse.getChipId();
     doc["heartbeat_interval"] = evse.getHeartbeatInterval();

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -880,6 +880,9 @@ bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutp
       if(evse.getRelayThermalBaselineX100() != OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE) {
         doc["relay_thermal_baseline_x100"] = evse.getRelayThermalBaselineX100();
       }
+      // 0 against firmware older than 9.3.0 (the field doesn't exist there),
+      // same as the controller-side default - no sentinel needed
+      doc["relay_stuck_recovery_count"] = evse.getRelayStuckRecoveryCount();
     }
     doc["chip_id"] = evse.getChipId();
     doc["heartbeat_interval"] = evse.getHeartbeatInterval();

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -539,8 +539,20 @@ class EvseManager : public MicroTasks::Task
       _monitor.resetFaultCounters(callback);
     }
     uint32_t getFrequency() { return _monitor.getFrequency(); }
+    uint32_t getZeroCrossThresholdMa() { return _monitor.getZeroCrossThresholdMa(); }
     const char *getChipId() { return _monitor.getChipId(); }
     bool isD9Supported() { return _monitor.isD9Supported(); }
+
+    // Relay contact-life health estimate
+    bool isRelayHealthKnown() { return _monitor.isRelayHealthKnown(); }
+    uint8_t getRelayLifeRemainingPct() { return _monitor.getRelayLifeRemainingPct(); }
+    uint32_t getRelayColdOpenCount() { return _monitor.getRelayColdOpenCount(); }
+    uint32_t getRelayElecDamageX1e6() { return _monitor.getRelayElecDamageX1e6(); }
+    uint32_t getRelayTransitBaselineMs() { return _monitor.getRelayTransitBaselineMs(); }
+    bool isRelayTransitDriftWarning() { return _monitor.isRelayTransitDriftWarning(); }
+    uint32_t getRelayThermalIndexX100() { return _monitor.getRelayThermalIndexX100(); }
+    uint32_t getRelayThermalBaselineX100() { return _monitor.getRelayThermalBaselineX100(); }
+    uint8_t getRelayThermalWarningLevel() { return _monitor.getRelayThermalWarningLevel(); }
     void restartEvse() {
       _monitor.restart();
     }

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -553,6 +553,10 @@ class EvseManager : public MicroTasks::Task
     uint32_t getRelayThermalIndexX100() { return _monitor.getRelayThermalIndexX100(); }
     uint32_t getRelayThermalBaselineX100() { return _monitor.getRelayThermalBaselineX100(); }
     uint8_t getRelayThermalWarningLevel() { return _monitor.getRelayThermalWarningLevel(); }
+    uint32_t getRelayStuckRecoveryCount() { return _monitor.getRelayStuckRecoveryCount(); }
+    void runStuckRelayRecovery(std::function<void(int ret)> callback = NULL) {
+      _monitor.runStuckRelayRecovery(callback);
+    }
     void restartEvse() {
       _monitor.restart();
     }

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -557,6 +557,9 @@ class EvseManager : public MicroTasks::Task
     void runStuckRelayRecovery(std::function<void(int ret)> callback = NULL) {
       _monitor.runStuckRelayRecovery(callback);
     }
+    void resetRelayHealth(std::function<void(int ret)> callback = NULL) {
+      _monitor.resetRelayHealth(callback);
+    }
     void restartEvse() {
       _monitor.restart();
     }

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -184,11 +184,21 @@ EvseMonitor::EvseMonitor(OpenEVSEClass &openevse) :
   _heartbeat_current(EVSE_HEARTBEAT_CURRENT),
   _sender(nullptr),
   _frequency(0),
+  _zero_cross_threshold_ma(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
   _relay_dc1(true),
   _relay_dc2(true),
   _relay_ac(true),
   _relay_status_known(false),
-  _chip_id("")
+  _chip_id(""),
+  _relay_health_known(false),
+  _relay_life_remaining_pct(0),
+  _relay_cold_open_count(0),
+  _relay_elec_damage_x1e6(0),
+  _relay_transit_baseline_ms(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
+  _relay_transit_drift_warning(false),
+  _relay_thermal_index_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
+  _relay_thermal_baseline_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
+  _relay_thermal_warning_level(0)
 {
 }
 
@@ -275,6 +285,7 @@ void EvseMonitor::evseBoot(const char *firmware)
   readChipId();
   readRelayStatus();
   readFrequency();
+  readRelayHealth();
 
 #ifndef DISABLE_HEARTBEAT
   _openevse.heartbeatEnable(EVSE_HEATBEAT_INTERVAL, EVSE_HEARTBEAT_CURRENT, [this](int ret, int interval, int current, int triggered) {
@@ -316,10 +327,13 @@ void EvseMonitor::updateEvseState(uint8_t evse_state, uint8_t pilot_state, uint3
     if(!isCharging()) {
       _amp = 0;
       _power = 0;
-      // Read voltage and frequency after relay opens
+      // Read voltage, frequency, and the relay-health estimate after relay
+      // opens - $GL is only meaningful once a relay open has occurred, since
+      // that's when the controller updates its cumulative-damage accumulator
       if(_sender) {
         getChargeCurrentAndVoltageFromEvse();
         readFrequency();
+        readRelayHealth();
       }
     }
     _session_complete.update(getFlags());
@@ -950,6 +964,17 @@ void EvseMonitor::getSettingsFromEvse()
       _settings_changed.Trigger();
     }
   });
+
+  // Relay health/damage barely moves between charge sessions (it only
+  // updates on a relay open), and the zero-cross threshold only changes via
+  // an explicit $SZ, but re-reading both here on the same ~60s cadence as
+  // the rest of the settings keeps them in sync if something else on the
+  // RAPI bus changes them, and covers installations that stay connected for
+  // days without a session boundary.
+  if(_sender) {
+    readFrequency();
+  }
+  readRelayHealth();
 }
 
 void EvseMonitor::getChargeCurrentAndVoltageFromEvse()
@@ -1098,10 +1123,21 @@ void EvseMonitor::resetFaultCounters(std::function<void(int ret)> callback)
 
 void EvseMonitor::readFrequency()
 {
-  _openevse.getFrequency([this](int ret, uint32_t frequency) {
-    if(RAPI_RESPONSE_OK == ret) {
-      _frequency = frequency;
+  // $GZ returns both AC line frequency and the relay-open current-zero
+  // threshold in one response; OpenEVSEClass::getFrequency() only exposes
+  // the first field, so read raw here rather than round-tripping $GZ twice
+  // (once via the library, once for the threshold).
+  if(!_sender) {
+    return;
+  }
+  _sender->sendCmd("$GZ", [this](int ret) {
+    if(RAPI_RESPONSE_OK == ret && _sender->getTokenCnt() >= 2) {
+      _frequency = strtoul(_sender->getToken(1), NULL, 10);
       DBUGF("frequency = %u (×100 Hz)", _frequency);
+      if(_sender->getTokenCnt() >= 3) {
+        _zero_cross_threshold_ma = strtoul(_sender->getToken(2), NULL, 10);
+        DBUGF("zero_cross_threshold_ma = %u", _zero_cross_threshold_ma);
+      }
     }
   });
 }
@@ -1126,6 +1162,36 @@ void EvseMonitor::readChipId()
     if(RAPI_RESPONSE_OK == ret && serial) {
       snprintf(_chip_id, sizeof(_chip_id), "%s", serial);
       DBUGF("chip_id = %s", _chip_id);
+    }
+  });
+}
+
+void EvseMonitor::readRelayHealth()
+{
+  // $GL - relay contact-life health estimate (requires the controller's
+  // RELAY_HEALTH feature). Not gated on isD9Supported() here: the callback
+  // itself no-ops (leaves _relay_health_known false) on unsupported
+  // controllers, since getRelayHealth() already returns
+  // RAPI_RESPONSE_FEATURE_NOT_SUPPORTED for those.
+  _openevse.getRelayHealth([this](int ret, uint8_t life_remaining_pct, uint32_t cold_open_count,
+                                   uint32_t elec_damage_x1e6, uint32_t transit_baseline_ms,
+                                   bool transit_drift_warning, uint32_t thermal_index_x100,
+                                   uint32_t thermal_baseline_x100, uint8_t thermal_warning_level)
+  {
+    if(RAPI_RESPONSE_OK == ret)
+    {
+      _relay_health_known = true;
+      _relay_life_remaining_pct = life_remaining_pct;
+      _relay_cold_open_count = cold_open_count;
+      _relay_elec_damage_x1e6 = elec_damage_x1e6;
+      _relay_transit_baseline_ms = transit_baseline_ms;
+      _relay_transit_drift_warning = transit_drift_warning;
+      _relay_thermal_index_x100 = thermal_index_x100;
+      _relay_thermal_baseline_x100 = thermal_baseline_x100;
+      _relay_thermal_warning_level = thermal_warning_level;
+      DBUGF("relay health: life=%u%% cold_opens=%u elec_damage=%u transit_drift=%d thermal_warn=%u",
+            _relay_life_remaining_pct, _relay_cold_open_count, _relay_elec_damage_x1e6,
+            _relay_transit_drift_warning, _relay_thermal_warning_level);
     }
   });
 }

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -199,7 +199,8 @@ EvseMonitor::EvseMonitor(OpenEVSEClass &openevse) :
   _relay_thermal_index_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
   _relay_thermal_baseline_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
   _relay_thermal_warning_level(0),
-  _relay_stuck_recovery_count(0)
+  _relay_stuck_recovery_count(0),
+  _relay_recovery_in_flight(false)
 {
 }
 
@@ -233,6 +234,15 @@ void EvseMonitor::evseBoot(const char *firmware)
   DBUGF("EVSE boot v%s", firmware);
 
   snprintf(_firmware_version, sizeof(_firmware_version), "%s", firmware);
+
+  // Invalidate controller-reported state that has no "known" gate of its own
+  // and would otherwise keep serving the previous controller's values
+  // indefinitely if this one doesn't support/answer the query - e.g. a
+  // controller swapped in without an ESP32 reboot, or a non-D9 controller.
+  // _relay_health_known itself only ever latches true (readRelayHealth()'s
+  // callback simply no-ops when unsupported), so it needs the same reset.
+  _relay_health_known = false;
+  _zero_cross_threshold_ma = OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE;
 
   _openevse.getFaultCounters([this](int ret, long gfci_count, long nognd_count, long stuck_count)
   {
@@ -374,6 +384,17 @@ unsigned long EvseMonitor::loop(MicroTasks::WakeReason reason)
        "UNKNOWN");
   DBUG(", _count = ");
   DBUGLN(_count);
+
+  if(_relay_recovery_in_flight) {
+    // A stuck-relay recovery ($FK) is in flight and can hold the RAPI queue
+    // for up to ~30s on the controller side - every periodic poll below
+    // would just enqueue behind it and, once the queue (RAPI_MAX_COMMANDS
+    // deep) fills, get RAPI_RESPONSE_QUEUE_FULL, heartbeatPulse() included.
+    // Sit this cycle out rather than starve the queue and risk tripping the
+    // controller's heartbeat-supervision fallback current.
+    _count++;
+    return EVSE_MONITOR_POLL_TIME;
+  }
 
   // unlock openevse fw compiled with BOOTLOCK
   if (isBootLocked()) {
@@ -1127,8 +1148,11 @@ void EvseMonitor::readFrequency()
   // $GZ returns both AC line frequency and the relay-open current-zero
   // threshold in one response; OpenEVSEClass::getFrequency() only exposes
   // the first field, so read raw here rather than round-tripping $GZ twice
-  // (once via the library, once for the threshold).
-  if(!_sender) {
+  // (once via the library, once for the threshold). getFrequency() itself
+  // short-circuits on !isD9Supported() without touching the bus - replicate
+  // that gate here too, or a pre-D9 controller gets a $GZ (NAK'd every time)
+  // at boot and every settings-poll cycle.
+  if(!_sender || !_openevse.isD9Supported()) {
     return;
   }
   _sender->sendCmd("$GZ", [this](int ret) {
@@ -1204,10 +1228,31 @@ void EvseMonitor::runStuckRelayRecovery(std::function<void(int ret)> callback)
   // $FK doesn't report whether the relay actually came free, only that the
   // controller ran (or refused) the cycle - re-read $GL/$GR afterward so
   // the cached recovery count and relay status reflect what just happened.
+  //
+  // _relay_recovery_in_flight pauses loop()'s own periodic RAPI traffic for
+  // the duration - see the guard there. Set unconditionally: an EV-connected
+  // refusal NAKs almost immediately (the controller checks before doing
+  // anything), so the pause is negligible on that path and only matters when
+  // the recovery genuinely runs (up to ~30s).
+  _relay_recovery_in_flight = true;
   _openevse.runStuckRelayRecovery([this, callback](int ret) {
+    _relay_recovery_in_flight = false;
     if(RAPI_RESPONSE_OK == ret) {
       readRelayHealth();
       readRelayStatus();
+    }
+    if(callback) callback(ret);
+  });
+}
+
+void EvseMonitor::resetRelayHealth(std::function<void(int ret)> callback)
+{
+  // $FH has no response payload beyond OK/NAK - re-read $GL afterward
+  // rather than guessing what a freshly-reset accumulator/baseline set
+  // looks like locally.
+  _openevse.resetRelayHealth([this, callback](int ret) {
+    if(RAPI_RESPONSE_OK == ret) {
+      readRelayHealth();
     }
     if(callback) callback(ret);
   });

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -198,7 +198,8 @@ EvseMonitor::EvseMonitor(OpenEVSEClass &openevse) :
   _relay_transit_drift_warning(false),
   _relay_thermal_index_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
   _relay_thermal_baseline_x100(OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE),
-  _relay_thermal_warning_level(0)
+  _relay_thermal_warning_level(0),
+  _relay_stuck_recovery_count(0)
 {
 }
 
@@ -1176,7 +1177,8 @@ void EvseMonitor::readRelayHealth()
   _openevse.getRelayHealth([this](int ret, uint8_t life_remaining_pct, uint32_t cold_open_count,
                                    uint32_t elec_damage_x1e6, uint32_t transit_baseline_ms,
                                    bool transit_drift_warning, uint32_t thermal_index_x100,
-                                   uint32_t thermal_baseline_x100, uint8_t thermal_warning_level)
+                                   uint32_t thermal_baseline_x100, uint8_t thermal_warning_level,
+                                   uint32_t stuck_relay_recovery_count)
   {
     if(RAPI_RESPONSE_OK == ret)
     {
@@ -1189,9 +1191,24 @@ void EvseMonitor::readRelayHealth()
       _relay_thermal_index_x100 = thermal_index_x100;
       _relay_thermal_baseline_x100 = thermal_baseline_x100;
       _relay_thermal_warning_level = thermal_warning_level;
-      DBUGF("relay health: life=%u%% cold_opens=%u elec_damage=%u transit_drift=%d thermal_warn=%u",
+      _relay_stuck_recovery_count = stuck_relay_recovery_count;
+      DBUGF("relay health: life=%u%% cold_opens=%u elec_damage=%u transit_drift=%d thermal_warn=%u stuck_recoveries=%u",
             _relay_life_remaining_pct, _relay_cold_open_count, _relay_elec_damage_x1e6,
-            _relay_transit_drift_warning, _relay_thermal_warning_level);
+            _relay_transit_drift_warning, _relay_thermal_warning_level, _relay_stuck_recovery_count);
     }
+  });
+}
+
+void EvseMonitor::runStuckRelayRecovery(std::function<void(int ret)> callback)
+{
+  // $FK doesn't report whether the relay actually came free, only that the
+  // controller ran (or refused) the cycle - re-read $GL/$GR afterward so
+  // the cached recovery count and relay status reflect what just happened.
+  _openevse.runStuckRelayRecovery([this, callback](int ret) {
+    if(RAPI_RESPONSE_OK == ret) {
+      readRelayHealth();
+      readRelayStatus();
+    }
+    if(callback) callback(ret);
   });
 }

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -200,11 +200,29 @@ class EvseMonitor : public MicroTasks::Task
 
     // Extended state (linco-work firmware)
     uint32_t _frequency;          // AC line frequency × 100 (from $GZ); 0 = unknown/unsupported
+    // Relay-open current-zero threshold (mA), from $GZ's 2nd field: current
+    // below which the controller considers it safe to open the relay at a
+    // current zero. Runtime-configurable on the controller via $SZ.
+    // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = unknown/unsupported controller.
+    uint32_t _zero_cross_threshold_ma;
     bool _relay_dc1;              // DC relay 1 enabled (only valid when _relay_status_known)
     bool _relay_dc2;              // DC relay 2 enabled (only valid when _relay_status_known)
     bool _relay_ac;               // AC relay enabled (only valid when _relay_status_known)
     bool _relay_status_known;     // true once $GR has been answered by the controller
     char _chip_id[48];            // EVSE chip ID from $GI
+
+    // Relay contact-life health estimate (linco-work RELAY_HEALTH feature,
+    // from $GL). Only meaningful once _relay_health_known is true - the
+    // controller may predate the feature or have it compiled out.
+    bool _relay_health_known;
+    uint8_t  _relay_life_remaining_pct;
+    uint32_t _relay_cold_open_count;
+    uint32_t _relay_elec_damage_x1e6;
+    uint32_t _relay_transit_baseline_ms;   // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = baseline not established
+    bool     _relay_transit_drift_warning;
+    uint32_t _relay_thermal_index_x100;    // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = not available
+    uint32_t _relay_thermal_baseline_x100; // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = not available
+    uint8_t  _relay_thermal_warning_level; // 0=ok/not available 1=watch 2=warn
 
     DataReady _data_ready;
     DataReady _boot_ready;
@@ -236,6 +254,7 @@ class EvseMonitor : public MicroTasks::Task
     void readFrequency();
     void readRelayStatus();
     void readChipId();
+    void readRelayHealth();
 
   protected:
     void setup();
@@ -444,7 +463,21 @@ class EvseMonitor : public MicroTasks::Task
     bool isACRelayEnabled()  { return _relay_ac; }
     bool isRelayStatusKnown() { return _relay_status_known; }
     uint32_t getFrequency()  { return _frequency; }  // × 100 Hz (5000 = 50.00 Hz); 0 = unknown
+    // Relay-open current-zero threshold, mA. OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE if unknown/unsupported
+    uint32_t getZeroCrossThresholdMa() { return _zero_cross_threshold_ma; }
     const char *getChipId()  { return _chip_id; }
+
+    // Relay contact-life health estimate (requires the controller's
+    // RELAY_HEALTH feature; check isRelayHealthKnown() first)
+    bool isRelayHealthKnown() { return _relay_health_known; }
+    uint8_t getRelayLifeRemainingPct() { return _relay_life_remaining_pct; }
+    uint32_t getRelayColdOpenCount() { return _relay_cold_open_count; }
+    uint32_t getRelayElecDamageX1e6() { return _relay_elec_damage_x1e6; }
+    uint32_t getRelayTransitBaselineMs() { return _relay_transit_baseline_ms; }
+    bool isRelayTransitDriftWarning() { return _relay_transit_drift_warning; }
+    uint32_t getRelayThermalIndexX100() { return _relay_thermal_index_x100; }
+    uint32_t getRelayThermalBaselineX100() { return _relay_thermal_baseline_x100; }
+    uint8_t getRelayThermalWarningLevel() { return _relay_thermal_warning_level; }
     // True if the controller's RAPI protocol supports the D9 command set
     bool isD9Supported() { return _openevse.isD9Supported(); }
     uint32_t getHeartbeatInterval() { return _heartbeat_interval; }

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -223,6 +223,7 @@ class EvseMonitor : public MicroTasks::Task
     uint32_t _relay_thermal_index_x100;    // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = not available
     uint32_t _relay_thermal_baseline_x100; // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = not available
     uint8_t  _relay_thermal_warning_level; // 0=ok/not available 1=watch 2=warn
+    uint32_t _relay_stuck_recovery_count;  // cumulative stuck-relay recovery attempts run; 0 against pre-9.3.0 controllers
 
     DataReady _data_ready;
     DataReady _boot_ready;
@@ -478,6 +479,11 @@ class EvseMonitor : public MicroTasks::Task
     uint32_t getRelayThermalIndexX100() { return _relay_thermal_index_x100; }
     uint32_t getRelayThermalBaselineX100() { return _relay_thermal_baseline_x100; }
     uint8_t getRelayThermalWarningLevel() { return _relay_thermal_warning_level; }
+    uint32_t getRelayStuckRecoveryCount() { return _relay_stuck_recovery_count; }
+    // Manually run the controller's stuck-relay recovery cycle (requires
+    // firmware 9.3.0+ / ADVPWR). NAK'd by the controller if an EV is
+    // connected. Blocking on the controller side for up to ~30s.
+    void runStuckRelayRecovery(std::function<void(int ret)> callback = NULL);
     // True if the controller's RAPI protocol supports the D9 command set
     bool isD9Supported() { return _openevse.isD9Supported(); }
     uint32_t getHeartbeatInterval() { return _heartbeat_interval; }

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -224,6 +224,10 @@ class EvseMonitor : public MicroTasks::Task
     uint32_t _relay_thermal_baseline_x100; // OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE = not available
     uint8_t  _relay_thermal_warning_level; // 0=ok/not available 1=watch 2=warn
     uint32_t _relay_stuck_recovery_count;  // cumulative stuck-relay recovery attempts run; 0 against pre-9.3.0 controllers
+    // True while a $FK command is outstanding (up to ~30s) - pauses loop()'s
+    // own periodic RAPI traffic so it doesn't overflow the RAPI queue and
+    // drop heartbeat pulses for that long. See runStuckRelayRecovery().
+    bool _relay_recovery_in_flight;
 
     DataReady _data_ready;
     DataReady _boot_ready;
@@ -484,6 +488,11 @@ class EvseMonitor : public MicroTasks::Task
     // firmware 9.3.0+ / ADVPWR). NAK'd by the controller if an EV is
     // connected. Blocking on the controller side for up to ~30s.
     void runStuckRelayRecovery(std::function<void(int ret)> callback = NULL);
+    // Reset the relay-health accumulator, self-learned baselines, and the
+    // stuck-relay recovery counter (requires the controller's RELAY_HEALTH
+    // feature) - use after a physical relay replacement, since the estimate
+    // is otherwise meaningless: it carries over wear from the old relay.
+    void resetRelayHealth(std::function<void(int ret)> callback = NULL);
     // True if the controller's RAPI protocol supports the D9 command set
     bool isD9Supported() { return _openevse.isD9Supported(); }
     uint32_t getHeartbeatInterval() { return _heartbeat_interval; }

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1570,6 +1570,55 @@ void handleAddRFID(MongooseHttpServerRequest *request) {
   rfid.waitForTag();
 }
 
+// -------------------------------------------------------------------
+// Reset the relay contact-life health estimate ($FH via EvseManager,
+// requires the controller's RELAY_HEALTH feature) - use after a physical
+// relay replacement, so the accumulator doesn't carry over wear from the
+// old relay.
+// url: /relay/reset
+// -------------------------------------------------------------------
+void handleRelayHealthReset(MongooseHttpServerRequest *request) {
+  MongooseHttpServerResponseStream *response;
+  if(false == requestPreProcess(request, response, CONTENT_TYPE_JSON)) {
+    return;
+  }
+  if(!actuatorMethodAllowed(request, response)) {
+    return;
+  }
+
+  evse.resetRelayHealth([request, response](int ret) {
+    response->setCode(RAPI_RESPONSE_OK == ret ? 200 : 500);
+    response->print(RAPI_RESPONSE_OK == ret ? "{\"msg\":\"done\"}" : "{\"msg\":\"error\"}");
+    request->send(response);
+  });
+}
+
+// -------------------------------------------------------------------
+// Manually run the stuck-relay recovery cycle ($FK via EvseManager,
+// requires firmware 9.3.0+ / ADVPWR). NAK'd by the controller if an EV is
+// connected. Blocking on the controller side for up to ~30s - the HTTP
+// response is deferred until the async RAPI callback fires (EvseMonitor
+// pauses its own periodic polling for the duration, see
+// _relay_recovery_in_flight) rather than blocking this request thread, so
+// the rest of the server stays responsive while the cycle runs.
+// url: /relay/recovery
+// -------------------------------------------------------------------
+void handleRelayRecovery(MongooseHttpServerRequest *request) {
+  MongooseHttpServerResponseStream *response;
+  if(false == requestPreProcess(request, response, CONTENT_TYPE_JSON)) {
+    return;
+  }
+  if(!actuatorMethodAllowed(request, response)) {
+    return;
+  }
+
+  evse.runStuckRelayRecovery([request, response](int ret) {
+    response->setCode(RAPI_RESPONSE_OK == ret ? 200 : 500);
+    response->print(RAPI_RESPONSE_OK == ret ? "{\"msg\":\"done\"}" : "{\"msg\":\"error\"}");
+    request->send(response);
+  });
+}
+
 String delayTimer = "0 0 0 0";
 
 void
@@ -1906,6 +1955,8 @@ void web_server_setup()
   server.on("/shaper$", handleCurrentShaper);
   server.on("/emoncms/describe$", handleDescribe);
   server.on("/rfid/add$", handleAddRFID);
+  server.on("/relay/reset$", handleRelayHealthReset);
+  server.on("/relay/recovery$", handleRelayRecovery);
 
   server.on("/schedule/plan$", handleSchedulePlan);
   server.on("/schedule", handleSchedule);

--- a/src/web_server_config.cpp
+++ b/src/web_server_config.cpp
@@ -28,6 +28,14 @@ handleConfigGet(MongooseHttpServerRequest *request, MongooseHttpServerResponseSt
   // from 53,236 down to 32,756 and it did not recover, while total free heap
   // stayed above 70KB. Safe as a static because handlers run to completion on
   // the single task that polls Mongoose.
+  //
+  // Capacity headroom: JSON_OBJECT_SIZE(128) is a sizing hint, not a hard
+  // member cap -- ArduinoJson only cares about total bytes, and a live TFT
+  // unit already serves ~135 members (~446 bytes of string pool) within this
+  // budget. The relay_health block added here (relay_life_pct and ~10
+  // siblings) still fits, but there isn't much room left for the next
+  // addition -- worth rechecking on hardware (or just bumping the constant)
+  // before adding more.
   static DynamicJsonDocument doc(JSON_OBJECT_SIZE(128) + 1024);
   doc.clear();
 


### PR DESCRIPTION
# Relay contact-life health estimation

Estimates how much life is left in the main charging contactor and surfaces
it through the stack: controller firmware → RAPI → client library → this
gateway firmware. Diagnostic only — never gates or alters charging logic at
any layer.

Spans three repos:

| Repo | Branch/tag | What it adds |
|---|---|---|
| `open_evse` (ATmega/SAMD controller) | `dev` @ `D9.3.0`) | The estimation model itself: `RelayHealth` module, new RAPI commands |
| `OpenEVSE_Lib` (client library) | `OpenEVSE9` `v0.0.22` | `getRelayHealth()` / `resetRelayHealth()` wrappers for the new commands |
| `openevse_esp32_firmware` (this repo) | `relay_health` @ `6856978` | Polls the new data, caches it, exposes it via `/config` JSON |

## Background / the problem

Relay life splits into two budgets that are easy to conflate: **mechanical**
life (cycles with no current flowing — springs/bearings, normally
10⁷–10⁸ cycles) and **electrical** life (cycles under load — contact erosion
from arcing, 10⁴–10⁵ cycles at rated current). For an EVSE contactor the
electrical budget is the one that matters, and the single biggest lever is
whether the contact opens hot (current still flowing) or cold (the car has
already ramped down). A handful of hot disconnects — fault interrupts,
e-stops, GFCI trips — can consume more life than years of normal cold
cycling.

The firmware already measured charging current, starting and peak
temperatures, current on relay open and whether a stop was clean or
fault, but nothing accumulated that into a life estimate, and nothing 
gave early warning of the one failure mode a cycle count can't predict: 
a welded contact.

## Model (`open_evse` firmware)

Cumulative-damage (Miner's rule): each relay open consumes a fraction of a
life budget, summed over the relay's life.

- **Cold open** (current already at/below a zero threshold): `d = 1/N_m`
- **Hot open** (current still flowing): `d = (1/N_e) · (I/I_r)² · α_load · α_temp`

Where `N_e`/`N_m` are the rated electrical/mechanical life (cycles, from the
relay's datasheet), `I_r` is rated current, and `α_load`/`α_temp` are
load-character and temperature penalty multipliers. In a well-behaved
installation the cold-cycle term rounds to ~0 (mechanical life is normally
untouchable at any realistic cycle count) and the reported percentage is
really tracking hot-switch events — exactly what you want surfaced.

Two more independent signals feed into the picture, both self-baselined per
station since enclosure thermals and hardware vary:

- **Coil drop-out (open) transit-time drift** — a lengthening time between
  the open command and the contact physically opening (measured via the
  load-side AC-sense pin, CGMI hardware only) is an early symptom of
  welding, ahead of the hard `EVSE_STATE_STUCK_RELAY` fault that ultimately
  catches it.
- **Thermal index `H = ΔT / I²`** (requires `TEMPERATURE_MONITORING`) —
  proportional to contact resistance. Heating at the contact is `I²·R`;
  normalizing by `I²` removes the load dependence, so `H` stays flat while
  the contact is healthy and climbs as it erodes/oxidizes.

Not implemented: direct contact-resistance measurement via closed-contact
voltage drop — this hardware has no differential voltage sensor across the
contacts to measure it.

### New source: `firmware/open_evse/RelayHealth.{h,cpp}`

Gated by `RELAY_HEALTH`, auto-enabled wherever `RELAY_ZC_SWITCH` + `AMMETER`
are (every current build target). New EEPROM state at offsets 44–55.

### New RAPI commands

| Command | Direction | Purpose |
|---|---|---|
| `$SZ ma` | set | Relay-open current-zero threshold (mA) — runtime-tunable per-unit ammeter noise floor |
| `$GZ` | get | Now returns **two** fields: `freqx100 zerothreshma` (was frequency-only) |
| `$GW` | get | Relay wear diagnostics: `hotswitchcnt lastopenma closetransitms opentransitms` |
| `$GL` | get | Relay life/health: `pctremain coldopencnt elecdamagex1e6 transitbaselinems transitdrift thermalx100 thermalbaselinex100 thermalwarn` |
| `$FH` | set | Reset the health accumulator/baselines (use after a physical relay replacement) |

Full field-by-field reference: `open_evse/firmware/open_evse/rapi_proc.h`.

## Client library (`OpenEVSE_Lib` 0.0.22)

Added `OpenEVSEClass::getRelayHealth(callback)` and `resetRelayHealth(callback)`
in `src/openevse.{h,cpp}`, mirroring the existing `getFrequency()` /
`getRelayStatus()` / `resetFaultCounters()` D9 extensions (same
`isD9Supported()` protocol gate, same token-parsing style). Added the
`OPENEVSE_RELAY_HEALTH_NOT_AVAILABLE` (`0xffff`) sentinel for fields that
aren't available yet (baseline not established) or at all (thermal fields
need `TEMPERATURE_MONITORING` on the controller).

`getFrequency()` itself was **not** changed to expose the new `$GZ`
zero-threshold field, to avoid a breaking signature change to an existing
public method — see below for how this gateway firmware gets that value
instead.

# Stuck-relay recovery support

Client-library support for the controller-side stuck-relay auto-recovery
feature (`open_evse` firmware 9.3.0, `dev` @ `5b3a755`). `OpenEVSE9` @
`2c7c3f3`, `library.json` 0.0.22.

Firmware 9.3.0 added an automatic recovery attempt for a welded/stuck main
contactor: when `EVSE_STATE_STUCK_RELAY` is entered with no EV connected,
the controller cycles the relay (3 rounds of 5 on/off toggles, each shorter
than the last) instead of going straight to an unrecoverable hard fault.
It also added `$FK` to run that same cycle manually, and extended `$GL`
(relay health) with a cumulative attempt counter. Full firmware-side
derivation: `open_evse/docs/stuck_relay_recovery.md`.


## `getRelayHealth()` - new field

The callback signature gained a 10th parameter,
`uint32_t stuck_relay_recovery_count`:

```cpp
OpenEVSE.getRelayHealth([](int ret, uint8_t life_remaining_pct,
                            uint32_t cold_open_count, uint32_t elec_damage_x1e6,
                            uint32_t transit_baseline_ms, bool transit_drift_warning,
                            uint32_t thermal_index_x100, uint32_t thermal_baseline_x100,
                            uint8_t thermal_warning_level,
                            uint32_t stuck_relay_recovery_count)
{
  if (ret == RAPI_RESPONSE_OK) {
    Serial.printf("Recovery attempts: %u\n", stuck_relay_recovery_count);
  }
});
```

Backward compatible on the wire: against a pre-9.3.0 controller, `$GL`
still only returns 8 fields, and `stuck_relay_recovery_count` reads back
`0` rather than the call failing.

## `runStuckRelayRecovery()` - new method

```cpp
void OpenEVSEClass::runStuckRelayRecovery(std::function<void(int ret)> callback);
```

Sends `$FK` to run the recovery cycle on demand - the same routine the
controller runs automatically. The controller NAKs it if an EV is
connected (unsafe to cycle the relay under load).

Uses an explicit **35 second** `RapiSender` timeout, not the library
default (`RAPI_TIMEOUT_MS`, 500ms). The controller call itself is blocking
and can legitimately take up to ~30s (3 rounds x 5 toggles x up to 2s
on+off, plus zero-cross/transit overhead) before it responds - the default
timeout would give up long before that.

Doesn't itself report whether the relay came free; check `getStatus()`
(state) or `getRelayHealth()` (the recovery counter, or re-poll relay
status) afterward.

## `resetRelayHealth()` - behavior change, no API change

`$FH` now also clears the recovery counter server-side, alongside the
existing damage-accumulator and baseline resets. No client-side change
needed - just documented.

## Requirements

Same D9-protocol gate (`isD9Supported()`) as the other linco-work
extensions, and firmware 9.3.0+ / `ADVPWR` for `runStuckRelayRecovery()` and
the recovery counter specifically (older/non-ADVPWR controllers NAK `$FK`
with `RAPI_RESPONSE_FEATURE_NOT_SUPPORTED` and report the counter as 0).

## Gateway firmware (this repo, `relay_health` branch)

`src/evse_monitor.{h,cpp}` — `EvseMonitor` gained:

- **`readRelayHealth()`** — calls `OpenEVSE.getRelayHealth()`, caches all
  eight fields, exposed via `isRelayHealthKnown()` +
  `getRelay*()`/`isRelay*()` getters.
- **`readFrequency()` rewritten** — reads `$GZ` raw via `EvseMonitor`'s own
  `RapiSender*` instead of the library's single-field `getFrequency()`, so it
  now also captures the zero-cross threshold from the same response instead
  of round-tripping `$GZ` twice.

### Polling cadence

| When | Why |
|---|---|
| At boot (`evseBoot()`) | Populate immediately on connect |
| After every charge session (`updateEvseState()`, the existing relay-open `!isCharging()` branch) | `$GL` is only meaningful once an open has occurred — that's when the controller's accumulator actually updates |
| Every ~60s (`getSettingsFromEvse()`, existing settings-poll cadence) | Catches changes from other RAPI clients and long-running sessions with no session boundary, without adding RAPI traffic |

### Exposure

`src/app_config.cpp`'s `config_serialize()` (the `/config` JSON), alongside
the existing `zero_cross`/`relay_dc1` fields:

```json
{
  "zero_cross": true,
  "zero_cross_threshold_ma": 300,
  "relay_dc1": true,
  "relay_life_pct": 100,
  "relay_cold_open_count": 42,
  "relay_elec_damage_x1e6": 0,
  "relay_transit_drift_warning": false,
  "relay_transit_baseline_ms": 18,
  "relay_thermal_warning_level": 0,
  "relay_thermal_index_x100": 12,
  "relay_thermal_baseline_x100": 11
}
```

Each field/block is **omitted** (not defaulted to 0/false) until the
controller has actually answered — same pattern already used for
`relay_dc1`/`relay_dc2`/`relay_ac`, so the GUI can distinguish "not
supported by this controller" from a real zero.

## Verification status

Firmware side (`open_evse`) built clean on `m328p_core`, `m328p_LCD_WIFI`,
`samd`, `samd_ice` via PlatformIO. Gateway side (`openevse_esp32_firmware`)
was **not** compiler-verified: the shared PlatformIO core dir's
`espressif32` platform install and the `native_simulator` env (no `g++` on
PATH) were both broken/unavailable in the session this was built in. Changes
were reviewed by hand against the exact wire format above and the existing
`readFrequency()`/`readRelayStatus()` call patterns, but a real build should
be run before merging.
