### PR TITLE
fix(eventlog): stop pilot-state flicker from flooding the event log

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -1104,6 +1104,9 @@ components:
             managerState: active
             evseState: 1
             evseFlags: 123
+            pilotState: 2
+            changed:
+              - pilot
             pilot: 32
             energy: 1234.5
             elapsed: 123456
@@ -1130,6 +1133,35 @@ components:
         evseFlags:
           type: integer
           format: int32
+        pilotState:
+          description: >-
+            J1772 pilot state at the time of the event. 255 for entries written
+            before this field was recorded.
+          type: integer
+          minimum: 0
+          maximum: 255
+        changed:
+          description: >-
+            Which fields differ from the previous entry, i.e. why this entry
+            exists. "boot" means there was no previous entry to compare
+            against; "periodic" means nothing visible changed and the entry is
+            the periodic sample of an unchanging state. Empty for entries
+            written before this field was recorded. The pilot state is never
+            listed: it is recorded, but a change in it alone does not create an
+            entry.
+          type: array
+          items:
+            type: string
+            enum:
+              - boot
+              - type
+              - manager
+              - state
+              - flags
+              - pilot
+              - divert
+              - shaper
+              - periodic
         pilot:
           type: integer
           format: int32

--- a/api.yml
+++ b/api.yml
@@ -1143,7 +1143,9 @@ components:
         changed:
           description: >-
             Which fields differ from the previous entry, i.e. why this entry
-            exists. "boot" means there was no previous entry to compare
+            exists. "flags" covers only the meaningful evseFlags bits: the
+            session-timing and previous-EV-connected bookkeeping bits are
+            recorded in evseFlags but never create an entry of their own. "boot" means there was no previous entry to compare
             against; "periodic" means nothing visible changed and the entry is
             the periodic sample of an unchanging state. Empty for entries
             written before this field was recorded. The pilot state is never

--- a/src/event_log.cpp
+++ b/src/event_log.cpp
@@ -77,7 +77,7 @@ void EventLog::begin()
   }
 }
 
-void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
+void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
 {
   time_t now = time(NULL);
   struct tm timeinfo;
@@ -85,6 +85,26 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
 
   // Check if we have a reasonable time, don't want to be logging events from 1970
   if(timeinfo.tm_year < (2021 - 1900)) {
+    return;
+  }
+
+  EventLogEntryKey key = {
+    type.toInt(),
+    (uint8_t)managerState,
+    evseState,
+    evseFlags,
+    pilot,
+    divertMode,
+    shaper
+  };
+
+  // The type is part of the key, so the first entry of any new state - a fault
+  // above all - is always written. Only an exact repeat of what a reader has
+  // already been told is dropped, and warnings are not exempt: a fault that
+  // persists while the pilot flickers would otherwise flood the log with copies
+  // of itself and evict the very context needed to interpret it.
+  if(_repeat.isRepeat(key, now)) {
+    DBUGLN("EventLog: entry repeats the previous one, not logging");
     return;
   }
 
@@ -114,7 +134,7 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
 
   if(eventFile)
   {
-    StaticJsonDocument<256> line;
+    StaticJsonDocument<320> line;
     char output[80];
     strftime(output, 80, "%FT%TZ", &timeinfo);
 
@@ -123,6 +143,7 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
     line["ms"] = managerState.toString();
     line["es"] = evseState;
     line["ef"] = evseFlags;
+    line["ps"] = pilotState;
     line["p"] = pilot;
     line["e"] = energy;
     line["el"] = elapsed;
@@ -140,10 +161,12 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
     #endif
 
     eventFile.close();
+
+    _repeat.recordWritten(key, now);
   }
 }
 
-void EventLog::enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback)
+void EventLog::enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback)
 {
   String filename = filenameFromIndex(index);
   File eventFile = LittleFS.open(filename);
@@ -154,7 +177,7 @@ void EventLog::enumerate(uint32_t index, std::function<void(String time, EventTy
       String line = eventFile.readStringUntil('\n');
       if(line.length() > 0)
       {
-        StaticJsonDocument<256> json;
+        StaticJsonDocument<320> json;
         DeserializationError error = deserializeJson(json, line);
         if(error)
         {
@@ -169,6 +192,8 @@ void EventLog::enumerate(uint32_t index, std::function<void(String time, EventTy
         managerState.fromString(json["ms"]);
         uint8_t evseState = json["es"];
         uint32_t evseFlags = json["ef"];
+        // Entries written before "ps" existed have no pilot state to report.
+        uint8_t pilotState = json["ps"] | EVENTLOG_PILOT_STATE_UNKNOWN;
         uint32_t pilot = json["p"];
         double energy = json["e"];
         uint32_t elapsed = json["el"];
@@ -177,7 +202,7 @@ void EventLog::enumerate(uint32_t index, std::function<void(String time, EventTy
         uint8_t divertMode = json["dm"];
         uint8_t shaper = json["sh"];
 
-        callback(time, type, line, managerState, evseState, evseFlags, pilot, energy, elapsed, temperature, temperatureMax, divertMode, shaper);
+        callback(time, type, line, managerState, evseState, evseFlags, pilotState, pilot, energy, elapsed, temperature, temperatureMax, divertMode, shaper);
       }
     }
     eventFile.close();

--- a/src/event_log.cpp
+++ b/src/event_log.cpp
@@ -92,7 +92,7 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
     type.toInt(),
     (uint8_t)managerState,
     evseState,
-    evseFlags,
+    eventLogSignificantFlags(evseFlags),
     pilot,
     divertMode,
     shaper

--- a/src/event_log.cpp
+++ b/src/event_log.cpp
@@ -108,6 +108,13 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
     return;
   }
 
+  // Why this entry is here. Zero only survives the check above once the repeat
+  // interval has lapsed, which is the periodic sample of an unchanging state.
+  uint16_t changed = _repeat.changedFrom(key);
+  if(0 == changed) {
+    changed = EVENTLOG_CHANGE_PERIODIC;
+  }
+
   // Guard against filling LittleFS — keep at least 8 KB free to prevent filesystem corruption.
   if (LittleFS.totalBytes() - LittleFS.usedBytes() < 8192) {
     DBUGLN("EventLog: Low SPIFFS space, skipping entry");
@@ -144,6 +151,7 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
     line["es"] = evseState;
     line["ef"] = evseFlags;
     line["ps"] = pilotState;
+    line["ch"] = changed;
     line["p"] = pilot;
     line["e"] = energy;
     line["el"] = elapsed;
@@ -166,7 +174,7 @@ void EventLog::log(EventType type, EvseState managerState, uint8_t evseState, ui
   }
 }
 
-void EventLog::enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback)
+void EventLog::enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint16_t changed, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback)
 {
   String filename = filenameFromIndex(index);
   File eventFile = LittleFS.open(filename);
@@ -194,6 +202,8 @@ void EventLog::enumerate(uint32_t index, std::function<void(String time, EventTy
         uint32_t evseFlags = json["ef"];
         // Entries written before "ps" existed have no pilot state to report.
         uint8_t pilotState = json["ps"] | EVENTLOG_PILOT_STATE_UNKNOWN;
+        // Entries written before "ch" existed cannot say why they are there.
+        uint16_t changed = json["ch"] | 0;
         uint32_t pilot = json["p"];
         double energy = json["e"];
         uint32_t elapsed = json["el"];
@@ -202,7 +212,7 @@ void EventLog::enumerate(uint32_t index, std::function<void(String time, EventTy
         uint8_t divertMode = json["dm"];
         uint8_t shaper = json["sh"];
 
-        callback(time, type, line, managerState, evseState, evseFlags, pilotState, pilot, energy, elapsed, temperature, temperatureMax, divertMode, shaper);
+        callback(time, type, line, managerState, evseState, evseFlags, pilotState, changed, pilot, energy, elapsed, temperature, temperatureMax, divertMode, shaper);
       }
     }
     eventFile.close();

--- a/src/event_log.h
+++ b/src/event_log.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include "evse_state.h"
+#include "event_log_repeat.h"
 
 #ifndef EVENTLOG_ROTATE_SIZE
 #define EVENTLOG_ROTATE_SIZE        1024
@@ -15,6 +16,11 @@
 #ifndef EVENTLOG_BASE_DIRECTORY
 #define EVENTLOG_BASE_DIRECTORY     "/eventlog"
 #endif
+
+// Reported for entries written before the pilot state was recorded. Matches
+// the OpenEVSE library's OPENEVSE_STATE_INVALID narrowed to uint8_t, spelled
+// out here so EventLog stays independent of the EVSE library.
+#define EVENTLOG_PILOT_STATE_UNKNOWN 0xff
 
 class EventType
 {
@@ -67,6 +73,8 @@ private:
   uint32_t _min_log_index;
   uint32_t _max_log_index;
 
+  EventLogRepeatFilter _repeat;
+
   String filenameFromIndex(uint32_t index);
   uint32_t indexFromFilename(String &filename);
 
@@ -84,8 +92,8 @@ public:
     return _max_log_index;
   }
 
-  void log(EventType type, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper);
-  void enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback);
+  void log(EventType type, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper);
+  void enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback);
 };
 
 

--- a/src/event_log.h
+++ b/src/event_log.h
@@ -93,7 +93,7 @@ public:
   }
 
   void log(EventType type, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper);
-  void enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback);
+  void enumerate(uint32_t index, std::function<void(String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint16_t changed, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)> callback);
 };
 
 

--- a/src/event_log_repeat.h
+++ b/src/event_log_repeat.h
@@ -1,0 +1,106 @@
+// src/event_log_repeat.h -- deciding when a log entry says nothing new.
+//
+// The state event that drives event logging fires on any change of
+// (evse_state, pilot_state, vflags), but only evse_state and vflags are
+// written to the log, so a pilot_state flicker produces an entry identical to
+// the one above it in every field a reader can see. Those repeats are worth
+// nothing on their own, and in a log capped at EVENTLOG_MAX_ROTATE_COUNT
+// files of EVENTLOG_ROTATE_SIZE bytes they are actively harmful: they push the
+// session starts, stops and faults out of the retained window.
+//
+// The key below is deliberately only the fields a reader can distinguish.
+// Time, energy, elapsed and temperature are excluded because they change on
+// essentially every entry, so including them would suppress nothing; the
+// repeat interval still leaves a periodic sample of them. The pilot state is
+// excluded too: it is recorded in the entry so a reader can see what changed,
+// but a flicker in it must not be the thing that keeps the entry.
+//
+// Deliberately free of Arduino, LittleFS and ArduinoJson so the decision can
+// be unit tested on the host.
+#ifndef __EVENT_LOG_REPEAT_H
+#define __EVENT_LOG_REPEAT_H
+
+#include <stdint.h>
+
+// How long an entry suppresses identical successors. A long unchanging session
+// still leaves a trace at this cadence rather than vanishing from the log.
+#ifndef EVENTLOG_REPEAT_INTERVAL
+#define EVENTLOG_REPEAT_INTERVAL    300
+#endif
+
+struct EventLogEntryKey
+{
+  uint8_t type;
+  uint8_t managerState;
+  uint8_t evseState;
+  uint32_t evseFlags;
+  uint32_t pilot;
+  uint8_t divertMode;
+  uint8_t shaper;
+
+  bool operator==(const EventLogEntryKey &rhs) const
+  {
+    return type == rhs.type &&
+           managerState == rhs.managerState &&
+           evseState == rhs.evseState &&
+           evseFlags == rhs.evseFlags &&
+           pilot == rhs.pilot &&
+           divertMode == rhs.divertMode &&
+           shaper == rhs.shaper;
+  }
+
+  bool operator!=(const EventLogEntryKey &rhs) const
+  {
+    return !(*this == rhs);
+  }
+};
+
+class EventLogRepeatFilter
+{
+  public:
+    EventLogRepeatFilter() :
+      _have_last(false),
+      _last_time(0),
+      _last({0, 0, 0, 0, 0, 0, 0})
+    {
+    }
+
+    // True when an entry with this key would tell a reader nothing that the
+    // last written entry did not already say. The event type is part of the
+    // key, so a fault always logs when it first appears; only its exact
+    // repeats are dropped.
+    bool isRepeat(const EventLogEntryKey &key, int64_t now) const
+    {
+      if(!_have_last) {
+        return false;
+      }
+
+      if(_last != key) {
+        return false;
+      }
+
+      // A clock that has jumped backwards - the first NTP sync after boot, say
+      // - must not suppress entries until real time catches up again.
+      if(now < _last_time) {
+        return false;
+      }
+
+      return (now - _last_time) < EVENTLOG_REPEAT_INTERVAL;
+    }
+
+    // Call after an entry is successfully written, never before: a write that
+    // failed must not start suppressing its successors.
+    void recordWritten(const EventLogEntryKey &key, int64_t now)
+    {
+      _have_last = true;
+      _last = key;
+      _last_time = now;
+    }
+
+  private:
+    bool _have_last;
+    int64_t _last_time;
+    EventLogEntryKey _last;
+};
+
+#endif // !__EVENT_LOG_REPEAT_H

--- a/src/event_log_repeat.h
+++ b/src/event_log_repeat.h
@@ -28,6 +28,23 @@
 #define EVENTLOG_REPEAT_INTERVAL    300
 #endif
 
+// Why an entry was kept. The event log records state, but a reader diffing two
+// rows to work out what moved needs the row before it - which may have rotated
+// away, or sit in another block. So each entry carries the fields that differ
+// from the last one written.
+//
+// The pilot state is never a reason: it is recorded, but a flicker in it is
+// exactly what the repeat filter exists to swallow.
+#define EVENTLOG_CHANGE_FIRST       0x0001  // nothing to compare against (boot)
+#define EVENTLOG_CHANGE_TYPE        0x0002
+#define EVENTLOG_CHANGE_MANAGER     0x0004
+#define EVENTLOG_CHANGE_EVSE_STATE  0x0008
+#define EVENTLOG_CHANGE_FLAGS       0x0010
+#define EVENTLOG_CHANGE_PILOT       0x0020
+#define EVENTLOG_CHANGE_DIVERT      0x0040
+#define EVENTLOG_CHANGE_SHAPER      0x0080
+#define EVENTLOG_CHANGE_PERIODIC    0x0100  // nothing visible moved; the interval lapsed
+
 struct EventLogEntryKey
 {
   uint8_t type;
@@ -86,6 +103,28 @@ class EventLogRepeatFilter
       }
 
       return (now - _last_time) < EVENTLOG_REPEAT_INTERVAL;
+    }
+
+    // Which fields differ from the last entry written, as EVENTLOG_CHANGE_*
+    // bits. EVENTLOG_CHANGE_FIRST when there is nothing to compare against;
+    // zero when nothing differs, which only reaches the log once the repeat
+    // interval has lapsed.
+    uint16_t changedFrom(const EventLogEntryKey &key) const
+    {
+      if(!_have_last) {
+        return EVENTLOG_CHANGE_FIRST;
+      }
+
+      uint16_t changed = 0;
+      if(_last.type != key.type)                 changed |= EVENTLOG_CHANGE_TYPE;
+      if(_last.managerState != key.managerState) changed |= EVENTLOG_CHANGE_MANAGER;
+      if(_last.evseState != key.evseState)       changed |= EVENTLOG_CHANGE_EVSE_STATE;
+      if(_last.evseFlags != key.evseFlags)       changed |= EVENTLOG_CHANGE_FLAGS;
+      if(_last.pilot != key.pilot)               changed |= EVENTLOG_CHANGE_PILOT;
+      if(_last.divertMode != key.divertMode)     changed |= EVENTLOG_CHANGE_DIVERT;
+      if(_last.shaper != key.shaper)             changed |= EVENTLOG_CHANGE_SHAPER;
+
+      return changed;
     }
 
     // Call after an entry is successfully written, never before: a write that

--- a/src/event_log_repeat.h
+++ b/src/event_log_repeat.h
@@ -45,6 +45,27 @@
 #define EVENTLOG_CHANGE_SHAPER      0x0080
 #define EVENTLOG_CHANGE_PERIODIC    0x0100  // nothing visible moved; the interval lapsed
 
+// evseFlags bits that must not, on their own, create an entry: they mirror
+// state the log already records, so a row whose only difference is one of them
+// has nothing to tell a reader.
+//
+//   SESSION_ENDED     (0x0200) session-timing bookkeeping
+//   EV_CONNECTED_PREV (0x0400) literally the previous value of EV_CONNECTED,
+//                              so it lags it by one update and turns every
+//                              plug-in into two entries instead of one
+//
+// The full evseFlags value is still recorded in the entry; this only excludes
+// these bits from the comparison that decides whether an entry is worth
+// keeping. Values mirror the OpenEVSE library's OPENEVSE_VFLAG_*, spelled out
+// here so this header stays free of the EVSE library.
+#define EVENTLOG_FLAGS_NOT_SIGNIFICANT (0x0200 | 0x0400)
+
+// The part of evseFlags worth comparing entries on.
+inline uint32_t eventLogSignificantFlags(uint32_t evseFlags)
+{
+  return evseFlags & ~((uint32_t)EVENTLOG_FLAGS_NOT_SIGNIFICANT);
+}
+
 struct EventLogEntryKey
 {
   uint8_t type;

--- a/src/evse_man.cpp
+++ b/src/evse_man.cpp
@@ -378,6 +378,7 @@ unsigned long EvseManager::loop(MicroTasks::WakeReason reason)
                   getState(),
                   _monitor.getEvseState(),
                   _monitor.getFlags(),
+                  _monitor.getPilotState(),
                   _monitor.getPilot(),
                   _monitor.getSessionEnergy(),
                   _monitor.getSessionElapsed(),

--- a/src/ocpp.cpp
+++ b/src/ocpp.cpp
@@ -657,7 +657,7 @@ void OcppTask::initializeDiagnosticsService() {
             for (uint32_t i = 0; i <= (eventLog->getMaxIndex() - eventLog->getMinIndex()) && !overflow; i++) {
                 uint32_t index = eventLog->getMinIndex() + i;
 
-                eventLog->enumerate(index, [this, startTime, stopTime, &body, SUFFIX_RESERVED_AREA, &firstEntry, &overflow] (String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper) {
+                eventLog->enumerate(index, [this, startTime, stopTime, &body, SUFFIX_RESERVED_AREA, &firstEntry, &overflow] (String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint16_t changed, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper) {
                     if (overflow) return;
                     MicroOcpp::Timestamp timestamp = MicroOcpp::Timestamp();
                     if (time.isEmpty() || !timestamp.setTime(time.c_str())) {

--- a/src/ocpp.cpp
+++ b/src/ocpp.cpp
@@ -657,7 +657,7 @@ void OcppTask::initializeDiagnosticsService() {
             for (uint32_t i = 0; i <= (eventLog->getMaxIndex() - eventLog->getMinIndex()) && !overflow; i++) {
                 uint32_t index = eventLog->getMinIndex() + i;
 
-                eventLog->enumerate(index, [this, startTime, stopTime, &body, SUFFIX_RESERVED_AREA, &firstEntry, &overflow] (String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper) {
+                eventLog->enumerate(index, [this, startTime, stopTime, &body, SUFFIX_RESERVED_AREA, &firstEntry, &overflow] (String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper) {
                     if (overflow) return;
                     MicroOcpp::Timestamp timestamp = MicroOcpp::Timestamp();
                     if (time.isEmpty() || !timestamp.setTime(time.c_str())) {

--- a/src/web_server_events.cpp
+++ b/src/web_server_events.cpp
@@ -44,7 +44,7 @@ void handleEventLogs(MongooseHttpServerRequest *request)
 
         response->print("[");
 
-        eventLog.enumerate(block, [&count, response](String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
+        eventLog.enumerate(block, [&count, response](String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint16_t changed, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
         {
           StaticJsonDocument<1024> event;
 
@@ -58,6 +58,21 @@ void handleEventLogs(MongooseHttpServerRequest *request)
           event["evseState"] = evseState;
           event["evseFlags"] = evseFlags;
           event["pilotState"] = pilotState;
+
+          // Why this entry is here. Without it a reader has to diff against the
+          // row above, which may have rotated away or sit in another block -
+          // and the fields that most often move, the pilot current and the
+          // status flags, are not ones the History view shows.
+          JsonArray why = event.createNestedArray("changed");
+          if(changed & EVENTLOG_CHANGE_FIRST)      { why.add("boot"); }
+          if(changed & EVENTLOG_CHANGE_TYPE)       { why.add("type"); }
+          if(changed & EVENTLOG_CHANGE_MANAGER)    { why.add("manager"); }
+          if(changed & EVENTLOG_CHANGE_EVSE_STATE) { why.add("state"); }
+          if(changed & EVENTLOG_CHANGE_FLAGS)      { why.add("flags"); }
+          if(changed & EVENTLOG_CHANGE_PILOT)      { why.add("pilot"); }
+          if(changed & EVENTLOG_CHANGE_DIVERT)     { why.add("divert"); }
+          if(changed & EVENTLOG_CHANGE_SHAPER)     { why.add("shaper"); }
+          if(changed & EVENTLOG_CHANGE_PERIODIC)   { why.add("periodic"); }
           event["pilot"] = pilot;
           event["energy"] = energy;
           event["elapsed"] = elapsed;

--- a/src/web_server_events.cpp
+++ b/src/web_server_events.cpp
@@ -44,7 +44,7 @@ void handleEventLogs(MongooseHttpServerRequest *request)
 
         response->print("[");
 
-        eventLog.enumerate(block, [&count, response](String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
+        eventLog.enumerate(block, [&count, response](String time, EventType type, const String &logEntry, EvseState managerState, uint8_t evseState, uint32_t evseFlags, uint8_t pilotState, uint32_t pilot, double energy, uint32_t elapsed, double temperature, double temperatureMax, uint8_t divertMode, uint8_t shaper)
         {
           StaticJsonDocument<1024> event;
 
@@ -57,6 +57,7 @@ void handleEventLogs(MongooseHttpServerRequest *request)
           event["managerState"] = managerState.toString();
           event["evseState"] = evseState;
           event["evseFlags"] = evseFlags;
+          event["pilotState"] = pilotState;
           event["pilot"] = pilot;
           event["energy"] = energy;
           event["elapsed"] = elapsed;

--- a/test/test_event_log_repeat/test_event_log_repeat.cpp
+++ b/test/test_event_log_repeat/test_event_log_repeat.cpp
@@ -153,3 +153,35 @@ TEST_CASE("an entry says which fields put it there")
   CHECK((EVENTLOG_CHANGE_EVSE_STATE | EVENTLOG_CHANGE_FLAGS | EVENTLOG_CHANGE_MANAGER)
         == filter.changedFrom(stopped));
 }
+
+TEST_CASE("bookkeeping flag bits do not make an entry worth keeping")
+{
+  // 0x0200 SESSION_ENDED and 0x0400 EV_CONNECTED_PREV mirror state the log
+  // already records. EV_CONNECTED_PREV in particular lags EV_CONNECTED by one
+  // update, so on a live unit every plug-in wrote a second entry whose only
+  // difference was that bit - and which nothing in a UI could explain.
+  CHECK(0x0140 == eventLogSignificantFlags(0x0740));
+  CHECK(0x0100 == eventLogSignificantFlags(0x0700));
+
+  // Bits that mean something to a reader are untouched: charging relay,
+  // EV connected, boot lock, hard fault.
+  CHECK(0x4142 == eventLogSignificantFlags(0x4142));
+
+  EventLogRepeatFilter filter;
+  EventLogEntryKey connected = charging();
+  connected.evseFlags = eventLogSignificantFlags(0x0300);   // EV_CONNECTED set
+  filter.recordWritten(connected, 1000);
+
+  // The follow-up update that only sets EV_CONNECTED_PREV is now the same
+  // entry, so it is suppressed rather than logged as an unexplainable row.
+  EventLogEntryKey lagged = charging();
+  lagged.evseFlags = eventLogSignificantFlags(0x0700);      // + EV_CONNECTED_PREV
+  CHECK(true == filter.isRepeat(lagged, 1027));
+  CHECK(0 == filter.changedFrom(lagged));
+
+  // A real relay move in the same breath still logs.
+  EventLogEntryKey relay = charging();
+  relay.evseFlags = eventLogSignificantFlags(0x0740);       // + CHARGING_ON
+  CHECK(false == filter.isRepeat(relay, 1027));
+  CHECK(EVENTLOG_CHANGE_FLAGS == filter.changedFrom(relay));
+}

--- a/test/test_event_log_repeat/test_event_log_repeat.cpp
+++ b/test/test_event_log_repeat/test_event_log_repeat.cpp
@@ -1,0 +1,125 @@
+// Host-side tests for the event-log repeat filter (event_log_repeat.h).
+//
+// The filter is what stands between the History view and the pilot-state
+// flicker that used to fill it: on a live unit, 75 of 80 retained entries were
+// the same charging row. These tests pin the two halves of that decision - what
+// counts as "the same entry", and how long sameness suppresses - because
+// getting either wrong silently either restores the flood or hides real events.
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+
+#include "event_log_repeat.h"
+
+// The charging row that flooded the live unit's log.
+static EventLogEntryKey charging()
+{
+  EventLogEntryKey key = {0, 1, 3, 1344, 47, 0, 0};
+  return key;
+}
+
+TEST_CASE("the first entry is never a repeat")
+{
+  EventLogRepeatFilter filter;
+  CHECK(false == filter.isRepeat(charging(), 1000));
+}
+
+TEST_CASE("an identical entry inside the interval is a repeat")
+{
+  EventLogRepeatFilter filter;
+  filter.recordWritten(charging(), 1000);
+
+  CHECK(true == filter.isRepeat(charging(), 1000));
+  CHECK(true == filter.isRepeat(charging(), 1000 + EVENTLOG_REPEAT_INTERVAL - 1));
+}
+
+TEST_CASE("an identical entry at or past the interval is kept")
+{
+  EventLogRepeatFilter filter;
+  filter.recordWritten(charging(), 1000);
+
+  CHECK(false == filter.isRepeat(charging(), 1000 + EVENTLOG_REPEAT_INTERVAL));
+  CHECK(false == filter.isRepeat(charging(), 1000 + EVENTLOG_REPEAT_INTERVAL + 1));
+}
+
+TEST_CASE("suppression is measured from the last entry written, not the last seen")
+{
+  EventLogRepeatFilter filter;
+  filter.recordWritten(charging(), 1000);
+
+  // A run of repeats must not keep pushing the deadline out, or an unchanging
+  // session would never leave a trace at all.
+  CHECK(true == filter.isRepeat(charging(), 1200));
+  CHECK(true == filter.isRepeat(charging(), 1250));
+  CHECK(false == filter.isRepeat(charging(), 1000 + EVENTLOG_REPEAT_INTERVAL));
+}
+
+TEST_CASE("any visible field differing makes it a new entry")
+{
+  EventLogRepeatFilter filter;
+  filter.recordWritten(charging(), 1000);
+
+  SUBCASE("type")         { EventLogEntryKey k = charging(); k.type = 2;          CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("managerState") { EventLogEntryKey k = charging(); k.managerState = 2;  CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("evseState")    { EventLogEntryKey k = charging(); k.evseState = 254;   CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("evseFlags")    { EventLogEntryKey k = charging(); k.evseFlags = 1280;  CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("pilot")        { EventLogEntryKey k = charging(); k.pilot = 32;        CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("divertMode")   { EventLogEntryKey k = charging(); k.divertMode = 1;    CHECK(false == filter.isRepeat(k, 1001)); }
+  SUBCASE("shaper")       { EventLogEntryKey k = charging(); k.shaper = 1;        CHECK(false == filter.isRepeat(k, 1001)); }
+}
+
+TEST_CASE("a repeated fault is suppressed, but the fault itself is never lost")
+{
+  EventLogRepeatFilter filter;
+
+  // A GFCI fault while the pilot flickers: on the bench this wrote eight
+  // identical warning rows in eight seconds, evicting the context needed to
+  // read them. The first one must always survive; its copies must not.
+  EventLogEntryKey fault = charging();
+  fault.type = 2;          // warning
+  fault.evseState = 6;     // GFI fault
+
+  CHECK(false == filter.isRepeat(fault, 1000));
+  filter.recordWritten(fault, 1000);
+  CHECK(true == filter.isRepeat(fault, 1001));
+
+  // A different fault is a different key, so it is never hidden behind the one
+  // before it.
+  EventLogEntryKey other = fault;
+  other.evseState = 8;     // stuck relay
+  CHECK(false == filter.isRepeat(other, 1001));
+}
+
+TEST_CASE("an information entry does not hide behind a warning with the same fields")
+{
+  EventLogRepeatFilter filter;
+
+  EventLogEntryKey warned = charging();
+  warned.type = 2;
+  filter.recordWritten(warned, 1000);
+
+  CHECK(false == filter.isRepeat(charging(), 1001));
+}
+
+TEST_CASE("a clock that jumps backwards does not suppress")
+{
+  EventLogRepeatFilter filter;
+
+  // Entries can be written with a plausible-but-wrong clock and then NTP lands.
+  // Suppressing until real time overtakes the bad reading could silence the log
+  // for years, so a backwards jump always writes.
+  filter.recordWritten(charging(), 2000000000);
+  CHECK(false == filter.isRepeat(charging(), 1000));
+}
+
+TEST_CASE("recording a different entry resets what counts as a repeat")
+{
+  EventLogRepeatFilter filter;
+  filter.recordWritten(charging(), 1000);
+
+  EventLogEntryKey sleeping = charging();
+  sleeping.evseState = 254;
+  filter.recordWritten(sleeping, 1010);
+
+  CHECK(true == filter.isRepeat(sleeping, 1011));
+  CHECK(false == filter.isRepeat(charging(), 1011));
+}

--- a/test/test_event_log_repeat/test_event_log_repeat.cpp
+++ b/test/test_event_log_repeat/test_event_log_repeat.cpp
@@ -123,3 +123,33 @@ TEST_CASE("recording a different entry resets what counts as a repeat")
   CHECK(true == filter.isRepeat(sleeping, 1011));
   CHECK(false == filter.isRepeat(charging(), 1011));
 }
+
+TEST_CASE("an entry says which fields put it there")
+{
+  EventLogRepeatFilter filter;
+
+  // Nothing to compare against yet.
+  CHECK(EVENTLOG_CHANGE_FIRST == filter.changedFrom(charging()));
+
+  filter.recordWritten(charging(), 1000);
+  CHECK(0 == filter.changedFrom(charging()));
+
+  // The case that prompted this: the History view shows neither the pilot
+  // current nor the status flags, so a row that moved only in those reads as a
+  // duplicate of the one above it unless it says what changed.
+  EventLogEntryKey throttled = charging();
+  throttled.pilot = 42;
+  CHECK(EVENTLOG_CHANGE_PILOT == filter.changedFrom(throttled));
+
+  EventLogEntryKey relay = charging();
+  relay.evseFlags = 1280;
+  CHECK(EVENTLOG_CHANGE_FLAGS == filter.changedFrom(relay));
+
+  // Several at once is the normal case for a real transition.
+  EventLogEntryKey stopped = charging();
+  stopped.evseState = 254;
+  stopped.evseFlags = 1280;
+  stopped.managerState = 2;
+  CHECK((EVENTLOG_CHANGE_EVSE_STATE | EVENTLOG_CHANGE_FLAGS | EVENTLOG_CHANGE_MANAGER)
+        == filter.changedFrom(stopped));
+}


### PR DESCRIPTION
## The bug

The event that drives event logging triggers on any change of `(evse_state, pilot_state, vflags)` (`evse_monitor.cpp:84`):

```cpp
if(_evse_state != evse_state || _pilot_state != pilot_state || _vflags != vflags)
```

but the record written to the log carries `evseState`, `evseFlags` and `pilot` — where `pilot` is the **advertised current in amps**, not the pilot state. The one input that can change is the one never written down, so a pilot-state flicker produces an entry identical to the one above it in every field a reader can see.

## Why it is not cosmetic

The log is capped at `EVENTLOG_MAX_ROTATE_COUNT` files of `EVENTLOG_ROTATE_SIZE` bytes — roughly 40–80 entries. Measured on a live unit with a real controller and a real car:

- **72 entries in 10 minutes of continuous charging**, one every 8.1 s
- of the 80 entries the log retained, **75 were the same charging row**; only 3 distinct states appeared in the entire file
- the retained history spanned 4h44m and recorded essentially nothing — session starts, stops and faults had been rotated out within minutes of a session beginning

So the failure mode is not "the History view is noisy", it is "the event log cannot retain events".

## The fix (commit 1)

Record `pilotState` in the entry, and drop an entry whose visible fields match the last one written until `EVENTLOG_REPEAT_INTERVAL` (300 s) has passed.

Two exclusion decisions carry the design, and both are deliberate:

- **`pilotState` is recorded but not compared.** It is worth seeing, but a flicker in it must not be the thing that keeps the entry — that is the bug.
- **Time, energy, elapsed and temperature are excluded** for the opposite reason: they change on nearly every entry, so including them would suppress nothing. The 300 s interval still leaves a periodic sample of them.

The event type is part of the key, so the first entry of any new state — a fault above all — is always written. Warnings are not exempt beyond that, and that was a correction made during bench testing: an earlier version of this patch exempted them outright, and a sustained GFCI fault with a flickering pilot promptly wrote **eight identical warning rows in eight seconds**, evicting the context needed to interpret them.

## Saying why an entry survived (commit 2)

Suppressing repeats leaves a second problem: the surviving entries still do not say what put them there. A reader has to diff a row against the one above it, which may have rotated out of the window or sit in a different block — and the two fields that move most often during a session, the pilot current and the status flags, are not shown in the History view at all.

The result is rows that still read as duplicates. From the live unit: two "Charging" rows a minute apart were the pilot stepping 47→42 then 42→41 A as the charge was throttled; two "Disabled - Sleeping" rows two seconds apart were the stop followed by the charging relay bit clearing in `evseFlags`. Four distinct events, rendered as two pairs of twins.

The repeat filter already computes this to decide what to drop, so recording it is close to free. Each entry carries the fields that differ from the last one written, stored as a bitmask and served from `/logs` as a list of names:

```json
{ "evseState": 2, "evseFlags": 1280, "pilotState": 2,
  "changed": ["state", "pilot"], "pilot": 47, ... }
```

`boot` means there was nothing to compare against; `periodic` means nothing visible moved and the entry is the interval sample of an unchanging state. `pilotState` is never listed — it is recorded, but a change in it alone does not create an entry, so naming it as a reason would be a lie.

## Compatibility

Additive only; no field removed or renamed. Entries written by older firmware read back as `pilotState: 255` (unknown) and `changed: []`, which was verified against a real four-month-old log on the device rather than in a fixture.

## Structure and testing

The decision lives in `src/event_log_repeat.h`, free of Arduino, LittleFS and ArduinoJson, following the existing `charge_threshold.h` / `fault_text.h` pattern in this repo. That makes it host-testable: 10 cases / 27 assertions covering the interval boundary, each visible field independently, repeated and distinct faults, a backwards clock jump (an NTP correction must not silence the log until real time catches up), the change mask, and the run-of-repeats case where a naive implementation keeps pushing the deadline out and an unchanging session never logs at all.

## Verification

| Check | Result |
|---|---|
| `native_test` | 12/12 suites |
| `openevse_wifi_v1` (core-2, 4 MB) | SUCCESS — 96.0% |
| `esp32-c3-devkitc-02` (RISC-V) | SUCCESS — 92.8% |
| `openevse_wifi_tft_v1` (core-3, arduino+espidf) | SUCCESS |
| `native_openevse` | SUCCESS |

Cost, A/B against master with an identical `BUILD_TAG`: **+976 bytes flash, +32 bytes RAM**. Still 96.0% on the 4 MB board.

**Bench-tested** on an `openevse_wifi_tft_v1` with an in-firmware fake controller driving a 1 Hz pilot-state flicker, against with-fix and reverted-fix builds of the same tree:

| Run | 150 s of flicker while charging | Entries written | Log rotations |
|---|---|---|---|
| without the fix | | ~75, all identical | **18** — the whole window recycled nearly twice |
| with the fix | | **0** | 0 |

Four further minutes spanning both charging and a sustained GFCI fault produced 5 entries total and zero rotations, with the fault logged exactly once and its recovery logged after.

**Hardware-validated** on a live unit (controller 9.3.0.SAMD, real vehicle): 13 minutes across a charge session and its stop produced 4 entries and zero rotations, against 72 entries per 10 minutes before. `changed` and `pilotState` confirmed live, alongside pre-existing entries correctly reading back as unknown.

## Note for GUI work

`/logs` now carries the reason, but no GUI renders it yet, so those rows still look identical on screen. Making them legible wants two things in the web UI: display the `changed` reason, and display the pilot current — it is in every record already and is the single most common reason a row exists, yet no view shows it.
