### PR TITLE
fix: resolve the MQTT broker and NTP host IPs without blocking loopTask

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -8,6 +8,8 @@
 #include <netdb.h>
 #else
 #include <lwip/netdb.h>
+#include <lwip/dns.h>
+#include <lwip/tcpip.h>
 #endif
 #include "openevse.h"
 #include "divert.h"
@@ -29,6 +31,7 @@ Mqtt::Mqtt(EvseManager &evseManager) :
   _lastRxTime(0)
 {
   _brokerIp[0]      = '\0';
+  _dnsResult[0]     = '\0';
   _brokerVersion[0] = '\0';
   _errorCategory[0] = '\0';
   _errorDetail[0]   = '\0';
@@ -127,14 +130,14 @@ unsigned long Mqtt::loop(MicroTasks::WakeReason reason) {
     }
   }
 
-  // If connected, perform periodic checks and safe deferred DNS lookup
+  // If connected, perform periodic checks and the deferred broker IP lookup
   if (_mqttclient.connected()) {
     if (millis() - _loop_timer > MQTT_LOOP_INTERVAL) {
       _loop_timer = millis();
       checkAndPublishUpdates();
     }
 
-    // DNS lookup deferred from onMqttConnect (safe to block here, not in callback)
+    // Broker IP lookup, deferred from onMqttConnect and started without blocking
     if (_needsDnsLookup) {
       _needsDnsLookup = false;
       struct in_addr addr4; struct in6_addr addr6;
@@ -142,27 +145,15 @@ unsigned long Mqtt::loop(MicroTasks::WakeReason reason) {
                   (inet_pton(AF_INET6, mqtt_server.c_str(), &addr6) == 1);
       if (isIp) {
         strncpy(_brokerIp, mqtt_server.c_str(), sizeof(_brokerIp) - 1);
-      } else if (mqtt_server.length() > 0) {
-        struct addrinfo hints = {}, *res = nullptr;
-        hints.ai_family = AF_UNSPEC;
-        if (getaddrinfo(mqtt_server.c_str(), nullptr, &hints, &res) == 0 && res) {
-          void *addr = res->ai_family == AF_INET
-            ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
-            : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
-          inet_ntop(res->ai_family, addr, _brokerIp, sizeof(_brokerIp) - 1);
-          freeaddrinfo(res);
-        } else {
-          strncpy(_brokerIp, "failed", sizeof(_brokerIp) - 1);
-        }
         _brokerIp[sizeof(_brokerIp) - 1] = '\0';
+      } else if (mqtt_server.length() > 0) {
+        startDnsLookup();
       }
-      if (_brokerIp[0] != '\0') {
-        // WebSocket only — this is a UI status field, not broker data
-        StaticJsonDocument<128> dns_event;
-        dns_event["mqtt_broker_ip"] = _brokerIp;
-        web_server_event(dns_event);
-      }
+      publishBrokerIp();
     }
+
+    // An asynchronous lookup may land on any later pass
+    takeDnsResult();
   }
 
   // Periodic status push so GUI always reflects the real connection state
@@ -233,6 +224,96 @@ void Mqtt::attemptConnection() {
       // If connect() returns false, it means it couldn't even start the attempt.
       onMqttDisconnect(-100, "Initial connection failed"); // Custom error
   }
+}
+
+#ifndef EPOXY_DUINO
+// Runs on the LwIP TCP/IP thread, not on loopTask. Formats the answer and then
+// publishes the flag with a release store, so a loopTask that sees the flag set is
+// guaranteed to see the whole buffer.
+void Mqtt::dnsFoundCallback(const char *name, const ip_addr_t *ipaddr, void *arg)
+{
+  Mqtt *self = static_cast<Mqtt *>(arg);
+  if (nullptr != ipaddr) {
+    ipaddr_ntoa_r(ipaddr, self->_dnsResult, sizeof(self->_dnsResult));
+  } else {
+    // A null address means the query completed and the name does not resolve.
+    strncpy(self->_dnsResult, "failed", sizeof(self->_dnsResult) - 1);
+    self->_dnsResult[sizeof(self->_dnsResult) - 1] = '\0';
+  }
+  __atomic_store_n(&self->_dnsResultReady, true, __ATOMIC_RELEASE);
+}
+#endif
+
+// Starts resolving the broker hostname for the `mqtt_broker_ip` status field.
+//
+// This must not block. loop() runs on loopTask, which feeds the task watchdog, and
+// the synchronous resolvers wait out the full query: with LWIP_IPV6 enabled an
+// AF_UNSPEC getaddrinfo() asks for both A and AAAA, each up to DNS_MAX_RETRIES
+// times across every configured server, which overruns the 5 s watchdog and reboots
+// the charger. So ask LwIP for the answer and let it call back when it has one.
+void Mqtt::startDnsLookup()
+{
+#ifdef EPOXY_DUINO
+  // Host build: no LwIP resolver and no watchdog to trip, so resolve inline.
+  struct addrinfo hints = {}, *res = nullptr;
+  hints.ai_family = AF_UNSPEC;
+  if (getaddrinfo(mqtt_server.c_str(), nullptr, &hints, &res) == 0 && res) {
+    void *addr = res->ai_family == AF_INET
+      ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
+      : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
+    inet_ntop(res->ai_family, addr, _brokerIp, sizeof(_brokerIp) - 1);
+    freeaddrinfo(res);
+  } else {
+    strncpy(_brokerIp, "failed", sizeof(_brokerIp) - 1);
+  }
+  _brokerIp[sizeof(_brokerIp) - 1] = '\0';
+#else
+  ip_addr_t addr;
+
+  // Discard any answer still in flight from a previous connection
+  __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
+
+  // dns_gethostbyname() is LwIP raw API, so it is only safe to call while holding
+  // the TCP/IP core lock. LwIP copies the name, so it need not outlive this call.
+  LOCK_TCPIP_CORE();
+  err_t err = dns_gethostbyname(mqtt_server.c_str(), &addr, dnsFoundCallback, this);
+  UNLOCK_TCPIP_CORE();
+
+  if (ERR_OK == err) {
+    // Already in LwIP's cache: answered here, and no callback will follow.
+    ipaddr_ntoa_r(&addr, _brokerIp, sizeof(_brokerIp));
+  } else if (ERR_INPROGRESS != err) {
+    // Could not even start the query (out of DNS table slots, no server set).
+    strncpy(_brokerIp, "failed", sizeof(_brokerIp) - 1);
+    _brokerIp[sizeof(_brokerIp) - 1] = '\0';
+  }
+  // ERR_INPROGRESS: dnsFoundCallback() will deliver it to takeDnsResult().
+#endif
+}
+
+// Picks up an answer left by dnsFoundCallback(), if one has arrived.
+void Mqtt::takeDnsResult()
+{
+#ifndef EPOXY_DUINO
+  if (!__atomic_load_n(&_dnsResultReady, __ATOMIC_ACQUIRE)) {
+    return;
+  }
+  __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
+  strncpy(_brokerIp, _dnsResult, sizeof(_brokerIp) - 1);
+  _brokerIp[sizeof(_brokerIp) - 1] = '\0';
+  publishBrokerIp();
+#endif
+}
+
+void Mqtt::publishBrokerIp()
+{
+  if ('\0' == _brokerIp[0]) {
+    return;
+  }
+  // WebSocket only — this is a UI status field, not broker data
+  StaticJsonDocument<128> dns_event;
+  dns_event["mqtt_broker_ip"] = _brokerIp;
+  web_server_event(dns_event);
 }
 
 void Mqtt::onMqttConnect() {
@@ -617,6 +698,7 @@ void Mqtt::restartConnection() {
   }
   _connecting = false;
   _needsDnsLookup = false;
+  __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
   _brokerIp[0] = '\0';
   _errorCategory[0] = '\0';   // clear stale failure reason on manual restart
   _errorDetail[0]   = '\0';

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -4,6 +4,9 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <MongooseMqttClient.h>
+#ifndef EPOXY_DUINO
+#include <lwip/ip_addr.h>
+#endif
 #include <MicroTasks.h>
 
 #include "emonesp.h"
@@ -54,7 +57,20 @@ class Mqtt : public MicroTasks::Task {
     char   _brokerVersion[96];  // payload of $SYS/broker/version, or ""
     time_t _connectedSince;     // Unix ts when last connected (0 = never)
     time_t _lastRxTime;         // Unix ts of most recent broker traffic, sent or received (0 = never)
-    bool   _needsDnsLookup = false; // set in onMqttConnect; DNS done safely in loop()
+    bool   _needsDnsLookup = false; // set in onMqttConnect; resolve started in loop()
+
+    // Broker DNS is resolved asynchronously, because the synchronous resolvers
+    // block for as long as the query takes and loop() runs under the task
+    // watchdog. dnsFoundCallback() runs on the LwIP TCP/IP thread and hands the
+    // answer to loop() through these two fields.
+    char   _dnsResult[46];            // written by dnsFoundCallback() only
+    volatile bool _dnsResultReady = false; // release/acquire flag for _dnsResult
+    void   startDnsLookup();
+    void   takeDnsResult();
+    void   publishBrokerIp();
+#ifndef EPOXY_DUINO
+    static void dnsFoundCallback(const char *name, const ip_addr_t *ipaddr, void *arg);
+#endif
     unsigned long _lastStatusPush = 0; // millis() of last periodic status WebSocket push
 
     // Last failure cause, for troubleshooting in the UI

--- a/src/time_man.cpp
+++ b/src/time_man.cpp
@@ -8,6 +8,8 @@
 #include <netdb.h>
 #else
 #include <lwip/netdb.h>
+#include <lwip/dns.h>
+#include <lwip/tcpip.h>
 #endif
 
 #include "debug.h"
@@ -24,6 +26,15 @@
 //#define TIME_POLL_TIME 10 * 1000
 #endif
 
+// How often to look for an asynchronous DNS answer while one is outstanding.
+// Only used while a lookup is in flight, so it does not affect the idle rate.
+#define DNS_TAKE_POLL_TIME 250
+
+// Give up waiting for a DNS callback after this long. LwIP always calls back,
+// found or not, so this only stops a lost callback pinning loop() to the poll
+// rate for the rest of the uptime.
+#define DNS_LOOKUP_TIMEOUT (30 * 1000UL)
+
 TimeManager timeManager;
 
 TimeManager::TimeManager() :
@@ -39,6 +50,7 @@ TimeManager::TimeManager() :
   _syncRequested(false)
 {
   _resolvedIp[0] = '\0';
+  _dnsResult[0]  = '\0';
 }
 
 unsigned long TimeManager::retryDelay()
@@ -55,6 +67,98 @@ unsigned long TimeManager::retryDelay()
                   ? _retryCount
                   : (uint8_t)(sizeof(delays) / sizeof(delays[0]) - 1);
   return delays[idx];
+}
+
+#ifndef EPOXY_DUINO
+// Runs on the LwIP TCP/IP thread, not on loopTask. Formats the answer and then
+// publishes the flag with a release store, so a loopTask that sees the flag set
+// is guaranteed to see the whole buffer.
+void TimeManager::dnsFoundCallback(const char *name, const ip_addr_t *ipaddr, void *arg)
+{
+  TimeManager *self = static_cast<TimeManager *>(arg);
+  if(nullptr != ipaddr) {
+    ipaddr_ntoa_r(ipaddr, self->_dnsResult, sizeof(self->_dnsResult));
+  } else {
+    // A null address means the query completed and the name does not resolve.
+    strncpy(self->_dnsResult, "failed", sizeof(self->_dnsResult) - 1);
+    self->_dnsResult[sizeof(self->_dnsResult) - 1] = '\0';
+  }
+  __atomic_store_n(&self->_dnsResultReady, true, __ATOMIC_RELEASE);
+}
+#endif
+
+// Starts resolving _timeHost for the status display. An answer already in
+// LwIP's cache lands in _resolvedIp before this returns; anything else arrives
+// through dnsFoundCallback() and is collected by takeDnsResult(). Never blocks.
+void TimeManager::startDnsLookup()
+{
+  if(nullptr == _timeHost) {
+    return;
+  }
+
+#ifdef EPOXY_DUINO
+  // Host build: no LwIP resolver and no watchdog to trip, so resolve inline.
+  struct addrinfo hints = {}, *res = nullptr;
+  hints.ai_family = AF_UNSPEC;
+  if(getaddrinfo(_timeHost, nullptr, &hints, &res) == 0 && res) {
+    void *addr = res->ai_family == AF_INET
+      ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
+      : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
+    inet_ntop(res->ai_family, addr, _resolvedIp, sizeof(_resolvedIp) - 1);
+    freeaddrinfo(res);
+  } else {
+    strncpy(_resolvedIp, "failed", sizeof(_resolvedIp) - 1);
+  }
+  _resolvedIp[sizeof(_resolvedIp) - 1] = '\0';
+#else
+  ip_addr_t addr;
+
+  // Discard any answer still in flight from an earlier attempt
+  __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
+  _dnsDeadline = 0;
+
+  // dns_gethostbyname() is LwIP raw API, so it is only safe to call while
+  // holding the TCP/IP core lock. LwIP copies the name, so it need not outlive
+  // this call.
+  LOCK_TCPIP_CORE();
+  err_t err = dns_gethostbyname(_timeHost, &addr, dnsFoundCallback, this);
+  UNLOCK_TCPIP_CORE();
+
+  if(ERR_OK == err) {
+    // Already in LwIP's cache: answered here, and no callback will follow.
+    ipaddr_ntoa_r(&addr, _resolvedIp, sizeof(_resolvedIp));
+    DBUGF("NTP: DNS cache hit, %s is %s", _timeHost, _resolvedIp);
+  } else if(ERR_INPROGRESS == err) {
+    // dnsFoundCallback() will hand the answer to takeDnsResult()
+    _dnsDeadline = millis() + DNS_LOOKUP_TIMEOUT;
+    if(0 == _dnsDeadline) {
+      _dnsDeadline = 1;     // 0 is the "nothing outstanding" sentinel
+    }
+  } else {
+    // Could not even start the query (no DNS server set, or the table is full)
+    strncpy(_resolvedIp, "failed", sizeof(_resolvedIp) - 1);
+    _resolvedIp[sizeof(_resolvedIp) - 1] = '\0';
+  }
+#endif
+}
+
+// Picks up an answer left by dnsFoundCallback(), if one has arrived.
+void TimeManager::takeDnsResult()
+{
+#ifndef EPOXY_DUINO
+  if(__atomic_load_n(&_dnsResultReady, __ATOMIC_ACQUIRE)) {
+    __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
+    _dnsDeadline = 0;
+    strncpy(_resolvedIp, _dnsResult, sizeof(_resolvedIp) - 1);
+    _resolvedIp[sizeof(_resolvedIp) - 1] = '\0';
+    DBUGF("NTP: DNS answer for %s is %s", _timeHost ? _timeHost : "", _resolvedIp);
+  } else if(0 != _dnsDeadline && (long)(millis() - _dnsDeadline) >= 0) {
+    // LwIP always calls back, found or not, so this should not happen. Stop
+    // polling for it rather than holding loop() at the poll rate forever.
+    DBUGLN("NTP: DNS callback never arrived");
+    _dnsDeadline = 0;
+  }
+#endif
 }
 
 const char *TimeManager::getNtpStatus()
@@ -86,6 +190,8 @@ void TimeManager::setHost(const char *host)
   _timeHost = host;
   _fetchingTime = false;
   _retryCount   = 0;
+  // Discard any answer in flight for the previous host
+  __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
   // Allow 2 s for the DNS resolver to initialise after WiFi connects before
   // firing the first request.  Update Now / mode-change use checkNow()
   // directly and bypass this delay to stay fully responsive.
@@ -135,19 +241,13 @@ void TimeManager::setup()
     _fetchingTime = false;
     // Distinguish DNS failure from other NTP errors (firewall, bad server, etc.)
     // Only show "DNS failed" badge when DNS resolution itself fails.
+    //
+    // Resolve asynchronously. This handler runs because the name did not
+    // resolve, so a synchronous lookup of that same name would take the full
+    // retry path — A and AAAA, DNS_MAX_RETRIES against every configured
+    // server — and outlast the task watchdog on loopTask.
     if(_timeHost) {
-      struct addrinfo hints = {}, *res = nullptr;
-      hints.ai_family = AF_UNSPEC;
-      if(getaddrinfo(_timeHost, nullptr, &hints, &res) == 0 && res) {
-        void *addr = res->ai_family == AF_INET
-          ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
-          : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
-        inet_ntop(res->ai_family, addr, _resolvedIp, sizeof(_resolvedIp) - 1);
-        freeaddrinfo(res);
-      } else {
-        strncpy(_resolvedIp, "failed", sizeof(_resolvedIp) - 1);
-        _resolvedIp[sizeof(_resolvedIp) - 1] = '\0';
-      }
+      startDnsLookup();
     } else {
       strncpy(_resolvedIp, "failed", sizeof(_resolvedIp) - 1);
       _resolvedIp[sizeof(_resolvedIp) - 1] = '\0';
@@ -161,6 +261,9 @@ void TimeManager::setup()
 
 unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
 {
+  // An asynchronous DNS answer may have landed since the last pass
+  takeDnsResult();
+
 #ifdef ENABLE_DEBUG
   DBUG("Time manager woke: ");
   DBUGLN(WakeReason_Scheduled == reason ? "WakeReason_Scheduled" :
@@ -233,22 +336,18 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
     {
       // Early DNS probe: populate _resolvedIp while the SNTP reply is still
       // pending so the UI shows DNS status without waiting for the full cycle.
-      // Mongoose will have resolved the hostname before this fires (the UDP
-      // packet was already sent), so getaddrinfo() hits LwIP's DNS cache.
+      // Mongoose usually resolved the hostname before this fires, so the query
+      // is answered from LwIP's cache — but when Mongoose's own resolve failed
+      // the cache is empty, and a synchronous lookup would then block loopTask
+      // past the task watchdog. Start it asynchronously instead.
       if(_resolvedIp[0] == '\0' && _timeHost) {
-        struct addrinfo hints = {}, *res = nullptr;
-        hints.ai_family = AF_UNSPEC;
-        if(getaddrinfo(_timeHost, nullptr, &hints, &res) == 0 && res) {
-          void *addr = res->ai_family == AF_INET
-            ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
-            : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
-          inet_ntop(res->ai_family, addr, _resolvedIp, sizeof(_resolvedIp) - 1);
-          freeaddrinfo(res);
-          DBUGF("NTP: early DNS probe → %s", _resolvedIp);
-        }
+        startDnsLookup();
       }
-      // Wake when the full watchdog deadline expires
-      return (unsigned long)(SNTP_FETCH_TIMEOUT - elapsed);
+      // Wake when the full watchdog deadline expires, or sooner to collect an
+      // outstanding DNS answer
+      unsigned long remaining = (unsigned long)(SNTP_FETCH_TIMEOUT - elapsed);
+      return (0 != _dnsDeadline && remaining > DNS_TAKE_POLL_TIME)
+        ? DNS_TAKE_POLL_TIME : remaining;
     }
   }
 
@@ -277,17 +376,12 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
         _retryCount    = 0;
         _lastSyncTime  = newTime.tv_sec;   // use NTP ts directly
         _nextCheckTime = millis() + TIME_POLL_TIME;
-        // Resolve hostname → IP for status display (DNS is cached at this point)
+        // Resolve hostname → IP for status display. The sync just succeeded so
+        // the answer is in LwIP's cache and comes back from startDnsLookup()
+        // immediately; going through the same path keeps this off the blocking
+        // resolvers even if the cache entry has since expired.
         if(_timeHost) {
-          struct addrinfo hints = {}, *res = nullptr;
-          hints.ai_family = AF_UNSPEC;
-          if(getaddrinfo(_timeHost, nullptr, &hints, &res) == 0 && res) {
-            void *addr = res->ai_family == AF_INET
-              ? (void *)&((struct sockaddr_in  *)res->ai_addr)->sin_addr
-              : (void *)&((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
-            inet_ntop(res->ai_family, addr, _resolvedIp, sizeof(_resolvedIp) - 1);
-            freeaddrinfo(res);
-          }
+          startDnsLookup();
         }
         MicroTask.wakeTask(this);
       });
@@ -296,7 +390,7 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
       {
         // Wake in 1 s for an early DNS probe while the SNTP request is
         // in-flight.  By then Mongoose will have resolved the hostname and
-        // sent the UDP packet, so getaddrinfo() returns from LwIP's cache
+        // sent the UDP packet, so the lookup is answered from LwIP's cache
         // and we can show the DNS badge before the sync completes.
         ret = 1000;
       }
@@ -319,6 +413,12 @@ unsigned long TimeManager::loop(MicroTasks::WakeReason reason)
     } else {
       ret = delay > 0 ? (unsigned long)delay : 0;
     }
+  }
+
+  // While a DNS answer is outstanding, come back for it rather than sleeping
+  // out a retry back-off that can be minutes long
+  if(0 != _dnsDeadline && ret > DNS_TAKE_POLL_TIME) {
+    ret = DNS_TAKE_POLL_TIME;
   }
 
   return ret;

--- a/src/time_man.h
+++ b/src/time_man.h
@@ -5,6 +5,9 @@
 #include <MicroTasks.h>
 #include <MicroTasksTask.h>
 #include <ArduinoJson.h>
+#ifndef EPOXY_DUINO
+#include <lwip/ip_addr.h>
+#endif
 
 // How long to wait for an in-flight SNTP reply before treating it as lost
 #ifndef SNTP_FETCH_TIMEOUT
@@ -25,6 +28,20 @@ class TimeManager : public MicroTasks::Task
     time_t _lastSyncTime;           // Unix timestamp of last successful sync
     char   _resolvedIp[46];         // last resolved IP, "failed", or ""
     bool   _syncRequested;          // set by checkNow(); shows "connecting" before fetch starts
+
+    // The NTP host is resolved asynchronously, because the synchronous resolvers
+    // block for as long as the query takes and loop() runs under the task
+    // watchdog. dnsFoundCallback() runs on the LwIP TCP/IP thread and hands the
+    // answer to loop() through these fields.
+    char   _dnsResult[46];                 // written by dnsFoundCallback() only
+    volatile bool _dnsResultReady = false; // release/acquire flag for _dnsResult
+    unsigned long _dnsDeadline = 0;        // 0 when no lookup is outstanding
+
+    void startDnsLookup();
+    void takeDnsResult();
+#ifndef EPOXY_DUINO
+    static void dnsFoundCallback(const char *name, const ip_addr_t *ipaddr, void *arg);
+#endif
 
     unsigned long retryDelay();     // exponential back-off based on _retryCount
 
@@ -62,6 +79,8 @@ class TimeManager : public MicroTasks::Task
       _retryCount    = 0;
       _syncRequested = true;          // show "connecting" immediately in the UI
       _resolvedIp[0] = '\0';          // drop stale DNS badge
+      // Discard any answer still in flight, so it cannot land on the new badge
+      __atomic_store_n(&_dnsResultReady, false, __ATOMIC_RELAXED);
       _nextCheckTime = millis();
       MicroTask.wakeTask(this);
     }


### PR DESCRIPTION
## The bug

Two status fields were filled with `getaddrinfo()`, which blocks for the whole query. Both run on `loopTask`, which feeds the task watchdog:

- `mqtt_broker_ip`, in `Mqtt::loop()`
- the NTP `resolved_ip`, at three sites in `TimeManager`

With `LWIP_IPV6` enabled an `AF_UNSPEC` lookup asks for both A and AAAA, each up to `DNS_MAX_RETRIES` (4) times across every configured server — so a slow or unanswered resolve runs well past the 5 s `CONFIG_ESP_TASK_WDT_TIMEOUT_S` and panics the charger.

Both were introduced on the same day, in `5a387c75` (MQTT) and `3e92a94b` (NTP).

## How it was found

**MQTT.** A unit that had been up 25 h rebooted with `reset_reason_name = task_wdt` and panic `loopTask (CPU 1)`. The `loopTask` stack from the coredump:

```
loopTask -> app_main -> loop() -> MicroTasks dispatch -> Mqtt::loop()
  -> lwip_getaddrinfo (netdb.c:505) -> lwip_netconn_do_gethostbyname
  -> sys_mbox_new -> xQueueSemaphoreTake
```

The broker hostname was a CNAME to AWS IoT that answers AAAA first, which is what made the `AF_UNSPEC` path expensive on that network. `_needsDnsLookup` is re-armed in `onMqttConnect()`, so every MQTT reconnect was another chance to reboot.

**NTP.** The same panic then turned up on an ESP32-S3 **with MQTT disabled**, so it could not be the same path. Its `loopTask` stack:

```
loopTask -> mg_sntp_handler -> MongooseSntpClient::eventHandler
  -> lwip_netconn_do_gethostbyname (api_msg.c:2231)
  -> lwip_netconn_do_dns_found -> dns_timeout_cb (dns.c:444)
```

`MongooseSntpClient::eventHandler` there is the `MG_SNTP_FAILED` dispatch, which reaches `_sntp.onError()`. That handler runs *because* the hostname did not resolve, and then resolves the same name synchronously — so it always takes the full retry path. `dns_timeout_cb` on the stack is that path in progress.

The "early DNS probe" site has the same exposure. Its comment assumes Mongoose has already warmed LwIP's cache, which holds only when Mongoose's own resolve succeeded; when it did not, the cache is empty and the probe blocks.

## The fix

Ask LwIP for the address and let it call back, in both files:

- `dns_gethostbyname()` answers immediately (`ERR_OK`) when the name is in the resolver cache.
- Otherwise it returns `ERR_INPROGRESS` and calls a callback on the TCP/IP thread. The callback formats the address and hands it over with a release store; `loop()` collects it with an acquire load on a later pass.
- Any other return means the query could not be started, which reports `"failed"` as before.

Nothing waits. The status fields behave as before except that on a cache miss the value appears a moment later instead of stalling the loop until it is known. The two NTP sites that run after a *successful* resolve hit the cache and so are unchanged in practice; they go through the same path to keep the blocking resolvers out of the file entirely.

`dns_gethostbyname()` is LwIP raw API, so it is called under `LOCK_TCPIP_CORE()`. `CONFIG_LWIP_TCPIP_CORE_LOCKING` and `CONFIG_LWIP_CHECK_THREAD_SAFETY` are both enabled in the prebuilt Arduino framework for every ESP32 target and in `sdkconfig.defaults`, so the locking is available and runtime-asserted.

`TimeManager::loop()` additionally returns at most 250 ms while a lookup is outstanding, so an answer is not left sitting through an NTP retry back-off of up to 30 minutes. A 30 s deadline stops a lost callback from holding that rate indefinitely.

The comment the MQTT change replaces said `loop()` was safe to block in. Moving that resolve off the Mongoose callback fixed a dropped-connection bug, but traded it for a watchdog reboot — neither context can afford to wait.

The host (`EPOXY_DUINO`) build keeps the inline `getaddrinfo()`: no LwIP resolver, and no watchdog to trip.

## Testing

- `openevse_wifi_v1` builds clean — 91.1% flash, 25.3% RAM, unchanged by either commit.
- `native_openevse` (EpoxyDuino) builds clean, so the host paths still compile.
- `pio test -e native_test`: all suites pass.
- The MQTT half is running on an ESP32 TFT unit: MQTT reconnects and `mqtt_broker_ip` populates with no watchdog reboot and no loop stall.
- The NTP half is not yet hardware-soaked against a deliberately unresponsive DNS server. Review of the async handoff is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved MQTT broker and NTP server hostname resolution to avoid blocking the application loop.
  * MQTT communication and time synchronization can continue while DNS resolution is in progress.
* **Reliability**
  * Added handling for DNS lookup timeouts and stale results during connection or synchronization retries.
* **Compatibility**
  * Preserved synchronous hostname resolution for desktop host builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->