### PR TITLE
loadsharing: gate periodic mDNS discovery on the enabled flag, fix the service name and IPv4 selection

### DIFF
--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -83,6 +83,7 @@ LoadSharingDiscoveryTask::LoadSharingDiscoveryTask(unsigned long cacheTtl,
     _active_query(nullptr),
     _query_start_time(0),
     _query_in_progress(false),
+    _manual_trigger(false),
     _groupState(nullptr),
     _discovery_count(0),
     _last_result_count(0)
@@ -116,9 +117,16 @@ unsigned long LoadSharingDiscoveryTask::loop(MicroTasks::WakeReason reason) {
       }
     }
   } else {
-    // No query in progress, check if we should start a new one
-    if (now - _last_discovery_time >= _discovery_interval_ms || _last_discovery_time == 0) {
-      // Time to start a new discovery
+    // No query in progress, check if we should start a new one. Periodic
+    // discovery only runs while load sharing is enabled: with it off nothing
+    // consumes the results, and every query is an mDNS round that every other
+    // OpenEVSE on the LAN answers plus a burst of heap churn on no-PSRAM
+    // boards. A manual trigger still runs a single query so the UI can browse
+    // for peers before enabling.
+    bool periodic_due = loadsharing_enabled &&
+                        (now - _last_discovery_time >= _discovery_interval_ms || _last_discovery_time == 0);
+    if (_manual_trigger || periodic_due) {
+      _manual_trigger = false;
       DBUGF("LoadSharingDiscoveryTask: Starting discovery iteration %lu", _discovery_count + 1);
       startAsyncQuery();
       _last_discovery_time = now;
@@ -147,8 +155,8 @@ void LoadSharingDiscoveryTask::end() {
 }
 
 void LoadSharingDiscoveryTask::triggerDiscovery() {
-  // Reset discovery timer to force immediate query on next task wake
-  _last_discovery_time = 0;
+  // Run one query on the next task wake, regardless of the enabled flag
+  _manual_trigger = true;
   MicroTask.wakeTask(this);
   DBUGF("LoadSharingDiscoveryTask: Triggered manual discovery");
 }

--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -12,6 +12,12 @@
 #include <ESPmDNS.h>
 #include <mdns.h>
 #include <algorithm>
+
+// The EpoxymDNS shim used by the native builds carries the esp_ip_addr_t
+// type field but not the IDF constant for it. IDF defines it as 0U.
+#ifndef ESP_IPADDR_TYPE_V4
+#define ESP_IPADDR_TYPE_V4 0U
+#endif
 #if __has_include(<esp_idf_version.h>)
 #include <esp_idf_version.h>
 #endif
@@ -310,13 +316,21 @@ bool LoadSharingDiscoveryTask::pollAsyncQuery() {
         resolvedHost = String(r->hostname);
       }
 
-      // Extract IP address
-      if (r->addr) {
-        uint32_t ip = r->addr->addr.u_addr.ip4.addr;
+      // Extract IP address. A responder lists every address it has, IPv6
+      // included (link-local and ULA AAAA records come back alongside the A
+      // record), and the list order is not ours to rely on. Take the first
+      // IPv4 entry; reading an IPv6 entry's first four bytes as IPv4 turned
+      // fd4b:288b:... into 253.75.40.139.
+      for (mdns_ip_addr_t* a = r->addr; a; a = a->next) {
+        if (a->addr.type != ESP_IPADDR_TYPE_V4) {
+          continue;
+        }
+        uint32_t ip = a->addr.u_addr.ip4.addr;
         peer.ipAddress = String((ip & 0xFF)) + "." +
                         String((ip >> 8) & 0xFF) + "." +
                         String((ip >> 16) & 0xFF) + "." +
                         String((ip >> 24) & 0xFF);
+        break;
       }
 
       peer.port = r->port;

--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -12,12 +12,6 @@
 #include <ESPmDNS.h>
 #include <mdns.h>
 #include <algorithm>
-
-// The EpoxymDNS shim used by the native builds carries the esp_ip_addr_t
-// type field but not the IDF constant for it. IDF defines it as 0U.
-#ifndef ESP_IPADDR_TYPE_V4
-#define ESP_IPADDR_TYPE_V4 0U
-#endif
 #if __has_include(<esp_idf_version.h>)
 #include <esp_idf_version.h>
 #endif

--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -100,9 +100,12 @@ unsigned long LoadSharingDiscoveryTask::loop(MicroTasks::WakeReason reason) {
   // If a query is currently in progress, poll its status
   if (_query_in_progress) {
     if (pollAsyncQuery()) {
-      // Query completed, process results handled in pollAsyncQuery()
-      _query_in_progress = false;
-      _active_query = nullptr;
+      // Query completed, results already processed in pollAsyncQuery(). The
+      // finished search object is still ours to free: mdns_query_async_delete
+      // is the only thing that releases it (struct, name strings, semaphore).
+      // Dropping the handle here leaked ~230 bytes every 10 s query and
+      // exhausted the heap in about an hour on no-PSRAM boards.
+      cleanupQuery();
     } else {
       // Query still in progress, check timeout
       if (now - _query_start_time > _query_timeout_ms) {

--- a/src/loadsharing_discovery_task.cpp
+++ b/src/loadsharing_discovery_task.cpp
@@ -196,16 +196,18 @@ void LoadSharingDiscoveryTask::startAsyncQuery() {
   // Start an async mDNS query for OpenEVSE services
   // Parameters:
   //   - name: NULL (search for all instances)
-  //   - service_type: "openevse" (without leading underscore)
-  //   - proto: "tcp" (without leading underscore)
+  //   - service_type: "_openevse", proto: "_tcp". The raw IDF API takes the
+  //     DNS-SD labels verbatim (mdns.h: "_http", "_tcp"); only the Arduino
+  //     ESPmDNS wrapper prepends the underscores. Units advertise via
+  //     MDNS.addService("openevse", "tcp"), i.e. _openevse._tcp.local.
   //   - type: MDNS_TYPE_PTR (PTR record for service discovery)
   //   - timeout_ms: query timeout
   //   - max_results: 20 (collect up to 20 results)
   //   - notifier: NULL (we'll poll instead)
   _active_query = (void*)mdns_query_async_new(
       NULL,
-      "openevse",
-      "tcp",
+      "_openevse",
+      "_tcp",
       MDNS_TYPE_PTR,
       _query_timeout_ms,
       20,

--- a/src/loadsharing_discovery_task.h
+++ b/src/loadsharing_discovery_task.h
@@ -41,6 +41,9 @@ struct DiscoveredPeer {
  *
  * Architecture:
  * - Task wakes every poll_interval_ms (default 2 seconds)
+ * - Periodic queries run only while load sharing is enabled; when disabled
+ *   the task idles and only runs a query on triggerDiscovery() (the
+ *   POST /loadsharing/discover path used by the peer-management UI)
  * - On cache TTL expiry, initiates async mDNS query
  * - Task polls query status and processes results when ready
  * - HTTP handlers always get immediate cached results
@@ -64,6 +67,7 @@ private:
   void* _active_query;                       // Opaque mdns_search_once_t handle (void* for compatibility)
   unsigned long _query_start_time;           // When current async query started
   bool _query_in_progress;                   // True while query is running
+  bool _manual_trigger;                      // A one-shot query was requested via triggerDiscovery()
 
   // Group state reference (set via begin)
   LoadSharingGroupState* _groupState;


### PR DESCRIPTION
Stacked on #1218 (the leak fix); the diff shown here will collapse to three commits once that merges.

## 1. Only run periodic discovery while load sharing is enabled

`LoadSharingDiscoveryTask` queried `_openevse._tcp` every 10 s on every unit from boot, enabled or not. With load sharing off nothing consumes the results: the peer poller only polls joined peers and the group state only refreshes online flags on peers already added. Each query is still an mDNS round that every other OpenEVSE on the LAN answers, plus a burst of small allocations that fragments the heap on no-PSRAM boards.

Now: periodic queries run only while `loadsharing_enabled` is true. When off the task idles. `POST /loadsharing/discover` (what the peer-management UI uses to browse for chargers before enabling) still runs a single query through a one-shot trigger flag, so that flow is unchanged. Turning the setting on is picked up on the next 2 s wake.

## 2. Query `_openevse._tcp`, not `openevse.tcp`

Found while verifying (1) with a host-side mDNS listener. The task calls the raw IDF `mdns_query_async_new` with `"openevse"`/`"tcp"`, assuming the API adds the DNS-SD underscores. It does not: mdns.h documents the arguments as `_http`, `_tcp`, and only the Arduino ESPmDNS wrapper prepends them. On the wire every unit was asking for `openevse.tcp.local`, which nothing advertises, while the units themselves (`MDNS.addService("openevse", "tcp")`) answer `_openevse._tcp.local`. **Discovery never found a peer on real hardware.** The integration harness presumably shims mDNS without the underscore distinction.

## 3. Take the first IPv4 address, not the first address

Found once (2) made discovery return results. `r->addr` was read as IPv4 without checking the family. A unit with IPv6 answers with its A record plus link-local and ULA AAAA records, and the ULA came first, so the peer was recorded as `253.75.40.139` (the first four bytes of `fd4b:288b:…`). Walk the list and take the first `ESP_IPADDR_TYPE_V4` entry.

## Verification (bench `openevse_wifi_tft_v1`, host listener on 224.0.0.251:5353)

| state | queries from the bench |
|---|---|
| before, load sharing disabled | continuous, every ~2 s (one search per 10 s with the library's retransmits), name `openevse.tcp.local` |
| after, load sharing disabled, 45 s | 0 |
| after, one `POST /loadsharing/discover` | one search, name `_openevse._tcp.local` |

`GET /loadsharing/peers` after the trigger:

| build | discovered peers |
|---|---|
| master | local device only |
| after (2) | `openevse-2760` at `253.75.40.139`, `openevse-bench32` at `10.75.0.29` |
| after (3) | `openevse-2760` at `10.75.1.157`, `openevse-bench32` at `10.75.0.29` |

Heap stayed flat and the MQTT session stayed up throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
