### PR TITLE
ci: pin PlatformIO Core to 6.1.19 to avoid broken SCons 4.11.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,9 +150,17 @@ jobs:
         python-version: '3.x'
 
     - name: Install PlatformIO
+      # Pinned: PlatformIO Core 6.2.0 bumped its bundled build engine to
+      # SCons 4.11.1 (tool-scons@4.41101.0), which fails every core-3.x
+      # (pioarduino, arduino+espidf hybrid) env at the final link step with
+      # `ModuleNotFoundError: No module named 'SCons.Tool.FortranCommon'`
+      # (openevse_wifi_v1_16mb, openevse_wifi_tft_v1[_dev]). 6.1.19 is the
+      # last release still on SCons 4.8.1 (tool-scons@4.40801.0), which
+      # works. Bump this once upstream ships a SCons/PlatformIO release that
+      # fixes it.
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade platformio
+        pip install --upgrade "platformio==6.1.19"
 
     - name: Install Avahi development libraries
       if: matrix.env == 'native_openevse'


### PR DESCRIPTION
PlatformIO Core 6.2.0 (released 2026-09-05) bumped its bundled build
engine dependency to tool-scons@4.41101.0 (SCons 4.11.1). That SCons
release breaks every core-3.x (pioarduino, arduino+espidf hybrid) env
at the final link step:

    ModuleNotFoundError: No module named 'SCons.Tool.FortranCommon'

Confirmed by diffing the pinned tool-scons requirement across pio
wheels: 6.1.19 declares "tool-scons": "~4.40801.0" (SCons 4.8.1, known
good), 6.2.0 declares "~4.41101.0" (SCons 4.11.1, broken). Plain
arduino-framework envs are unaffected since they don't go through the
CMake/SCons link path that trips this; native builds are unaffected
too. This is what failed openevse_wifi_v1_16mb and
openevse_wifi_tft_v1_dev (and openevse_wifi_tft_v1) in run 34148595091
and run 34006507482, on two unrelated PRs.

Pin CI to the last known-good Core release until upstream ships a
PlatformIO/SCons pairing that fixes this.
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018HEz6PgbPcYyjbLapKxbuK