### PR TITLE
fix(net): log the IP address, not the netmask, on connect

### DIFF
--- a/src/net_manager.cpp
+++ b/src/net_manager.cpp
@@ -232,7 +232,7 @@ void NetManagerTask::haveNetworkConnection(IPAddress myAddress, IPAddress netmas
   _macaddress = WiFi.macAddress();
 
   DEBUG.print("Connected, IP: ");
-  DEBUG.println(tmpStr);
+  DEBUG.println(_ipaddress);
 
   displayState();
 


### PR DESCRIPTION
Since ad620f0e (`Prefer same-subnet peer addresses from mDNS discovery`, part of #1027), `haveNetworkConnection()` formats the netmask into the same `tmpStr` buffer before the `Connected, IP:` debug line, so the console prints the mask:

```
Connected, IP: 255.255.254.0
```

The stored `_ipaddress` and the LCD are correct; only the log line is wrong. Print `_ipaddress` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
