### PR TITLE
build(tsdb): depend on esp_tsdb from the PlatformIO registry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -602,18 +602,22 @@ build_type = debug
 # the only difference is platform = core-3 and the larger flash layout. This is
 # the reference target proving the two-core build; feature work (tsdb, HA, P4,
 # the S3 display boards, …) stacks on top in later PRs.
-# Shared esp_tsdb lib_dep for ENABLE_TSDB targets (core-3 only). Pinned to a
-# tag rather than a version constraint: the package is not in the PlatformIO
-# registry, so it is fetched by git URL and the ref is what pins it.
+# Shared esp_tsdb lib_dep for ENABLE_TSDB targets (core-3 only). Pinned to an
+# exact version, not a range: a caret would let a future minor into firmware
+# builds without anyone deciding to take it. Dependency scanning still works on
+# an exact pin -- `pio pkg outdated` reports Current/Wanted/Latest -- which is
+# the reason this is a registry package rather than the git URL it used to be:
+# a URL dep is invisible to the scanner, so a new esp_tsdb release went
+# unnoticed until someone happened to look.
 #
-# v2.4.0 is the first release with the sidecar header write. Before it, the
+# v2.4.0 was the first release with the sidecar header write. Before it, the
 # database header was rewritten in place on every sample, and because LittleFS
 # stores a file as a CTZ skip-list a write at offset 0 rewrites the whole file
 # (~20 ms/KB) -- so once energy.tsdb passed ~170 KB the write exceeded
-# CONFIG_ESP_TASK_WDT_TIMEOUT_S=5 and the unit boot-looped. Do not move this pin
-# back below v2.4.0.
+# CONFIG_ESP_TASK_WDT_TIMEOUT_S=5 and the unit boot-looped (#1207). Do not move
+# this pin back below v2.4.0.
 [core3_tsdb_common]
-esp_tsdb_lib = https://github.com/zakery292/esp_tsdb.git#v2.4.1
+esp_tsdb_lib = rar/esp_tsdb@2.4.3
 
 [env:openevse_wifi_v1_16mb]
 board = esp32dev


### PR DESCRIPTION
Follow-up to #1207. Swaps the `esp_tsdb` git-URL pin for a PlatformIO registry dependency.

## Why

This repo runs `PlatformIO Dependabot` daily (`.github/workflows/dependabot.yml`). That action calls PlatformIO's `fetch_outdated_candidates` — i.e. `pio pkg outdated` — which **only sees registry packages**. Every git-URL dependency is invisible to it:

```
Package      Current  Wanted  Latest  Type     Environments
ArduinoJson  6.20.1   6.20.1  7.4.3   Library  openevse_wifi_v1_16mb
ConfigJson   0.0.6    0.0.6   0.0.7   Library  openevse_wifi_v1_16mb
```

No `esp_tsdb`, no `ArduinoMongoose`, no `OpenEVSE_Lib`. That is how the header-write fix in #1207 went unnoticed while it was already published — nothing was watching, so it took a boot-looping unit to find out.

`esp_tsdb` is now published to the registry, so this declares it by version. Verified against the same command the workflow runs, with an older version deliberately pinned:

```
Package   Current  Wanted  Latest  Type     Environments
esp_tsdb  2.4.2    2.4.2   2.4.3   Library  openevse_wifi_v1_16mb
```

## Notes

**Exact version, not a range.** A caret would let a future minor into firmware builds without anyone deciding to take it. As the output above shows, an exact pin is still reported as outdated, so the pin costs nothing in scanning.

**Same code as the `v2.4.1` tag this replaces.** 2.4.2 added the registry publish to the library's release workflow; 2.4.3 kept build byproducts (`dist/`, `release_notes.md`, `.github/`) out of the package archive, taking it from 203 KB to 59 KB. Neither touched a line of the library.

**On the package namespace:** PlatformIO namespaces a package by the publishing account, so this is `rar/esp_tsdb` while the repo, the GitHub releases and the ESP Component Registry entry all live under `zakery292`. The publish is automated in that repo's release workflow and runs on every tag, so the registry entry cannot drift from the tags. Happy to change the arrangement if you would rather it were published from somewhere else.

**Verification:** `openevse_wifi_v1_16mb` builds clean against the registry package — flash 30.2%, RAM 19.9%.

One caveat for anyone who hits it: a freshly published version is not immediately visible to a machine that has already queried the registry. `pio system prune --cache` clears the stale index.
