### PR TITLE
Add 2-line LCD backlight type (mono/RGB) control, bump OpenEVSE_Lib t…

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   https://github.com/jeremypoulter/ArduinoMongoose.git#ca0a817de014cf4ab1833b32383532366fca10d7  ; master: mbedTLS-3 port + unique SUBSCRIBE ids + TLS teardown UAF fix (97ff3b4)
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  openevse/OpenEVSE@0.0.23  ; PlatformIO registry package (was a git+tag pin) - D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
+  openevse/OpenEVSE@0.0.24  ; PlatformIO registry package (was a git+tag pin) - D9 command support (protocol-gated) + relay-health $GL/$FH/$FK, 2-line LCD backlight type setter
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -760,7 +760,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  openevse/OpenEVSE@0.0.23
+  openevse/OpenEVSE@0.0.24
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -717,13 +717,17 @@ bool config_deserialize(DynamicJsonDocument &doc)
 
   if(doc.containsKey("lcd_type"))
   {
-    const char *val = doc["lcd_type"];
-    EvseMonitor::LcdType type = (val && strcmp(val, "mono") == 0) ?
-      EvseMonitor::LcdType::Mono : EvseMonitor::LcdType::RGB;
-    if(type != evse.getLcdType()) {
-      evse.setLcdType(type);
-      config_modified = true;
-      DBUGLN("lcd_type changed");
+    if(doc["lcd_type"].is<const char *>()) {
+      const char *val = doc["lcd_type"];
+      if(val && (strcmp(val, "mono") == 0 || strcmp(val, "rgb") == 0)) {
+        EvseMonitor::LcdType type = (strcmp(val, "mono") == 0) ?
+          EvseMonitor::LcdType::Mono : EvseMonitor::LcdType::RGB;
+        if(type != evse.getLcdType()) {
+          evse.setLcdType(type);
+          config_modified = true;
+          DBUGLN("lcd_type changed");
+        }
+      }
     }
   }
 
@@ -1035,6 +1039,5 @@ void config_reset()
   LittleFS.format();
   config_load_settings();
 }
-
 
 

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -715,15 +715,29 @@ bool config_deserialize(DynamicJsonDocument &doc)
     }
   }
 
-  if(doc.containsKey("lcd_type"))
+  // Skipped entirely once a $S0 write has actually been rejected with $NK:
+  // that means this controller build doesn't have LCD16X2+RGBLCD compiled
+  // in, getLcdType() can never change no matter what's requested, and
+  // retrying on every POST would just re-trigger a config-change
+  // notification for a write that can't take. See the comment on
+  // EvseMonitor::_lcd_type_supported.
+  if(doc.containsKey("lcd_type") && evse.isLcdTypeSupported())
   {
     const char *val = doc["lcd_type"];
-    EvseMonitor::LcdType type = (val && strcmp(val, "mono") == 0) ?
-      EvseMonitor::LcdType::Mono : EvseMonitor::LcdType::RGB;
-    if(type != evse.getLcdType()) {
-      evse.setLcdType(type);
-      config_modified = true;
-      DBUGLN("lcd_type changed");
+    // ArduinoJson hands back nullptr for a non-string value, so this also
+    // covers {"lcd_type": true}/{"lcd_type": 0} etc. Anything other than
+    // exactly "mono" or "rgb" is ignored rather than silently treated as
+    // RGB - there's no existing precedent for a string-valued EVSE setting
+    // here to inherit a looser convention from.
+    bool isMono = val && 0 == strcmp(val, "mono");
+    bool isRgb  = val && 0 == strcmp(val, "rgb");
+    if(isMono || isRgb) {
+      EvseMonitor::LcdType type = isMono ? EvseMonitor::LcdType::Mono : EvseMonitor::LcdType::RGB;
+      if(type != evse.getLcdType()) {
+        evse.setLcdType(type);
+        config_modified = true;
+        DBUGLN("lcd_type changed");
+      }
     }
   }
 
@@ -911,9 +925,15 @@ bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutp
     doc["front_button"] = evse.isFrontButtonEnabled();
     doc["boot_lock"] = evse.isBootLockEnabled();
     // 2-line LCD backlight type. Only meaningful on controller builds with a
-    // physical character LCD (LCD16X2 + RGBLCD); other builds NAK the $S0 set
-    // and simply ignore this, same as other flags-word bits.
-    doc["lcd_type"] = (EvseMonitor::LcdType::Mono == evse.getLcdType()) ? "mono" : "rgb";
+    // physical character LCD (LCD16X2 + RGBLCD) - there's no RAPI capability
+    // bit for that, so support is only known once a $S0 write has actually
+    // been tried. Shown by default (nothing has been tried yet, so this is
+    // an optimistic guess, not a confirmed capability) and omitted once a
+    // write has actually come back $NK, so the GUI stops offering a control
+    // that can never take effect on this hardware.
+    if(evse.isLcdTypeSupported()) {
+      doc["lcd_type"] = (EvseMonitor::LcdType::Mono == evse.getLcdType()) ? "mono" : "rgb";
+    }
     // D9-only capability flag so clients can gate the controls below
     doc["d9_support"] = evse.isD9Supported();
     // PP auto-ampacity / zero-cross switching only exist on D9+ controllers

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -715,6 +715,18 @@ bool config_deserialize(DynamicJsonDocument &doc)
     }
   }
 
+  if(doc.containsKey("lcd_type"))
+  {
+    const char *val = doc["lcd_type"];
+    EvseMonitor::LcdType type = (val && strcmp(val, "mono") == 0) ?
+      EvseMonitor::LcdType::Mono : EvseMonitor::LcdType::RGB;
+    if(type != evse.getLcdType()) {
+      evse.setLcdType(type);
+      config_modified = true;
+      DBUGLN("lcd_type changed");
+    }
+  }
+
   if(doc.containsKey("pp_auto"))
   {
     bool enable = doc["pp_auto"];
@@ -898,6 +910,10 @@ bool config_serialize(DynamicJsonDocument &doc, bool longNames, bool compactOutp
     }
     doc["front_button"] = evse.isFrontButtonEnabled();
     doc["boot_lock"] = evse.isBootLockEnabled();
+    // 2-line LCD backlight type. Only meaningful on controller builds with a
+    // physical character LCD (LCD16X2 + RGBLCD); other builds NAK the $S0 set
+    // and simply ignore this, same as other flags-word bits.
+    doc["lcd_type"] = (EvseMonitor::LcdType::Mono == evse.getLcdType()) ? "mono" : "rgb";
     // D9-only capability flag so clients can gate the controls below
     doc["d9_support"] = evse.isD9Supported();
     // PP auto-ampacity / zero-cross switching only exist on D9+ controllers

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -444,6 +444,9 @@ class EvseManager : public MicroTasks::Task
     EvseMonitor::LcdType getLcdType() {
       return _monitor.getLcdType();
     }
+    void setLcdType(EvseMonitor::LcdType type, std::function<void(int ret)> callback = NULL) {
+      _monitor.setLcdType(type, callback);
+    }
     const char *getFirmwareVersion() {
       return _monitor.getFirmwareVersion();
     }

--- a/src/evse_man.h
+++ b/src/evse_man.h
@@ -447,6 +447,9 @@ class EvseManager : public MicroTasks::Task
     void setLcdType(EvseMonitor::LcdType type, std::function<void(int ret)> callback = NULL) {
       _monitor.setLcdType(type, callback);
     }
+    bool isLcdTypeSupported() {
+      return _monitor.isLcdTypeSupported();
+    }
     const char *getFirmwareVersion() {
       return _monitor.getFirmwareVersion();
     }

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -840,6 +840,38 @@ void EvseMonitor::enableOvercurrentMonitor(bool enabled, std::function<void(int 
   }
 }
 
+void EvseMonitor::setLcdType(LcdType type, std::function<void(int ret)> callback)
+{
+  if(getLcdType() == type) {
+    if(callback) callback(RAPI_RESPONSE_OK);
+    return;
+  }
+
+  uint8_t rapi_type = (LcdType::Mono == type) ? OPENEVSE_LCD_TYPE_MONO : OPENEVSE_LCD_TYPE_RGB;
+  _openevse.setLcdType(rapi_type, [this, callback](int ret)
+  {
+    if(RAPI_RESPONSE_OK == ret)
+    {
+      // Refresh the flags
+      _openevse.getSettings([this, callback](int ret, long pilot, uint32_t flags)
+      {
+        if(RAPI_RESPONSE_OK == ret) {
+          DBUGF("pilot = %ld, flags = %x", pilot, flags);
+          _settings_flags = flags;
+        }
+
+        _settings_changed.Trigger();
+
+        if(callback){
+          callback(ret);
+        }
+      });
+    } else if(callback){
+      callback(ret);
+    }
+  });
+}
+
 void EvseMonitor::enableFrontButton(bool enabled, std::function<void(int ret)> callback)
 {
   if(isFrontButtonEnabled() != enabled) {

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -766,6 +766,23 @@ void EvseMonitor::setServiceLevel(ServiceLevel level, std::function<void(int ret
   });
 }
 
+void EvseMonitor::refreshSettingsFlags(std::function<void(int ret)> callback)
+{
+  _openevse.getSettings([this, callback](int ret, long pilot, uint32_t flags)
+  {
+    if(RAPI_RESPONSE_OK == ret) {
+      DBUGF("pilot = %ld, flags = %x", pilot, flags);
+      _settings_flags = flags;
+    }
+
+    _settings_changed.Trigger();
+
+    if(callback){
+      callback(ret);
+    }
+  });
+}
+
 void EvseMonitor::enableFeature(uint8_t feature, bool enabled, std::function<void(int ret)> callback)
 {
   _openevse.feature(feature, enabled, [this, callback](int ret)
@@ -773,19 +790,7 @@ void EvseMonitor::enableFeature(uint8_t feature, bool enabled, std::function<voi
     if(RAPI_RESPONSE_OK == ret)
     {
       // Refresh the flags
-      _openevse.getSettings([this, callback](int ret, long pilot, uint32_t flags)
-      {
-        if(RAPI_RESPONSE_OK == ret) {
-          DBUGF("pilot = %ld, flags = %x", pilot, flags);
-          _settings_flags = flags;
-        }
-
-        _settings_changed.Trigger();
-
-        if(callback){
-          callback(ret);
-        }
-      });
+      refreshSettingsFlags(callback);
     } else if(callback){
       callback(ret);
     }
@@ -854,19 +859,7 @@ void EvseMonitor::setLcdType(LcdType type, std::function<void(int ret)> callback
     if(RAPI_RESPONSE_OK == ret)
     {
       // Refresh the flags
-      _openevse.getSettings([this, callback](int ret, long pilot, uint32_t flags)
-      {
-        if(RAPI_RESPONSE_OK == ret) {
-          DBUGF("pilot = %ld, flags = %x", pilot, flags);
-          _settings_flags = flags;
-        }
-
-        _settings_changed.Trigger();
-
-        if(callback){
-          callback(ret);
-        }
-      });
+      refreshSettingsFlags(callback);
     } else {
       // A real $NK (as opposed to a timeout/queue-full/disconnected
       // transport failure, none of which say anything about whether the

--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -175,6 +175,7 @@ EvseMonitor::EvseMonitor(OpenEVSEClass &openevse) :
   _count(0),
   _heartbeat(false),
   _firmware_version(""),
+  _lcd_type_supported(true),
 #ifdef ENABLE_MCP9808
   _mcp9808(),
 #endif
@@ -866,8 +867,20 @@ void EvseMonitor::setLcdType(LcdType type, std::function<void(int ret)> callback
           callback(ret);
         }
       });
-    } else if(callback){
-      callback(ret);
+    } else {
+      // A real $NK (as opposed to a timeout/queue-full/disconnected
+      // transport failure, none of which say anything about whether the
+      // controller understands $S0 at all) means this build doesn't have
+      // LCD16X2+RGBLCD compiled in - there's no RAPI capability query for
+      // that, so this is the only way to find out. Latching it stops
+      // app_config.cpp from retrying (and re-triggering a config-change
+      // notification) on every subsequent POST that still carries lcd_type,
+      // since getLcdType() can never change on a controller that rejects
+      // the write that would change it.
+      if(RAPI_RESPONSE_NK == ret) {
+        _lcd_type_supported = false;
+      }
+      if(callback) callback(ret);
     }
   });
 }

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -302,6 +302,7 @@ class EvseMonitor : public MicroTasks::Task
     void enableVentRequired(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableTemperatureCheck(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableOvercurrentMonitor(bool enabled, std::function<void(int ret)> callback = NULL);
+    void setLcdType(LcdType type, std::function<void(int ret)> callback = NULL);
     void setPanicTemperature(uint32_t tempC, std::function<void(int ret)> callback = NULL);
     void enableFrontButton(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableBootLock(bool enabled, std::function<void(int ret)> callback = NULL);

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -304,6 +304,19 @@ class EvseMonitor : public MicroTasks::Task
     void setMqttVoltage(double volts);
     void setServiceLevel(ServiceLevel level, std::function<void(int ret)> callback = NULL);
     void configureCurrentSensorScale(long scale, long offset, std::function<void(int ret)> callback = NULL);
+    // Re-read the controller's settings flags ($GE), publish the change
+    // unconditionally, then hand the result to `callback`. Shared by
+    // enableFeature() and setLcdType(), which previously each carried a
+    // verbatim copy of it - one copy, so they cannot drift apart.
+    // Deliberately NOT used by the three other $GE readers: evseBoot()
+    // signals boot-readiness instead of triggering, setServiceLevel()
+    // chains a getCurrentCapacity() off the same response, and
+    // getSettingsFromEvse() only triggers on an actual change because it
+    // runs once a minute. Their differences are the point, not drift.
+    // n.b. `callback` is invoked with the *$GE's* result, not the result of
+    // whatever write preceded it - long-standing behaviour of this refresh,
+    // preserved verbatim by the extraction.
+    void refreshSettingsFlags(std::function<void(int ret)> callback = NULL);
     void enableFeature(uint8_t feature, bool enabled, std::function<void(int ret)> callback = NULL);
     void enableDiodeCheck(bool enabled, std::function<void(int ret)> callback = NULL);
     void enableGfiTestCheck(bool enabled, std::function<void(int ret)> callback = NULL);

--- a/src/evse_monitor.h
+++ b/src/evse_monitor.h
@@ -239,6 +239,16 @@ class EvseMonitor : public MicroTasks::Task
     char _firmware_version[32];
     char _serial[16];
 
+    // Whether $S0 (set LCD backlight type) is understood by this controller
+    // build. There's no RAPI capability query for this - LCD16X2/RGBLCD are
+    // compile-time flags on the controller with no wire-visible signal
+    // either way (see rapi.md's own "test commands for compatibility"
+    // note) - so this starts optimistic and latches false the first time a
+    // write is actually rejected with a real $NK, not a transport-level
+    // failure (timeout/queue-full/disconnected), which says nothing about
+    // whether the command itself exists.
+    bool _lcd_type_supported;
+
 #ifdef ENABLE_MCP9808
     Adafruit_MCP9808 _mcp9808;
 #endif
@@ -509,6 +519,12 @@ class EvseMonitor : public MicroTasks::Task
       return (OPENEVSE_ECF_MONO_LCD == (getSettingsFlags() & OPENEVSE_ECF_MONO_LCD)) ?
         LcdType::Mono :
         LcdType::RGB;
+    }
+    // False once a $S0 write has actually been rejected with $NK this
+    // session - see the comment on _lcd_type_supported. Starts true: there
+    // is no way to know without trying.
+    bool isLcdTypeSupported() {
+      return _lcd_type_supported;
     }
     const char *getFirmwareVersion() {
       return _firmware_version;


### PR DESCRIPTION
# 2-line LCD backlight type (Monochrome / RGB)

Adds a web UI control for the OpenEVSE controller's 2-line character LCD
backlight type, on branch `RGB_LCD` across three repos. Previously this could
only be changed over RAPI directly (Blocked by OpenEVSE_esp32_firmware) or from the controller's own front-panel
menu; there was no way to set it from the app.

## Background

The Adafruit RGBLCD character display used on classic OpenEVSE V6 boards (and
in JuiceBox v2 conversions, which reuse the JuiceBox's RGB-backlit LED Strip) can
run in one of two backlight modes:

- **Monochrome** — single-colour backlight.
- **RGB** — full colour, used for the state-colour backlight (green/yellow/
  teal/red/violet, see `docs/lcd.md`) and required for a JuiceBox v2
  replacement.

The controller firmware already exposed this as `$S0 0|1` (RAPI) /
`ECF_MONO_LCD` (EEPROM flags bit `0x0100`), gated behind the `LCD16X2` +
`RGBLCD` compile flags — only the `m328p_LCD_WIFI` build defines both;
`m328p_core` ("WiFi, no text LCD") defines neither, so `$S0` NAKs there. No
change was needed on the controller firmware (`open_evse`) side. `OpenEVSE_Lib`
could already *read* the flag but had no method to *set* it — that was the
actual gap this closes.

## Changes by repo

### OpenEVSE_Lib (branch `OpenEVSE9`, commit `8e93b3a`)

- `OPENEVSE_LCD_TYPE_MONO` / `OPENEVSE_LCD_TYPE_RGB` constants
  (`src/openevse.h`).
- `OpenEVSEClass::setLcdType(uint8_t type, callback)` (`src/openevse.cpp`) —
  sends `$S0 0|1`, following the same validate-then-`sendCmd` shape as
  `setServiceLevel()`/`feature()`.
- Bumped `library.json` to `0.0.24`.

### openevse_esp32_firmware (branch `RGB_LCD`, commit `b572f4c5`)

- `EvseMonitor::setLcdType()` (`src/evse_monitor.h`/`.cpp`) — calls
  `OpenEVSEClass::setLcdType()`, then re-reads `$GE` to refresh the cached
  flags word and fires `_settings_changed`, matching the pattern used by
  `enableDiodeCheck()` and friends.
- `EvseManager::setLcdType()` (`src/evse_man.h`) — thin pass-through, next to
  the existing `getLcdType()`.
- `app_config.cpp` — `lcd_type` (`"mono"` / `"rgb"`) added to `GET /config`
  and handled in the `POST /config` deserializer, unconditionally (like
  `diode_check`, `boot_lock`, etc. — there is no RAPI capability bit for
  "has a physical LCD", so unsupported builds just NAK the `$S0` silently).
- `platformio.ini` — `openevse/OpenEVSE` pin bumped `0.0.23` → `0.0.24` (both
  the main `[common]` lib_deps and the `native_simulator` env).

### gui-nightshift (branch `RGB_LCD`, commit `a2ef421`)

- Display settings page (`src/routes/settings/Display.svelte`) — new "2 Line
  LCD" field, a Monochrome/"Red - Green - Blue" segmented control (same
  pattern as the existing Theme/Clock controls), gated on `lcd_type` being
  present in the config store. Defaults to RGB when absent.
- Description note: "JuiceBox v2 Replacement select Red - Green - Blue."
- i18n keys added to `en.json` and all three translated catalogs
  (`source/es.json`, `source/fr.json`, `source/hu.json`) to satisfy the
  locale-parity test.
- Tests added to `Display.test.js` covering the default-RGB state and the
  write-on-change behaviour.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the LCD display as monochrome or RGB.
  - LCD type settings are saved and restored when supported by the controller.
  - Configuration reports the selected LCD type when supported.
- **Bug Fixes**
  - Improved compatibility with controllers that do not support LCD type selection by avoiding unsupported configuration updates.
- **Chores**
  - Updated the OpenEVSE platform package dependency to version 0.0.24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->