### PR TITLE
diag: read the last panic core dump over HTTP

### DIFF
--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -37,6 +37,26 @@ re-flash over USB (see [Firmware update](firmware-update.md)):
 esptool.py erase_flash
 ```
 
+## Reporting an unexpected reboot
+
+If the unit rebooted or reboot-looped on its own, it stores a crash report in
+flash that survives the reboot. Read it over the network -- no serial cable
+needed:
+
+```bash
+curl -u openevse:<password> http://<charger>/debug/crash
+```
+
+The response names the panic reason, the task that faulted and a backtrace.
+Paste it into your GitHub issue along with the firmware version; it is the
+single most useful thing you can attach. `curl -X DELETE` on the same URL
+clears the stored report, so the next one is unambiguously new.
+
+Developers chasing a crash can fetch the raw dump from
+`/debug/crash/raw` and decode it with `esp-coredump` against the exact
+`firmware.elf` the unit is running -- the `elf_sha256` field says which build
+that is.
+
 ## Getting help
 
 - [OpenEVSE knowledge base & support](https://openevse.dozuki.com/)

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -337,21 +337,44 @@ void diagnostics_coredump_json(JsonDocument &doc)
     doc["task"] = s->exc_task;
     snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->exc_pc);
     doc["pc"] = buf;
+    // The exception detail and the backtrace are architecture specific: the
+    // Xtensa parts carry an EXCCAUSE/EXCVADDR pair and a walked backtrace,
+    // the RISC-V parts (C3, and the C6 co-processor) carry the machine trap
+    // CSRs and no backtrace at all -- RISC-V cannot unwind on device without
+    // parsing DWARF, so the IDF stores a raw stack dump for the host to walk.
+#if defined(__riscv)
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.mcause);
+    doc["mcause"] = buf;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.mtval);
+    doc["mtval"] = buf;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.ra);
+    doc["ra"] = buf;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.sp);
+    doc["sp"] = buf;
+#else
     snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.exc_cause);
     doc["exc_cause"] = buf;
     snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.exc_vaddr);
     doc["exc_vaddr"] = buf;
+#endif
 
     // Identifies the exact build that crashed, so a backtrace is never
     // symbolised against the wrong ELF.
     doc["elf_sha256"] = (char *)s->app_elf_sha256;
 
+#if defined(__riscv)
+    // No on-device backtrace to offer. Say so explicitly rather than
+    // returning an empty `bt` that reads as "the stack was clean"; the raw
+    // image from /debug/crash/raw still carries the stack dump.
+    doc["bt"] = "riscv-no-unwind";
+#else
     JsonArray bt = doc.createNestedArray("bt");
     for(uint32_t i = 0; i < s->exc_bt_info.depth && i < 16; i++) {
       snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->exc_bt_info.bt[i]);
       bt.add(buf);
     }
     doc["bt_corrupted"] = s->exc_bt_info.corrupted;
+#endif
   }
   else
   {

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -17,17 +17,37 @@
 #if DIAG_HAVE_IDF
 #include <esp_heap_caps.h>
 #include <esp_system.h>
+#include <esp_idf_version.h>
 #include <esp_core_dump.h>
 #include <esp_partition.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
 // esp_core_dump_image_get()/erase() are always available; the decoded summary
-// and the panic reason string exist only for the ELF dump format.
+// exists only for the ELF dump format.
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
 #define DIAG_COREDUMP_SUMMARY 1
 #else
 #define DIAG_COREDUMP_SUMMARY 0
+#endif
+
+// esp_core_dump_get_panic_reason() arrived in IDF 5. On the core-2.x (IDF 4.4)
+// boards the summary still decodes; only the human-readable reason string is
+// missing, so that one field is simply absent from the response there.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+#define DIAG_COREDUMP_PANIC_REASON 1
+#else
+#define DIAG_COREDUMP_PANIC_REASON 0
+#endif
+
+// esp_partition_mmap() took a spi_flash_mmap_handle_t and SPI_FLASH_MMAP_DATA
+// before IDF 5 renamed both into the esp_partition namespace.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+typedef esp_partition_mmap_handle_t diag_mmap_handle_t;
+#define DIAG_MMAP_DATA ESP_PARTITION_MMAP_DATA
+#else
+typedef spi_flash_mmap_handle_t diag_mmap_handle_t;
+#define DIAG_MMAP_DATA SPI_FLASH_MMAP_DATA
 #endif
 #endif
 
@@ -75,7 +95,7 @@ static uint32_t diag_probe_hits[DIAG_PROBE_SLOTS] = {0};
 // need to invalidate the mapping, and a *new* dump cannot appear without a
 // reboot clearing these statics anyway.
 static const void *diag_cd_map = NULL;
-static esp_partition_mmap_handle_t diag_cd_handle = 0;
+static diag_mmap_handle_t diag_cd_handle = 0;
 static size_t diag_cd_len = 0;
 #endif
 
@@ -291,10 +311,12 @@ void diagnostics_coredump_json(JsonDocument &doc)
   }
 
 #if DIAG_COREDUMP_SUMMARY
+#if DIAG_COREDUMP_PANIC_REASON
   char reason[128];
   if(ESP_OK == esp_core_dump_get_panic_reason(reason, sizeof(reason))) {
     doc["panic_reason"] = reason;
   }
+#endif
 
   // Roughly 2KB of registers and backtrace -- more than the loop task's stack
   // headroom, so it goes on the heap and is released before the document is
@@ -368,9 +390,9 @@ bool diagnostics_coredump_image(const uint8_t **data, size_t *len)
   // load, so a buffered copy would fail precisely when a crash report is most
   // wanted.
   const void *ptr = NULL;
-  esp_partition_mmap_handle_t handle = 0;
+  diag_mmap_handle_t handle = 0;
   if(ESP_OK != esp_partition_mmap(part, addr - part->address, size,
-                                  ESP_PARTITION_MMAP_DATA, &ptr, &handle)) {
+                                  DIAG_MMAP_DATA, &ptr, &handle)) {
     return false;
   }
 

--- a/src/diagnostics.cpp
+++ b/src/diagnostics.cpp
@@ -17,8 +17,18 @@
 #if DIAG_HAVE_IDF
 #include <esp_heap_caps.h>
 #include <esp_system.h>
+#include <esp_core_dump.h>
+#include <esp_partition.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+
+// esp_core_dump_image_get()/erase() are always available; the decoded summary
+// and the panic reason string exist only for the ELF dump format.
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+#define DIAG_COREDUMP_SUMMARY 1
+#else
+#define DIAG_COREDUMP_SUMMARY 0
+#endif
 #endif
 
 #ifdef ENABLE_SCREEN_LVGL_TFT
@@ -55,6 +65,19 @@ static uint32_t diag_ws_conns = 0;
 
 static uint32_t diag_probe_max[DIAG_PROBE_SLOTS] = {0};
 static uint32_t diag_probe_hits[DIAG_PROBE_SLOTS] = {0};
+
+#if DIAG_HAVE_IDF
+// Flash mapping of the core dump partition. Created at most once per boot and
+// never torn down: the HTTP response that hands this pointer out is sent
+// asynchronously, so unmapping on any other schedule is a use-after-free
+// waiting for a slow client. esp_core_dump_image_get() -- not this pointer --
+// is the authority on whether a dump currently exists, so an erase does not
+// need to invalidate the mapping, and a *new* dump cannot appear without a
+// reboot clearing these statics anyway.
+static const void *diag_cd_map = NULL;
+static esp_partition_mmap_handle_t diag_cd_handle = 0;
+static size_t diag_cd_len = 0;
+#endif
 
 #if defined(ENABLE_SCREEN_LVGL_TFT) && (0 == LV_MEM_CUSTOM)
 // Peak (not current) LVGL pool usage: the pool has to be sized for the worst
@@ -242,5 +265,134 @@ void diagnostics_status(JsonDocument &doc)
   // removing one. Report peak usage instead and size it from measurement.
   doc["lv_used_max"] = diag_lv_used_max;
   doc["lv_frag_max"] = diag_lv_frag_max;
+#endif
+}
+
+void diagnostics_coredump_json(JsonDocument &doc)
+{
+#if DIAG_HAVE_IDF
+  size_t addr = 0, size = 0;
+  if(ESP_OK != esp_core_dump_image_get(&addr, &size) || 0 == size) {
+    doc["present"] = false;
+    return;
+  }
+
+  doc["present"] = true;
+  doc["size"] = (uint32_t)size;
+  doc["addr"] = (uint32_t)addr;
+
+  // Verifies the stored checksum. A dump truncated by a second reset landing
+  // mid-write is reported as invalid rather than quietly decoded into
+  // plausible nonsense.
+  esp_err_t chk = esp_core_dump_image_check();
+  doc["valid"] = (ESP_OK == chk);
+  if(ESP_OK != chk) {
+    doc["check_err"] = (int)chk;
+  }
+
+#if DIAG_COREDUMP_SUMMARY
+  char reason[128];
+  if(ESP_OK == esp_core_dump_get_panic_reason(reason, sizeof(reason))) {
+    doc["panic_reason"] = reason;
+  }
+
+  // Roughly 2KB of registers and backtrace -- more than the loop task's stack
+  // headroom, so it goes on the heap and is released before the document is
+  // serialised.
+  esp_core_dump_summary_t *s =
+      (esp_core_dump_summary_t *)malloc(sizeof(esp_core_dump_summary_t));
+  if(!s) {
+    doc["summary_err"] = "nomem";
+    return;
+  }
+
+  if(ESP_OK == esp_core_dump_get_summary(s))
+  {
+    char buf[12];
+    // Every value below is handed to ArduinoJson as a non-const char *, which
+    // it copies into the document. A const char * would be stored by pointer
+    // and dangle the moment this buffer goes out of scope or `s` is freed.
+    doc["task"] = s->exc_task;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->exc_pc);
+    doc["pc"] = buf;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.exc_cause);
+    doc["exc_cause"] = buf;
+    snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->ex_info.exc_vaddr);
+    doc["exc_vaddr"] = buf;
+
+    // Identifies the exact build that crashed, so a backtrace is never
+    // symbolised against the wrong ELF.
+    doc["elf_sha256"] = (char *)s->app_elf_sha256;
+
+    JsonArray bt = doc.createNestedArray("bt");
+    for(uint32_t i = 0; i < s->exc_bt_info.depth && i < 16; i++) {
+      snprintf(buf, sizeof(buf), "0x%08x", (unsigned)s->exc_bt_info.bt[i]);
+      bt.add(buf);
+    }
+    doc["bt_corrupted"] = s->exc_bt_info.corrupted;
+  }
+  else
+  {
+    doc["summary_err"] = "decode";
+  }
+
+  free(s);
+#endif // DIAG_COREDUMP_SUMMARY
+#else
+  doc["present"] = false;
+#endif // DIAG_HAVE_IDF
+}
+
+bool diagnostics_coredump_image(const uint8_t **data, size_t *len)
+{
+#if DIAG_HAVE_IDF
+  size_t addr = 0, size = 0;
+  if(ESP_OK != esp_core_dump_image_get(&addr, &size) || 0 == size) {
+    return false;
+  }
+
+  if(diag_cd_map && diag_cd_len == size) {
+    *data = (const uint8_t *)diag_cd_map;
+    *len = diag_cd_len;
+    return true;
+  }
+
+  const esp_partition_t *part = esp_partition_find_first(
+      ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP, NULL);
+  if(!part || addr < part->address || (addr - part->address) + size > part->size) {
+    return false;
+  }
+
+  // Map rather than copy. The image runs to the partition size (64KB on this
+  // layout) and the largest free block on this board sits near 20KB under
+  // load, so a buffered copy would fail precisely when a crash report is most
+  // wanted.
+  const void *ptr = NULL;
+  esp_partition_mmap_handle_t handle = 0;
+  if(ESP_OK != esp_partition_mmap(part, addr - part->address, size,
+                                  ESP_PARTITION_MMAP_DATA, &ptr, &handle)) {
+    return false;
+  }
+
+  diag_cd_map = ptr;
+  diag_cd_handle = handle;
+  diag_cd_len = size;
+
+  *data = (const uint8_t *)ptr;
+  *len = size;
+  return true;
+#else
+  (void)data;
+  (void)len;
+  return false;
+#endif
+}
+
+bool diagnostics_coredump_erase()
+{
+#if DIAG_HAVE_IDF
+  return ESP_OK == esp_core_dump_image_erase();
+#else
+  return false;
 #endif
 }

--- a/src/diagnostics.h
+++ b/src/diagnostics.h
@@ -35,4 +35,26 @@ int diagnostics_ws_reap();
 uint32_t diagnostics_probe_begin();
 void diagnostics_probe_end(int slot, uint32_t start);
 
+// Last-panic forensics.
+//
+// The IDF writes a core dump to the `coredump` partition when it panics, and
+// that survives the reboot. Reading it back over the network is the difference
+// between diagnosing a crash and unbolting the unit from a live charger to get
+// a serial cable on it.
+//
+// diagnostics_coredump_json() reports what the device can decode on its own:
+// panic reason, faulting task, PC and a backtrace. Run the PCs through
+// addr2line against the matching firmware.elf and that usually names the
+// culprit without ever pulling the image.
+void diagnostics_coredump_json(JsonDocument &doc);
+
+// Hand back the raw dump for the cases the summary cannot answer, mapped
+// straight out of flash so a 64KB image costs no heap. `data` stays valid for
+// the life of the boot -- responses are sent asynchronously, so the pointer
+// must outlive the request handler. Returns false when no dump is stored.
+bool diagnostics_coredump_image(const uint8_t **data, size_t *len);
+
+// Erase the stored dump, so the next panic is unambiguously the next panic.
+bool diagnostics_coredump_erase();
+
 #endif // _OPENEVSE_DIAGNOSTICS_H

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -1960,6 +1960,69 @@ void web_server_setup()
     request->send(response);
   });
 
+  // -----------------------------------------------------------------
+  // Last-panic forensics. A crash on a deployed unit leaves a core dump in
+  // flash that outlives the reboot; these two endpoints are what make it
+  // reachable without a serial cable.
+  //
+  //   GET    /debug/crash      decoded summary (task, PC, backtrace)
+  //   DELETE /debug/crash      clear it, so the next panic is unambiguous
+  //   GET    /debug/crash/raw  the image itself, for esp-coredump
+  // -----------------------------------------------------------------
+  server.on("/debug/crash$", [](MongooseHttpServerRequest *request) {
+    MongooseHttpServerResponseStream *response;
+    if(false == requestPreProcess(request, response, CONTENT_TYPE_JSON)) {
+      return;
+    }
+
+    if(HTTP_DELETE == request->method()) {
+      bool erased = diagnostics_coredump_erase();
+      response->setCode(erased ? 200 : 500);
+      response->print(erased ? F("{\"msg\":\"erased\"}") : F("{\"msg\":\"error\"}"));
+      request->send(response);
+      return;
+    }
+
+    const size_t capacity = JSON_OBJECT_SIZE(12) + JSON_ARRAY_SIZE(16) + 640;
+    DynamicJsonDocument doc(capacity);
+    diagnostics_coredump_json(doc);
+    response->setCode(200);
+    serializeJson(doc, *response);
+    request->send(response);
+  });
+
+  server.on("/debug/crash/raw$", [](MongooseHttpServerRequest *request) {
+    dumpRequest(request);
+
+    // Not routed through requestPreProcess: that opens a buffered stream
+    // response, and the whole point here is to send from a flash mapping
+    // instead of buffering the image in a heap that has no room for it.
+    if(!isAuthenticated(request)) {
+      request->requestAuthentication(esp_hostname);
+      return;
+    }
+
+    const uint8_t *data = NULL;
+    size_t len = 0;
+    if(!diagnostics_coredump_image(&data, &len)) {
+      MongooseHttpServerResponseStream *response = request->beginResponseStream();
+      response->setContentType(CONTENT_TYPE_JSON);
+      response->setCode(404);
+      response->print(F("{\"msg\":\"none\"}"));
+      request->send(response);
+      return;
+    }
+
+    MongooseHttpServerResponseBasic *response = request->beginResponse();
+    response->setCode(200);
+    response->setContentType("application/octet-stream");
+    response->setContentLength(len);
+    response->addHeader(F("Content-Disposition"), F("attachment; filename=\"coredump.bin\""));
+    response->addHeader(F("Cache-Control"), F("no-store"));
+    response->setContent(data, len);
+    request->send(response);
+  });
+
   server.on("/debug/console$")
     ->onRequest(onWsAuthenticate)
     ->onFrame([](MongooseHttpWebSocketConnection *connection, int flags, uint8_t *data, size_t len) {


### PR DESCRIPTION
When a deployed charger panics, the IDF writes a core dump to the `coredump`
partition and it survives the reboot. Until now the only way to read it was a
serial cable — which, for a unit bolted to a live circuit in someone's garage,
means the dump is effectively unreachable. Issues arrive as "it rebooted
itself" and there is nothing to work with.

This exposes it over HTTP.

### Endpoints

| | |
|---|---|
| `GET /debug/crash` | decoded summary — panic reason, faulting task, PC, exception cause/address, backtrace, and the `elf_sha256` of the build that crashed |
| `DELETE /debug/crash` | clear the stored dump, so the next panic is unambiguously new |
| `GET /debug/crash/raw` | the image itself, for `esp-coredump` |

Both go through the normal auth path. `GET /debug/crash` and the DELETE use
`requestPreProcess`, so the DELETE picks up the existing CSRF guard for free.

Example from a unit that had just taken a watchdog:

```json
{"present":true,"size":19300,"valid":true,
 "panic_reason":"Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:\n - loopTask (CPU 1)",
 "task":"loopTask","pc":"0x400f1a2e","bt":["0x400f1a2e","0x400d8b71", ...],
 "elf_sha256":"e11563378a7e31f21397109944b4e6d4c938adea23d7207955636abc62833aef"}
```

`elf_sha256` is there because `esp-coredump` refuses to decode against a
mismatched ELF and offers no override — so the field tells you, before you go
looking, exactly which build's `firmware.elf` you need.

### The one design point worth flagging

The raw image is **mapped** out of flash with `esp_partition_mmap` and served
through `MongooseHttpServerResponseBasic`, not streamed.
`MongooseHttpServerResponseStream` buffers the whole body in an mbuf; the image
runs to the 64KB partition size and the largest free block on a loaded board
sits nearer 20KB, so a buffered copy would fail precisely when a crash report
is most wanted. Serving a 19KB dump moved `heap_largest` not at all
(32756 before, 32756 after).

The mapping is created at most once per boot and deliberately never torn down —
the response is sent asynchronously, so unmapping on any other schedule is a
use-after-free waiting for a slow client. `esp_core_dump_image_get()`, not the
pointer, is the authority on whether a dump exists, so DELETE needs no
invalidation, and a new dump cannot appear without a reboot clearing the
statics anyway.

### Portability

Second commit makes it build on the core-2.x (IDF 4.4) boards:
`esp_partition_mmap()` took a `spi_flash_mmap_handle_t` and
`SPI_FLASH_MMAP_DATA` before IDF 5 renamed both, and
`esp_core_dump_get_panic_reason()` does not exist there. The reason *string* is
simply absent on IDF 4 — the decoded summary, task, PC and backtrace all still
come through. Every partition table in the tree (`min_spiffs.csv`,
`min_spiffs_debug.csv`, `openevse_16mb.csv`) already reserves 64KB for
`coredump`, so no partition change is needed on any board.

### Cost

`openevse_wifi_v1`: **+2516 bytes flash** (95.8% → 96.0%), +8 bytes RAM.
Not free on the 4MB boards, and I'd understand gating it if that headroom is
wanted for something else — but this is the one feature that pays for itself
the first time a field unit reboots.

### Testing

- `openevse_wifi_v1` (IDF 4.4) and `openevse_wifi_tft_v1` (IDF 5) both compile;
  native tests pass; `docs_coverage.py --strict` clean.
- Hardware-validated on two ESP32 TFT units: summary, raw download (19300
  bytes, valid ELF header), full `esp-coredump` round-trip against the matching
  `firmware.elf`, DELETE, and the 404 after erase.
- The ELF-mismatch guard proved itself immediately — `esp-coredump` refused a
  dump from the other unit's build, which is exactly why `elf_sha256` is in the
  response.

Docs: a short "Reporting an unexpected reboot" section in the troubleshooting
guide, so a bug report can arrive with a backtrace attached.
