### PR TITLE
fix(build): pin UART2 to GPIO16/17 on the TFT boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -125,6 +125,17 @@ build_flags_openevse_tft =
   -D ENABLE_WS2812FX
   -D ENABLE_MCP9808
   -D ENABLE_PN532
+  ; UART2 pins, pinned explicitly. Both TFT envs put something on Serial2 --
+  ; the release env its debug console, the _dev env the RAPI link to the
+  ; OpenEVSE -- and neither can rely on the core's default any more:
+  ; arduino-esp32 2.0.17 defaulted ESP32 UART2 to RX2=16/TX2=17, but 3.x
+  ; (HardwareSerial.h, "Default pins for UART2 are arbitrary") changed it to
+  ; RX2=4/TX2=25. Nothing is wired to 4/25 on this board, so begin() succeeds
+  ; on dead pins and the only symptom is silence -- for _dev that reads as
+  ; "OpenEVSE not responding or not connected". The ch_denky variant defines
+  ; no RX2/TX2 of its own, so this is the only thing holding the pins.
+  -D RX2=16
+  -D TX2=17
 build_partitions = min_spiffs.csv
 build_partitions_debug = min_spiffs_debug.csv
 build_partitions_16mb = openevse_16mb.csv


### PR DESCRIPTION
## Problem

`pio run -e openevse_wifi_tft_v1_dev -t upload -t monitor` comes up with no link to the OpenEVSE controller:

```
OpenEVSE not responding or not connected
EVSE manager woke: WakeReason_Scheduled connected: 0
```

Building the `v5.1.5` tag on the same hardware works, so this is a regression rather than a wiring problem.

## Root cause

The `_dev` env puts the RAPI link on `Serial2`:

```ini
[env:openevse_wifi_tft_v1_dev]
-D DEBUG_PORT=Serial      # debug on UART0 -> USB console
-D RAPI_PORT=Serial2      # OpenEVSE on UART2
```

…and never said which pins UART2 should use, so it inherited the Arduino core's default. That default changed:

| | Arduino core | ESP32 UART2 default |
|---|---|---|
| v5.1.5 | 2.0.17 (`espressif32@6.12.0`) | **RX2=16, TX2=17** |
| master | 3.3.11 (pioarduino core-3) | **RX2=4, TX2=25** |

Core 3.x labels the block *"Default pins for UART2 are arbitrary, and defined here for convenience"*, so Espressif considered them free to change.

`openevse_wifi_tft_v1` moved to `platform = ${common.platform_core3}` as part of the Arduino-as-an-IDF-component work and `_dev` extends it, so the RAPI link silently moved to GPIO4/25. The `ch_denky` variant defines no `RX2`/`TX2` of its own, so nothing was holding the pins.

GPIO4 and GPIO25 are unused on this board, so `Serial2.begin()` **succeeds on dead pins** — no error, no warning, and the only symptom is the silence reported as `OpenEVSE not responding or not connected`.

## Fix

Pin the pins explicitly in `common.build_flags_openevse_tft`. That fragment is used by exactly the two TFT envs, and covers both uses of `Serial2`:

- `openevse_wifi_tft_v1_dev` — the RAPI link (the reported bug)
- `openevse_wifi_tft_v1` — the debug console, which had moved to the same dead pins, so release-build debug output has been going nowhere since the core-3 move

## Verification

Preprocessed the core's `HardwareSerial.cpp` with the exact build flags, with and without the change:

```c
// before                                   // after
case UART_NUM_2:                            case UART_NUM_2:
  rxPin = ... (int8_t)(gpio_num_t)4 ...       rxPin = ... (int8_t)16 ...
  txPin = ... (int8_t)(gpio_num_t)25 ...      txPin = ... (int8_t)17 ...
```

The hybrid build compiles the Arduino core from source, so the `-D` genuinely takes effect — it would have been inert on the prebuilt-libs path. `pio run -e openevse_wifi_tft_v1_dev` is green.

Confirmed on hardware: `openevse_wifi_tft_v1_dev` flashed to an OpenEVSE WiFi TFT v1 board talks to the OpenEVSE controller again.

## Related, not changed here

`openevse_wifi_v1_16mb` (also core-3) sets `DEBUG_PORT=Serial1` with only `-D TX1=16` and no `RX1`. Core 3.x moved `RX1` from GPIO9 to GPIO26, so that port now claims GPIO26 as its RX. GPIO26 looks free on that board and the port is TX-only in practice, so it should be harmless — but it is the same class of latent bug and may deserve an explicit `-D RX1=9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
