### PR TITLE
fix(build): drop redundant -D ESP32 that core-3 redefines

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -101,7 +101,13 @@ feature_flags =
   -D MG_MAX_HTTP_REQUEST_SIZE=8196
 
 build_flags =
-  -D ESP32
+  ; NB: no `-D ESP32` here -- the Arduino framework already defines it, and on
+  ; the two platforms it does so with different values: core-2.x defines it
+  ; bare (= 1) while core-3.x/pioarduino has arduino-esp32 export
+  ; `-DESP32=ESP32` from its CMakeLists as a PUBLIC compile option. Adding our
+  ; own bare `-D ESP32` on top of that made gcc warn `"ESP32" redefined` for
+  ; every core-3 translation unit. Nothing here tests ESP32 arithmetically
+  ; (only #ifdef / defined()), so the framework's definition is all we need.
   -D ARDUINO_ARCH_ESP32
   -D USE_ESP32
   -D USE_ESP32_FRAMEWORK_ARDUINO


### PR DESCRIPTION
## Problem

Every core-3 build logs a warning per translation unit:

```
Compiling .pio/build/openevse_wifi_tft_v1_dev/src/mqtt.cpp.o
<command-line>: warning: "ESP32" redefined
<command-line>: note: this is the location of the previous definition
```

`[common] build_flags` carried a plain `-D ESP32` (value `1`), but the Arduino framework already defines `ESP32` on every ESP32 target — and the two platforms do it with different values:

| platform | who defines it | value |
| --- | --- | --- |
| core-2.x (`espressif32@7.0.1`, arduino 2.0.17) | `tools/platformio-build-esp32.py` `CPPDEFINES` | bare `ESP32` (= 1) — same as ours, no warning |
| core-3.x (pioarduino, arduino 3.3.x) | `arduino-esp32/CMakeLists.txt`, PUBLIC compile option | `-DESP32=ESP32` — differs, hence the warning |

## Fix

Remove our `-D ESP32`; it was redundant on both platforms.

No effective value changes anywhere:

- on core-3 the framework's `-DESP32=ESP32` was already winning, since it lands last on the command line;
- nothing in the tree tests `ESP32` arithmetically — only `#ifdef` / `defined()`;
- the native / EpoxyDuino / divert_sim envs declare their own `-D ESP32` in their own `build_flags` and are untouched.

## Verification

- `openevse_wifi_tft_v1_dev` (core-3): full rebuild from an emptied build dir — **SUCCESS, zero `redefined` warnings**.
- `openevse_wifi_v1` (core-2): full build — **SUCCESS** (281 files compiled and linked), and `pio run -t idedata` confirms `ESP32` is still defined, by the framework.

## Note for anyone building both platforms locally

Unrelated to this change, but hit while verifying it: both platforms install into the *same* package directory `~/.platformio/packages/framework-arduinoespressif32`, so alternating between a core-2 and a core-3 env swaps arduino 2.0.17 ↔ 3.3.11 each time. After such a swap the core-3 env's cached `build.ninja` can reference a file the new package no longer ships (here `cores/esp32/IPv6Address.cpp`, dropped in 3.3.11) and the build fails with `Source ... not found` until `.pio/build/<env>` is removed. CI is unaffected (fresh package dirs per job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)