### PR TITLE
Bump OpenEVSE from 0.0.23 to 0.0.24

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ lib_deps =
   https://github.com/jeremypoulter/ArduinoMongoose.git#ca0a817de014cf4ab1833b32383532366fca10d7  ; master: mbedTLS-3 port + unique SUBSCRIBE ids + TLS teardown UAF fix (97ff3b4)
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  openevse/OpenEVSE@0.0.23  ; PlatformIO registry package (was a git+tag pin) - D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
+  openevse/OpenEVSE@0.0.24  ; PlatformIO registry package (was a git+tag pin) - D9 command support (protocol-gated) + relay-health $GL/$FH/$FK
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4
@@ -760,7 +760,7 @@ lib_deps =
   bblanchon/ArduinoJson@6.20.1
   jeremypoulter/Micro Debug@0.0.5
   jeremypoulter/ConfigJson@0.0.6
-  openevse/OpenEVSE@0.0.23
+  openevse/OpenEVSE@0.0.24
   jeremypoulter/ESPAL@0.0.7
   jeremypoulter/StreamSpy@0.0.2
   jeremypoulter/MicroTasks@0.0.4


### PR DESCRIPTION
Bump OpenEVSE from 0.0.23 to 0.0.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the OpenEVSE library dependency to version 0.0.24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->