### PR TITLE
fix(loadsharing): free the finished mDNS search, it was leaking every 10 s

### DIFF
--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -100,9 +100,12 @@ unsigned long LoadSharingDiscoveryTask::loop(MicroTasks::WakeReason reason) {
   // If a query is currently in progress, poll its status
   if (_query_in_progress) {
     if (pollAsyncQuery()) {
-      // Query completed, process results handled in pollAsyncQuery()
-      _query_in_progress = false;
-      _active_query = nullptr;
+      // Query completed, results already processed in pollAsyncQuery(). The
+      // finished search object is still ours to free: mdns_query_async_delete
+      // is the only thing that releases it (struct, name strings, semaphore).
+      // Dropping the handle here leaked ~230 bytes every 10 s query and
+      // exhausted the heap in about an hour on no-PSRAM boards.
+      cleanupQuery();
     } else {
       // Query still in progress, check timeout
       if (now - _query_start_time > _query_timeout_ms) {


### PR DESCRIPTION
## Summary

`LoadSharingDiscoveryTask` (from #1027) issues an async mDNS `_openevse._tcp` query every 10 s, whether or not load sharing is enabled. When the query completed, `loop()` dropped the handle without calling `mdns_query_async_delete`, which is the only thing that frees the search object (struct, name strings, FreeRTOS semaphore). Only the timeout branch cleaned up, and the mDNS side finishes the search at the same 5 s deadline, so the completion branch won nearly every cycle.

The fix runs `cleanupQuery()` on the completion path too.

## Symptom

On a no-PSRAM `openevse_wifi_tft_v1` with `mqtts` configured, the unit panicked roughly hourly. Core dump (via `/debug/crash`, symbolized against the build ELF):

```
mbedtls_ssl_config_init            ssl_tls.c:5665      <- memset(NULL)
mg_ssl_if_conn_init                mongoose.c:5173     <- MG_CALLOC returned NULL
mg_connect_opt
MongooseMqttClient::connect
Mqtt::attemptConnection            mqtt.cpp:226
Mqtt::loop                         mqtt.cpp:126
```

That is an out-of-memory at MQTT-over-TLS reconnect, not a bug in that path. Every board on master leaks the same way; larger heaps just take longer to run out.

## Measurement (bench TFT, `/status` polled every 15 s)

| build | free_heap start | free_heap end | window | slope |
|---|---|---|---|---|
| master 5b519263 | 82740 | 70868 | 529 s | **-22.4 B/s** (~1.3 KB/min) |
| this fix 6a5379c1 | 101872 | 101880 | 349 s | 0 B/s |

The pre-fix number works out to ~230 bytes per query, which is one `mdns_search_once_t` plus its strings and semaphore. Post-fix `heap_largest` held at 29684 for the whole window and the MQTT session stayed up.

## Follow-up question

Should discovery run at all while `loadsharing_enabled` is false? It costs an mDNS round every 10 s on every unit today. Left as-is here since that is a design choice rather than a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
